### PR TITLE
Remove the second timezone command in ntp KS test

### DIFF
--- a/ntp-pools.ks.in
+++ b/ntp-pools.ks.in
@@ -13,7 +13,6 @@ autopart
 
 keyboard us
 lang en_US.UTF-8
-timezone America/New_York --utc
 rootpw testcase
 shutdown
 


### PR DESCRIPTION
This should warn user somehow. I lost many hours today on why the hell is the ``nontp`` option set to false in my tests based on this test.