### PR TITLE
reqpart, default-fstype: ensure just one result from blkid

### DIFF
--- a/default-fstype.ks.in
+++ b/default-fstype.ks.in
@@ -22,12 +22,12 @@ shutdown
 %end
 
 %post
-root_fstype=$(blkid -o value -t LABEL=root -s TYPE)
+root_fstype=$(blkid -o value -t LABEL=root -s TYPE -l)
 if [ $root_fstype != "ext4" ]; then
     echo "default fstype is incorrect (got $root_fstype; expected ext4)" >> /root/RESULT
 fi
 
-boot_fstype=$(blkid -o value -t LABEL=boot -s TYPE)
+boot_fstype=$(blkid -o value -t LABEL=boot -s TYPE -l)
 if [ $boot_fstype != "ext4" ]; then
     echo "default boot fstype is incorrect (got $boot_fstype; expected ext4)" >> /root/RESULT
 fi

--- a/reqpart.ks.in
+++ b/reqpart.ks.in
@@ -30,7 +30,7 @@ if [ -z "${boot_mount}" ]; then
 fi
 
 # Also verify the partitions we explicitly asked for got made.
-root_fstype=$(blkid -o value -t LABEL=root -s TYPE)
+root_fstype=$(blkid -o value -t LABEL=root -s TYPE -l)
 if [ "${root_fstype}" != "ext4" ]; then
     echo "default fstype is incorrect (got $root_fstype; expected ext4)" >> /root/RESULT
 fi


### PR DESCRIPTION
running reqpart in openQA, I found blkid would actually return
three results for this search, so the output would be 'xfs\n
xfs\nxfs' (not ext4 because I'm testing with a Server image).
The -l option protects against this by returning only one
result for the search, the one with the 'highest priority' (per
the man page).