### PR TITLE
Fix packages-instlangs-3

### DIFF
--- a/packages-instlangs-3.ks.in
+++ b/packages-instlangs-3.ks.in
@@ -23,7 +23,7 @@ shutdown
 # Add glibc-all-langpacks to install locale data separately from
 # lang --addsupport.
 %packages --instLangs=es:fr:it
-python-blivet
+python3-blivet
 glibc-all-langpacks
 %end
 


### PR DESCRIPTION
python-blivet doesn't exist anymore.