### PR TITLE
Master fix tests

### DIFF
--- a/scripts/kstest-runner
+++ b/scripts/kstest-runner
@@ -43,7 +43,8 @@ from pylorax.mount import IsoMountpoint
 import libvirt
 
 class InstallError(Exception):
-    pass
+    def __str__(self):
+        return super().__str__().replace("#012", "\n")
 
 class VirtualInstall(object):
     """
@@ -148,6 +149,7 @@ class VirtualInstall(object):
         subprocess.call(["virsh", "undefine", self.virt_name])
         subprocess.call(["virsh", "pool-destroy", poolName])
         subprocess.call(["virsh", "pool-undefine", poolName])
+
 
 def virt_install(opts, install_log):
     """

--- a/scripts/kstest-runner
+++ b/scripts/kstest-runner
@@ -72,9 +72,9 @@ class VirtualInstall(object):
         # add --graphics none later
         # add whatever serial cmds are needed later
         args = ["-n", self.virt_name,
-                 "-r", str(memory),
-                 "--noreboot",
-                 "--noautoconsole"]
+                "-r", str(memory),
+                "--noreboot",
+                "--noautoconsole"]
 
         args.append("--graphics")
         if vnc:
@@ -115,6 +115,7 @@ class VirtualInstall(object):
         args.append(channel_args)
 
         log.info("Running virt-install.")
+        log.info("virt-install %s", args)
         try:
             execWithRedirect("virt-install", args, raise_err=True)
         except subprocess.CalledProcessError as e:

--- a/scripts/run_one_ks.sh
+++ b/scripts/run_one_ks.sh
@@ -108,19 +108,20 @@ runone() {
                        --vnc vnc \
                        --timeout 60 \
                        ${disk_args}
+    echo
     if [[ -f ${tmpdir}/virt-install.log && "$(grep CRIT ${tmpdir}/virt-install.log)" != "" ]]; then
-        echo RESULT:${name}:FAILED:$(grep CRIT ${tmpdir}/virt-install.log)
+        echo "RESULT:${name}:FAILED:\n$(grep CRIT ${tmpdir}/virt-install.log | sed 's/#012/\n/g')"
         cleanup ${tmpdir}
         cleanup_tmp ${tmpdir}
         return 1
     elif [[ -f ${tmpdir}/livemedia.log ]]; then
         if [[ "$(grep 'due to timeout' ${tmpdir}/livemedia.log)" != "" ]]; then
-            echo RESULT:${name}:FAILED:Test timed out.
+            echo "RESULT:${name}:FAILED:Test timed out."
             cleanup ${tmpdir}
             cleanup_tmp ${tmpdir}
             return 2
         elif [[ "$(grep 'Call Trace' ${tmpdir}/livemedia.log)" != "" ]]; then
-            echo RESULT:${name}:FAILED:Kernel panic.
+            echo "RESULT:${name}:FAILED:Kernel panic."
             cleanup ${tmpdir}
             cleanup_tmp ${tmpdir}
             return 0
@@ -128,7 +129,7 @@ runone() {
 
         result=$(validate ${tmpdir})
         if [[ $? != 0 ]]; then
-            echo RESULT:${name}:FAILED:"${result}"
+            echo "RESULT:${name}:FAILED:${result}"
             cleanup ${tmpdir}
             cleanup_tmp ${tmpdir}
             return 1

--- a/scripts/run_one_ks.sh
+++ b/scripts/run_one_ks.sh
@@ -108,6 +108,8 @@ runone() {
                        --vnc vnc \
                        --timeout 60 \
                        ${disk_args}
+    cp ${tmpdir}/virt-install.log ${tmpdir}/virt-install-human.log
+    sed -i 's/#012/\n/g' ${tmpdir}/virt-install-human.log
     echo
     if [[ -f ${tmpdir}/virt-install.log && "$(grep CRIT ${tmpdir}/virt-install.log)" != "" ]]; then
         echo "RESULT:${name}:FAILED:\n$(grep CRIT ${tmpdir}/virt-install.log | sed 's/#012/\n/g')"


### PR DESCRIPTION
Some cosmetic improvements.

1) log virt-install command with parameters to catch errors from this
2) Replace ``#012`` by ``\n`` in output message. It will be the still in the logs (virt-install.log) but in console output it will be readable.