### PR TITLE
proxy tests: handle HTTPS and mirrorlists for KSTEST_URL, unify format

### DIFF
--- a/proxy-auth.ks.in
+++ b/proxy-auth.ks.in
@@ -27,29 +27,67 @@ echo 'anaconda:qweqwe' > /tmp/proxy.password
 %end
 
 %post --nochroot
-# Look for the following as evidence that a proxy was used:
-# a .treeinfo request
-grep -q '\.treeinfo$' /tmp/proxy.log
-if [[ $? -ne 0 ]]; then
-    echo '.treeinfo request was not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+# Checks must differ depending on the form of KSTEST_URL
+# HTTP mirror list; we find the hostname with the cuts
+httplist=$(echo "@KSTEST_URL@" | grep -e '--mirrorlist="\?http:' | cut -d'=' -f2 | cut -d'/' -f3)
+# HTTPS mirror list; ditto
+httpslist=$(echo "@KSTEST_URL@" | grep -e '--mirrorlist="\?https:' | cut -d'=' -f2 | cut -d'/' -f3)
+# HTTP direct mirror; ditto
+httpdir=$(echo "@KSTEST_URL@" | grep -e '--url="\?http:' | cut -d'=' -f2 | cut -d'/' -f3)
+# HTTPS direct mirror; we don't need to capture hostname here
+httpsdir=$(echo "@KSTEST_URL@" | grep -e '--url="\?https:')
+
+if [ "$httpslist" ]; then
+    # check for CONNECT request to mirrorlist host
+    grep -q "CONNECT $httpslist " /tmp/proxy.log
+    if [[ $? -ne 0 ]]; then
+        echo 'Connection to TLS mirrorlist server was not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+    fi
+elif [ "$httplist" ]; then
+    # check for GET request to mirrorlist host (we can't really guess
+    # any path component, even 'mirrorlist' isn't guaranteed). There's
+    # a potential 'false pass' here if the mirror list and repo are on
+    # the same server and the repo requests are proxied but mirror
+    # requests are not.
+    grep -q "$httplist" /tmp/proxy.log
+    if [[ $? -ne 0 ]]; then
+        echo 'Mirror list server request was not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+    fi
+elif [ "$httpsdir" ]; then
+    # check for CONNECT request to mirror
+    grep -q "CONNECT $httpsdir " /tmp/proxy.log
+    if [[ $? -ne 0 ]]; then
+        echo 'Connection to TLS repository server was not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+    fi
+elif [ "$httpdir" ]; then
+    # check for .treeinfo request
+    grep -q '\.treeinfo$' /tmp/proxy.log
+    if [[ $? -ne 0 ]]; then
+        echo '.treeinfo request to repository server was not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+    fi
+else
+    result='Could not parse url line!'
 fi
 
-# primary.xml from the repodata
-grep -q 'repodata/.*primary.xml' /tmp/proxy.log
-if [[ $? -ne 0 ]]; then
-    echo 'repodata requests were not provxied' >> $ANA_INSTALL_PATH/root/RESULT
-fi
+# unless direct https URL was used, also check for:
+if [ ! "$httpsdir" ]; then
+    # primary.xml from the repodata
+    grep -q 'repodata/.*primary.xml' /tmp/proxy.log
+    if [[ $? -ne 0 ]]; then
+        echo 'repodata requests were not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+    fi
 
-# the kernel package from the Fedora repo
-grep -q 'kernel-.*\.rpm' /tmp/proxy.log
-if [[ $? -ne 0 ]]; then
-    echo 'base repo package requests were not proxied' >> $ANA_INSTALL_PATH/root/RESULT
-fi
+    # the kernel package from the Fedora repo
+    grep -q 'kernel-.*\.rpm' /tmp/proxy.log
+    if [[ $? -ne 0 ]]; then
+        echo 'package requests were not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+    fi
 
-# testpkg-http-core from the addon repo
-grep -q 'testpkg-http-core.*\.rpm' /tmp/proxy.log
-if [[ $? -ne 0 ]]; then
-    echo 'addon repo package requests were not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+    # testpkg-http-core from the addon repo
+    grep -q 'testpkg-http-core.*\.rpm' /tmp/proxy.log
+    if [[ $? -ne 0 ]]; then
+        echo 'addon repo package requests were not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+    fi
 fi
 
 # Check that the addon repo file was installed
@@ -73,15 +111,22 @@ if [[ $? -ne 0 ]]; then
     echo 'unable to query kstest-http repo' >> $ANA_INSTALL_PATH/root/RESULT
 fi
 
