### PR TITLE
Grab logs from anaconda after installation

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -48,6 +48,9 @@ validate() {
     # exists.
     virt-copy-out ${args} /root/anaconda.coverage ${disksdir}
 
+    # Grab logs from Anaconda installation
+    virt-copy-out ${args} /var/log/anaconda/*.log ${disksdir} 2>/dev/null
+
     # There should be a /root/RESULT file with results in it.  Check
     # its contents and decide whether the test finally succeeded or
     # not.


### PR DESCRIPTION
This won't be working if there will be exception or any other abnormal end of installation. Still it's useful for tests where ``RESULT`` file will contain ``FAILED``.