### PR TITLE
Change "keyboard en" to "keyboard us"

### DIFF
--- a/firewall.ks.in
+++ b/firewall.ks.in
@@ -8,7 +8,7 @@ zerombr
 clearpart --all --initlabel
 autopart
 
-keyboard en
+keyboard us
 lang en
 timezone America/New_York --utc
 rootpw testcase

--- a/services.ks.in
+++ b/services.ks.in
@@ -8,7 +8,7 @@ zerombr
 clearpart --all --initlabel
 autopart
 
-keyboard en
+keyboard us
 lang en
 timezone America/New_York --utc
 rootpw testcase

--- a/timezoneLOCAL.ks.in
+++ b/timezoneLOCAL.ks.in
@@ -8,7 +8,7 @@ zerombr
 clearpart --all --initlabel
 autopart
 
-keyboard en
+keyboard us
 lang en
 timezone Europe/Prague
 rootpw testcase

--- a/timezoneUTC.ks.in
+++ b/timezoneUTC.ks.in
@@ -8,7 +8,7 @@ zerombr
 clearpart --all --initlabel
 autopart
 
-keyboard en
+keyboard us
 lang en
 timezone Europe/Prague --utc
 rootpw testcase


### PR DESCRIPTION
There is no "en" keyboard since no two English-speaking countries can
agree on what key goes where, and actual England uses "gb".