-# Finally, check that the repoquery used the proxy
-tail -1 /tmp/proxy.log | grep -q repodata
-if [[ $? -ne 0 ]]; then
-    echo 'repoquery on installed system was not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+# again unless direct https URL was used:
+if [ ! "$httpsdir" ]; then
+    # Finally, check that the repoquery used the proxy
+    tail -1 /tmp/proxy.log | grep -q repodata
+    if [[ $? -ne 0 ]]; then
+        echo 'repoquery on installed system was not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+    fi
 fi
 
 # If nothing was written to RESULT, it worked
 if [[ ! -f $ANA_INSTALL_PATH/root/RESULT ]]; then
-    echo 'SUCCESS' > $ANA_INSTALL_PATH/root/RESULT
+    if [ "$httpsdir" ]; then
+        echo 'SUCCESS but limited testing for TLS repository server' > $ANA_INSTALL_PATH/root/RESULT
+    else
+        echo 'SUCCESS' > $ANA_INSTALL_PATH/root/RESULT
+    fi
 fi
 
 %end

--- a/proxy-cmdline.ks.in
+++ b/proxy-cmdline.ks.in
@@ -21,30 +21,70 @@ shutdown
 %include scripts/proxy-common.ks
 
 %post --nochroot
-# Look for the following as evidence that a proxy was used:
-# a .treeinfo request
-grep -q '\.treeinfo$' /tmp/proxy.log
-if [[ $? -ne 0 ]]; then
-    echo '.treeinfo request was not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+# Checks must differ depending on the form of KSTEST_URL
+# HTTP mirror list; we find the hostname with the cuts
+httplist=$(echo "@KSTEST_URL@" | grep -e '--mirrorlist="\?http:' | cut -d'=' -f2 | cut -d'/' -f3)
+# HTTPS mirror list; ditto
+httpslist=$(echo "@KSTEST_URL@" | grep -e '--mirrorlist="\?https:' | cut -d'=' -f2 | cut -d'/' -f3)
+# HTTP direct mirror; ditto
+httpdir=$(echo "@KSTEST_URL@" | grep -e '--url="\?http:' | cut -d'=' -f2 | cut -d'/' -f3)
+# HTTPS direct mirror; we don't need to capture hostname here
+httpsdir=$(echo "@KSTEST_URL@" | grep -e '--url="\?https:')
+
+if [ "$httpslist" ]; then
+    # check for CONNECT request to mirrorlist host
+    grep -q "CONNECT $httpslist " /tmp/proxy.log
+    if [[ $? -ne 0 ]]; then
+        echo 'Connection to TLS mirrorlist server was not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+    fi
+elif [ "$httplist" ]; then
+    # check for GET request to mirrorlist host (we can't really guess
+    # any path component, even 'mirrorlist' isn't guaranteed). There's
+    # a potential 'false pass' here if the mirror list and repo are on
+    # the same server and the repo requests are proxied but mirror
+    # requests are not.
+    grep -q "$httplist" /tmp/proxy.log
+    if [[ $? -ne 0 ]]; then
+        echo 'Mirror list server request was not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+    fi
+elif [ "$httpsdir" ]; then
+    # check for CONNECT request to mirror
+    grep -q "CONNECT $httpsdir " /tmp/proxy.log
+    if [[ $? -ne 0 ]]; then
+        echo 'Connection to TLS repository server was not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+    fi
+elif [ "$httpdir" ]; then
+    # check for .treeinfo request
+    grep -q '\.treeinfo$' /tmp/proxy.log
+    if [[ $? -ne 0 ]]; then
+        echo '.treeinfo request to repository server was not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+    fi
+else
+    result='Could not parse url line!'
 fi
 
-# primary.xml from the repodata
-grep -q 'repodata/.*primary.xml' /tmp/proxy.log
-if [[ $? -ne 0 ]]; then
-    echo 'repodata requests were not provxied' >> $ANA_INSTALL_PATH/root/RESULT
-fi
+# unless direct https URL was used, also check for:
+if [ ! "$httpsdir" ]; then
+    # primary.xml from the repodata
+    grep -q 'repodata/.*primary.xml' /tmp/proxy.log
+    if [[ $? -ne 0 ]]; then
+        echo 'repodata requests were not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+    fi
 
