### PR TITLE
Add a test for different cases of encrypted swap

### DIFF
--- a/encrypt-swap.ks.in
+++ b/encrypt-swap.ks.in
@@ -1,0 +1,93 @@
+#version=DEVEL
+url @KSTEST_URL@
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+part /boot --fstype=ext4 --size=500 --ondisk=sda
+part / --size=4000 --fstype=ext4 --fsoptions=loud,noatime --ondisk=sda --label=rootfs
+
+# Create three encrypted swap partitions. First, a regular partition
+part swap --fstype=swap --size=500 --encrypted --passphrase=TestCase --ondisk=sda --label=part_swap
+
+# LVM
+part pv.1 --fstype=lvmpv --size=500 --ondisk=sda
+volgroup fedora pv.1
+logvol swap --name=swap --vgname=fedora --size=400 --grow --fstype=swap --encrypted --passphrase=TestCase
+
+# RAID
+part raid.01 --size=500 --ondisk=sdb
+part raid.02 --size=500 --ondisk=sdc
+raid swap --level=1 --device=0 --fstype=swap --encrypted --label=md_swap --passphrase=TestCase raid.01 raid.02
+
+keyboard us
+lang en_US.UTF-8
+timezone America/New_York --utc
+rootpw testcase
+shutdown
+
+%packages
+%end
+
+%post
+# verify that the regular partition is active
+swap_part_luks="$(blkid -L part_swap)"
+swap_part_dm="$(basename $(readlink $swap_part_luks))"
+if ! grep -q "$swap_part_dm" /proc/swaps ; then
+    echo "*** encrypted swap partition not active" >> /root/RESULT
+fi
+
+# verify that the swap entry in /etc/fstab is correct
+swap_part_regular_entry="^${swap_part_luks}\\s\\+swap\\s"
+swap_part_uuid_entry="^UUID=$(blkid -o value -s UUID $swap_part_luks)\\s\\+swap\\s"
+if ! ( grep -q "$swap_part_regular_entry" /etc/fstab || grep -q "$swap_part_uuid_entry" /etc/fstab ) ; then
+    echo "*** encrypted swap partition not found in /etc/fstab" >> /root/RESULT
+fi
+
+# Find the LUKS device created for the swap on LVM
+swap_lv="/dev/mapper/fedora-swap"
+swap_lv_uuid="$(blkid -o value -s UUID "$swap_lv")"
+swap_lv_luks=/dev/mapper/luks-"$swap_lv_uuid"
+
+if [ ! -e "$swap_lv_luks" ]; then
+    echo "*** encrypted swap LV device not found" >> /root/RESULT
+fi
+
+# verify that the swap is active
+swap_lv_dm="$(basename $(readlink $swap_lv_luks))"
+if ! grep -q "$swap_lv_dm" /proc/swaps ; then
+    echo "*** encrypted swap LV is not active" >> /root/RESULT
+fi
+
+# verify that the swap entry in /etc/fstab is correct
+swap_lv_regular_entry="^${swap_lv_luks}\\s\\+swap\\s"
+swap_lv_uuid_entry="^UUID=$(blkid -o value -s UUID $swap_lv_luks)\\s\\+swap\\s"
+if ! ( grep -q "$swap_lv_regular_entry" /etc/fstab || grep -q "$swap_lv_uuid_entry" /etc/fstab ) ; then
+    echo "*** encrypted swap LV is not in /etc/fstab" >> /root/RESULT
+fi
+
+# One more time, for RAID
+# Look for the LUKS device using the --label in the raid command
+swap_md_luks="$(blkid -L md_swap)"
+if [ ! -e "$swap_md_luks" ]; then
+    echo "*** encrypted swap MD device not found" >> /root/RESULT
+fi
+
+swap_md_dm="$(basename $(readlink $swap_md_luks))"
+if ! grep -q "$swap_md_dm" /proc/swaps ; then
+    echo "*** encrypted swap MD is not active" >> /root/RESULT
+fi
+
+swap_md_regular_entry="^${swap_md_luks}\\s\\+swap\\s"
+swap_md_uuid_entry="^UUID=$(blkid -o value -s UUID $swap_md_luks)\\s\\+swap\\s"
+if ! ( grep -q "$swap_md_regular_entry" /etc/fstab || grep -q "$swap_md_uuid_entry" /etc/fstab ) ; then
+    echo "*** encrypted swap MD is not in /etc/fstab" >> /root/RESULT
+fi
+
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+
+%end

--- a/encrypt-swap.sh
+++ b/encrypt-swap.sh
@@ -1,0 +1,55 @@
+#
+# Copyright (C) 2016  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+
+TESTTYPE="storage"
+
+. ${KSTESTDIR}/functions.sh
+
+prepare_disks() {
+    tmpdir=$1
+
+    # Need an extra two disks for RAID, but they don't need to be big
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-a.img 10G
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-b.img 1G
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-c.img 1G
+    echo ${tmpdir}/disk-a.img ${tmpdir}/disk-b.img ${tmpdir}/disk-c.img
+}
+
+validate() {
+    disksdir=$1
+    # The raid disks don't contain anything relevant to the results, so leave
+    # those out
+    args="-a ${disksdir}/disk-a.img"
+
+    # Grab the coverage results out of the installed system while it still
+    # exists.
+    virt-copy-out ${args} /root/anaconda.coverage ${disksdir}
+
+    # There should be a /root/RESULT file with results in it.  Check
+    # its contents and decide whether the test finally succeeded or
+    # not.
+    result=$(virt-cat ${args} -m /dev/disk/by-label/rootfs /root/RESULT)
+    if [[ $? != 0 ]]; then
+        status=1
+        echo '*** /root/RESULT does not exist in VM image.'
+    elif [[ "${result}" != SUCCESS* ]]; then
+        status=1
+        echo "${result}"
+    fi
+
+    return ${status}
+}


### PR DESCRIPTION
This will fail on finding the /etc/fstab entry for the swap on RAID (but everything before that ought to work). The RAID case will be fixed by the second commit of https://github.com/rhinstaller/anaconda/pull/659.