### PR TITLE
Skip libvirt IPs

### DIFF
--- a/scripts/find-ip
+++ b/scripts/find-ip
@@ -21,6 +21,7 @@
 # Print something that looks like an externally accessible IPv4 address.
 
 ip addr list | \
+    grep -v '192.168.122.1' | \
     grep '^[[:space:]]*inet\>.*scope global' | \
     head -1 | \
     sed 's/^[[:space:]]*inet \([[:digit:].]*\).*/\1/'


### PR DESCRIPTION
The script is taking the first IP it finds, which in my case is 192.168.122.1 and stuff doesn't appear to work for some reason. I have a br0 configured which shows at the end of the ip addr list output.