-# the kernel package from the Fedora repo
-grep -q 'kernel-.*\.rpm' /tmp/proxy.log
-if [[ $? -ne 0 ]]; then
-    echo 'base repo package requests were not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+    # the kernel package from the Fedora repo
+    grep -q 'kernel-.*\.rpm' /tmp/proxy.log
+    if [[ $? -ne 0 ]]; then
+        echo 'package requests were not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+    fi
 fi
 
 # If nothing was written to RESULT, it worked
 if [[ ! -f $ANA_INSTALL_PATH/root/RESULT ]]; then
-    echo 'SUCCESS' > $ANA_INSTALL_PATH/root/RESULT
+    if [ "$httpsdir" ]; then
+        echo 'SUCCESS but limited testing for TLS repository server' > $ANA_INSTALL_PATH/root/RESULT
+    else
+        echo 'SUCCESS' > $ANA_INSTALL_PATH/root/RESULT
+    fi
 fi
 
-# Write the result to the installed /root
-echo "$result" > $ANA_INSTALL_PATH/root/RESULT
 %end

--- a/proxy-cmdline.ks.in
+++ b/proxy-cmdline.ks.in
@@ -23,17 +23,26 @@ shutdown
 %post --nochroot
 # Look for the following as evidence that a proxy was used:
 # a .treeinfo request
-# primary.xml from the repodata
-# a package. Let's say kernel, there should definitely have been a kernel
+grep -q '\.treeinfo$' /tmp/proxy.log
+if [[ $? -ne 0 ]]; then
+    echo '.treeinfo request was not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+fi
 
-if ! grep -q '\.treeinfo$' /tmp/proxy.log; then
-    result='.treeinfo request was not proxied'
-elif ! grep -q 'repodata/.*primary.xml' /tmp/proxy.log; then
-    result='repodata requests were not proxied'
-elif ! grep -q 'kernel-.*\.rpm' /tmp/proxy.log; then
-    result='package requests were not proxied'
-else
-    result='SUCCESS'
+# primary.xml from the repodata
+grep -q 'repodata/.*primary.xml' /tmp/proxy.log
+if [[ $? -ne 0 ]]; then
+    echo 'repodata requests were not provxied' >> $ANA_INSTALL_PATH/root/RESULT
+fi
+
+# the kernel package from the Fedora repo
+grep -q 'kernel-.*\.rpm' /tmp/proxy.log
+if [[ $? -ne 0 ]]; then
+    echo 'base repo package requests were not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+fi
+
+# If nothing was written to RESULT, it worked
+if [[ ! -f $ANA_INSTALL_PATH/root/RESULT ]]; then
+    echo 'SUCCESS' > $ANA_INSTALL_PATH/root/RESULT
 fi
 
 # Write the result to the installed /root

--- a/proxy-kickstart.ks.in
+++ b/proxy-kickstart.ks.in
@@ -1,5 +1,5 @@
-url @KSTEST_URL@ --proxy=127.0.0.1:8080
-repo --name=kstest-http --baseurl=HTTP-ADDON-REPO --proxy=127.0.0.1:8080 --install
+url @KSTEST_URL@ --proxy=http://127.0.0.1:8080
+repo --name=kstest-http --baseurl=HTTP-ADDON-REPO --proxy=http://127.0.0.1:8080 --install
 install
 network --bootproto=dhcp
 
@@ -22,29 +22,67 @@ shutdown
 %include scripts/proxy-common.ks
 
 %post --nochroot
-# Look for the following as evidence that a proxy was used:
-# a .treeinfo request
-grep -q '\.treeinfo$' /tmp/proxy.log
-if [[ $? -ne 0 ]]; then
-    echo '.treeinfo request was not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+# Checks must differ depending on the form of KSTEST_URL
+# HTTP mirror list; we find the hostname with the cuts
+httplist=$(echo "@KSTEST_URL@" | grep -e '--mirrorlist="\?http:' | cut -d'=' -f2 | cut -d'/' -f3)
+# HTTPS mirror list; ditto
+httpslist=$(echo "@KSTEST_URL@" | grep -e '--mirrorlist="\?https:' | cut -d'=' -f2 | cut -d'/' -f3)
+# HTTP direct mirror; ditto
+httpdir=$(echo "@KSTEST_URL@" | grep -e '--url="\?http:' | cut -d'=' -f2 | cut -d'/' -f3)
+# HTTPS direct mirror; we don't need to capture hostname here
+httpsdir=$(echo "@KSTEST_URL@" | grep -e '--url="\?https:')
+
+if [ "$httpslist" ]; then
+    # check for CONNECT request to mirrorlist host
+    grep -q "CONNECT $httpslist " /tmp/proxy.log
+    if [[ $? -ne 0 ]]; then
+        echo 'Connection to TLS mirrorlist server was not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+    fi
+elif [ "$httplist" ]; then
+    # check for GET request to mirrorlist host (we can't really guess
+    # any path component, even 'mirrorlist' isn't guaranteed). There's
+    # a potential 'false pass' here if the mirror list and repo are on
+    # the same server and the repo requests are proxied but mirror
+    # requests are not.
+    grep -q "$httplist" /tmp/proxy.log
+    if [[ $? -ne 0 ]]; then
+        echo 'Mirror list server request was not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+    fi
+elif [ "$httpsdir" ]; then
+    # check for CONNECT request to mirror
+    grep -q "CONNECT $httpsdir " /tmp/proxy.log
+    if [[ $? -ne 0 ]]; then
+        echo 'Connection to TLS repository server was not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+    fi
+elif [ "$httpdir" ]; then
+    # check for .treeinfo request
+    grep -q '\.treeinfo$' /tmp/proxy.log
+    if [[ $? -ne 0 ]]; then
+        echo '.treeinfo request to repository server was not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+    fi
+else
+    result='Could not parse url line!'
 fi
 
