### PR TITLE
Add \+ to match more white space for RHEL

### DIFF
--- a/lvm-1.ks.in
+++ b/lvm-1.ks.in
@@ -37,8 +37,8 @@ if [ $root_fstype != "ext4" ]; then
 fi
 
 # verify root entry in /etc/fstab is correct
-root_lv_entry="$(grep ^$root_lv\\s/\\s /etc/fstab)"
-root_uuid_entry="$(grep ^$root_uuid\\s/\\s /etc/fstab)"
+root_lv_entry="$(grep ^$root_lv\\s\\+/\\s /etc/fstab)"
+root_uuid_entry="$(grep ^$root_uuid\\s\\+/\\s /etc/fstab)"
 if [ -z "$root_lv_entry" -a -z "$root_uuid_entry" ] ; then
     echo "*** root lv is not the root entry in /etc/fstab" >> /root/RESULT
 fi
@@ -58,8 +58,8 @@ if ! grep -q $swap_dm /proc/swaps ; then
 fi
 
 # verify swap entry in /etc/fstab is correct
-swap_lv_entry="$(grep ^$swap_lv\\sswap\\s /etc/fstab)"
-swap_uuid_entry="$(grep ^$swap_uuid\\sswap\\s /etc/fstab)"
+swap_lv_entry="$(grep ^$swap_lv\\s\\+swap\\s /etc/fstab)"
+swap_uuid_entry="$(grep ^$swap_uuid\\s\\+swap\\s /etc/fstab)"
 if [ -z "$swap_lv_entry" -a -z "$swap_uuid_entry" ] ; then
     echo "*** swap lv is not in /etc/fstab" >> /root/RESULT
 fi

--- a/lvm-cache-1.ks.in
+++ b/lvm-cache-1.ks.in
@@ -42,8 +42,8 @@ if [ "$root_fstype" != "ext4" ]; then
 fi
 
 # verify root entry in /etc/fstab is correct
-root_lv_entry=$(grep ^$root_lv\\s/\\s /etc/fstab)
-root_uuid_entry=$(grep ^$root_uuid\\s/\\s /etc/fstab)
+root_lv_entry=$(grep ^$root_lv\\s\\+/\\s /etc/fstab)
+root_uuid_entry=$(grep ^$root_uuid\\s\\+/\\s /etc/fstab)
 if [ -z "$root_lv_entry" -a -z "$root_uuid_entry" ] ; then
     echo "*** root LV is not the root entry in /etc/fstab" >> /root/RESULT
 fi
@@ -55,8 +55,8 @@ if [ "$root_lv_size" != "4000.00" ]; then
 fi
 
 # verify home entry in /etc/fstab is correct
-home_lv_entry=$(grep ^$home_lv\\s/home\\s /etc/fstab)
-home_uuid_entry=$(grep ^$home_uuid\\s/home\\s /etc/fstab)
+home_lv_entry=$(grep ^$home_lv\\s\\+/home\\s /etc/fstab)
+home_uuid_entry=$(grep ^$home_uuid\\s\\+/home\\s /etc/fstab)
 if [ -z "$home_lv_entry" -a -z "$home_uuid_entry" ] ; then
     echo "*** home LV is not the home entry in /etc/fstab" >> /root/RESULT
 fi
@@ -76,8 +76,8 @@ if ! grep -q "$swap_dm" /proc/swaps ; then
 fi
 
 # verify swap entry in /etc/fstab is correct
-swap_lv_entry=$(grep ^$swap_lv\\sswap\\s /etc/fstab)
-swap_uuid_entry=$(grep ^$swap_uuid\\sswap\\s /etc/fstab)
+swap_lv_entry=$(grep ^$swap_lv\\s\\+swap\\s /etc/fstab)
+swap_uuid_entry=$(grep ^$swap_uuid\\s\\+swap\\s /etc/fstab)
 if [ -z "$swap_lv_entry" -a -z "$swap_uuid_entry" ] ; then
     echo "*** swap lv is not in /etc/fstab" >> /root/RESULT
 fi

