### PR TITLE
proxy: log host and port for CONNECT requests

### DIFF
--- a/scripts/proxy.py
+++ b/scripts/proxy.py
@@ -75,6 +75,10 @@ class ProxyHandler(SimpleHTTPRequestHandler):
         # of a URL.
         host, port = self.path.split(':')
 
+        # Log the host and port. This is the best we can do for proxied
+        # TLS logging.
+        log.info('CONNECT {0} {1}'.format(host, port))
+
         # Open a socket to the requested location
         target = socket.create_connection((host, port))
 


### PR DESCRIPTION
TLS proxying is done with CONNECT requests, where all the proxy
does is open a tunnel to the remote server and let the client
and the server negotiate a TLS connection. The simple proxy for
the proxy tests implements this, but doesn't log it at all, so
we can't test that TLS requests were proxied.

Since this is, after all, TLS traffic, there's no way we can
log the actual request locations, but we can at least log the
host and port whenever a CONNECT request is handled, so let's
do that much.