-# primary.xml from the repodata
-grep -q 'repodata/.*primary.xml' /tmp/proxy.log
-if [[ $? -ne 0 ]]; then
-    echo 'repodata requests were not provxied' >> $ANA_INSTALL_PATH/root/RESULT
-fi
+# unless direct https URL was used, also check for:
+if [ ! "$httpsdir" ]; then
+    # primary.xml from the repodata
+    grep -q 'repodata/.*primary.xml' /tmp/proxy.log
+    if [[ $? -ne 0 ]]; then
+        echo 'repodata requests were not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+    fi
 
-# the kernel package from the Fedora repo
-grep -q 'kernel-.*\.rpm' /tmp/proxy.log
-if [[ $? -ne 0 ]]; then
-    echo 'base repo package requests were not proxied' >> $ANA_INSTALL_PATH/root/RESULT
-fi
+    # the kernel package from the Fedora repo
+    grep -q 'kernel-.*\.rpm' /tmp/proxy.log
+    if [[ $? -ne 0 ]]; then
+        echo 'package requests were not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+    fi
 
-# testpkg-http-core from the addon repo
-grep -q 'testpkg-http-core.*\.rpm' /tmp/proxy.log
-if [[ $? -ne 0 ]]; then
-    echo 'addon repo package requests were not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+    # testpkg-http-core from the addon repo
+    grep -q 'testpkg-http-core.*\.rpm' /tmp/proxy.log
+    if [[ $? -ne 0 ]]; then
+        echo 'addon repo package requests were not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+    fi
 fi
 
 # Check that the addon repo file was installed
@@ -68,15 +106,22 @@ if [[ $? -ne 0 ]]; then
     echo 'unable to query kstest-http repo' >> $ANA_INSTALL_PATH/root/RESULT
 fi
 
-# Finally, check that the repoquery used the proxy
-tail -1 /tmp/proxy.log | grep -q repodata
-if [[ $? -ne 0 ]]; then
-    echo 'repoquery on installed system was not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+# again unless direct https URL was used:
+if [ ! "$httpsdir" ]; then
+    # Finally, check that the repoquery used the proxy
+    tail -1 /tmp/proxy.log | grep -q repodata
+    if [[ $? -ne 0 ]]; then
+        echo 'repoquery on installed system was not proxied' >> $ANA_INSTALL_PATH/root/RESULT
+    fi
 fi
 
 # If nothing was written to RESULT, it worked
 if [[ ! -f $ANA_INSTALL_PATH/root/RESULT ]]; then
-    echo 'SUCCESS' > $ANA_INSTALL_PATH/root/RESULT
+    if [ "$httpsdir" ]; then
+        echo 'SUCCESS but limited testing for TLS repository server' > $ANA_INSTALL_PATH/root/RESULT
+    else
+        echo 'SUCCESS' > $ANA_INSTALL_PATH/root/RESULT
+    fi
 fi
 
 %end


### PR DESCRIPTION
while working on running kickstart-tests in openQA, I noticed
that they do not work if KSTEST_URL is anything but an HTTP
mirror. If it's a mirror list and/or uses HTTPS, the tests
fail. This should work as well as possible in all four cases,
and warn that complete checking is not possible for a direct
HTTPS mirror URL when that is used. Also bring proxy-cmdline's
format more in line with the other two files.

This differs from #14 by not trying to do anything to change the
proxy code inclusion or template out the files, it's strictly just the
bug fixes and making cmdline look more similar to the other two.