--- a/lvm-cache-2.ks.in
+++ b/lvm-cache-2.ks.in
@@ -42,8 +42,8 @@ if [ "$root_fstype" != "ext4" ]; then
 fi
 
 # verify root entry in /etc/fstab is correct
-root_lv_entry=$(grep ^$root_lv\\s/\\s /etc/fstab)
-root_uuid_entry=$(grep ^$root_uuid\\s/\\s /etc/fstab)
+root_lv_entry=$(grep ^$root_lv\\s\\+/\\s /etc/fstab)
+root_uuid_entry=$(grep ^$root_uuid\\s\\+/\\s /etc/fstab)
 if [ -z "$root_lv_entry" -a -z "$root_uuid_entry" ] ; then
     echo "*** root LV is not the root entry in /etc/fstab" >> /root/RESULT
 fi
@@ -69,8 +69,8 @@ if ! grep -q "$swap_dm" /proc/swaps ; then
 fi
 
 # verify swap entry in /etc/fstab is correct
-swap_lv_entry=$(grep ^$swap_lv\\sswap\\s /etc/fstab)
-swap_uuid_entry=$(grep ^$swap_uuid\\sswap\\s /etc/fstab)
+swap_lv_entry=$(grep ^$swap_lv\\s\\+swap\\s /etc/fstab)
+swap_uuid_entry=$(grep ^$swap_uuid\\s\\+swap\\s /etc/fstab)
 if [ -z "$swap_lv_entry" -a -z "$swap_uuid_entry" ] ; then
     echo "*** swap lv is not in /etc/fstab" >> /root/RESULT
 fi

--- a/lvm-raid-1.ks.in
+++ b/lvm-raid-1.ks.in
@@ -40,8 +40,8 @@ if [ $root_fstype != "ext4" ]; then
 fi
 
 # verify root entry in /etc/fstab is correct
-root_lv_entry="$(grep ^$root_lv\\s/\\s /etc/fstab)"
-root_uuid_entry="$(grep ^$root_uuid\\s/\\s /etc/fstab)"
+root_lv_entry="$(grep ^$root_lv\\s\\+/\\s /etc/fstab)"
+root_uuid_entry="$(grep ^$root_uuid\\s\\+/\\s /etc/fstab)"
 if [ -z "$root_lv_entry" -a -z "$root_uuid_entry" ] ; then
     echo "*** root lv is not the root entry in /etc/fstab" >> /root/RESULT
 fi
@@ -67,8 +67,8 @@ if ! grep -q $swap_dm /proc/swaps ; then
 fi
 
 # verify swap entry in /etc/fstab is correct
-swap_lv_entry="$(grep ^$swap_lv\\sswap\\s /etc/fstab)"
-swap_uuid_entry="$(grep ^$swap_uuid\\sswap\\s /etc/fstab)"
+swap_lv_entry="$(grep ^$swap_lv\\s\\+swap\\s /etc/fstab)"
+swap_uuid_entry="$(grep ^$swap_uuid\\s\\+swap\\s /etc/fstab)"
 if [ -z "$swap_lv_entry" -a -z "$swap_uuid_entry" ] ; then
     echo "*** swap lv is not in /etc/fstab" >> /root/RESULT
 fi

--- a/lvm-thinp-1.ks.in
+++ b/lvm-thinp-1.ks.in
@@ -39,8 +39,8 @@ if [ $root_fstype != "ext4" ]; then
 fi
 
 # verify root entry in /etc/fstab is correct
-root_lv_entry="$(grep ^$root_lv\\s/\\s /etc/fstab)"
-root_uuid_entry="$(grep ^$root_uuid\\s/\\s /etc/fstab)"
+root_lv_entry="$(grep ^$root_lv\\s\\+/\\s /etc/fstab)"
+root_uuid_entry="$(grep ^$root_uuid\\s\\+/\\s /etc/fstab)"
 if [ -z "$root_lv_entry" -a -z "$root_uuid_entry" ] ; then
     echo "*** root lv is not the root entry in /etc/fstab" >> /root/RESULT
 fi
@@ -66,8 +66,8 @@ if [ $home_fstype != "ext4" ]; then
 fi
 
 # verify home entry in /etc/fstab is correct
-home_lv_entry="$(grep ^$home_lv\\s/home\\s /etc/fstab)"
-home_uuid_entry="$(grep ^$home_uuid\\s/home\\s /etc/fstab)"
+home_lv_entry="$(grep ^$home_lv\\s\\+/home\\s /etc/fstab)"
+home_uuid_entry="$(grep ^$home_uuid\\s\\+/home\\s /etc/fstab)"
 if [ -z "$home_lv_entry" -a -z "$home_uuid_entry" ] ; then
     echo "*** home lv is not the home entry in /etc/fstab" >> /home/RESULT
 fi
@@ -87,8 +87,8 @@ if ! grep -q $swap_dm /proc/swaps ; then
 fi
 
 # verify swap entry in /etc/fstab is correct
-swap_lv_entry="$(grep ^$swap_lv\\sswap\\s /etc/fstab)"
-swap_uuid_entry="$(grep ^$swap_uuid\\sswap\\s /etc/fstab)"
+swap_lv_entry="$(grep ^$swap_lv\\s\\+swap\\s /etc/fstab)"
+swap_uuid_entry="$(grep ^$swap_uuid\\s\\+swap\\s /etc/fstab)"
 if [ -z "$swap_lv_entry" -a -z "$swap_uuid_entry" ] ; then
     echo "*** swap lv is not in /etc/fstab" >> /root/RESULT
 fi

--- a/lvm-thinp-2.ks.in
+++ b/lvm-thinp-2.ks.in
@@ -39,8 +39,8 @@ if [ $root_fstype != "ext4" ]; then
 fi
 
 # verify root entry in /etc/fstab is correct
-root_lv_entry="$(grep ^$root_lv\\s/\\s /etc/fstab)"
-root_uuid_entry="$(grep ^$root_uuid\\s/\\s /etc/fstab)"
+root_lv_entry="$(grep ^$root_lv\\s\\+/\\s /etc/fstab)"
+root_uuid_entry="$(grep ^$root_uuid\\s\\+/\\s /etc/fstab)"
 if [ -z "$root_lv_entry" -a -z "$root_uuid_entry" ] ; then
     echo "*** root lv is not the root entry in /etc/fstab" >> /root/RESULT
 fi
@@ -66,8 +66,8 @@ if [ $home_fstype != "ext4" ]; then
 fi
 
 # verify home entry in /etc/fstab is correct
-home_lv_entry="$(grep ^$home_lv\\s/home\\s /etc/fstab)"
-home_uuid_entry="$(grep ^$home_uuid\\s/home\\s /etc/fstab)"
+home_lv_entry="$(grep ^$home_lv\\s\\+/home\\s /etc/fstab)"
+home_uuid_entry="$(grep ^$home_uuid\\s\\+/home\\s /etc/fstab)"
 if [ -z "$home_lv_entry" -a -z "$home_uuid_entry" ] ; then
     echo "*** home lv is not the home entry in /etc/fstab" >> /home/RESULT
 fi
@@ -87,8 +87,8 @@ if ! grep -q $swap_dm /proc/swaps ; then
 fi
 
 # verify swap entry in /etc/fstab is correct
-swap_lv_entry="$(grep ^$swap_lv\\sswap\\s /etc/fstab)"
-swap_uuid_entry="$(grep ^$swap_uuid\\sswap\\s /etc/fstab)"
+swap_lv_entry="$(grep ^$swap_lv\\s\\+swap\\s /etc/fstab)"
+swap_uuid_entry="$(grep ^$swap_uuid\\s\\+swap\\s /etc/fstab)"
 if [ -z "$swap_lv_entry" -a -z "$swap_uuid_entry" ] ; then
     echo "*** swap lv is not in /etc/fstab" >> /root/RESULT
 fi


### PR DESCRIPTION
On RHEL 7 there are more white spaces in /etc/fstab between the block device and the mount point. I've updated the regex to match this case.