### PR TITLE
Fix testing more tests from command line

### DIFF
--- a/scripts/run_kickstart_tests.sh
+++ b/scripts/run_kickstart_tests.sh
@@ -131,9 +131,9 @@ if [[ $# != 0 ]]; then
     # Allow people to leave off the .sh.
     for t in $*; do
         if [[ "${t}" == *.sh ]]; then
-            tests+="${t}"
+            tests+="${t} "
         else
-            tests+="${t}.sh"
+            tests+="${t}.sh "
         fi
     done
 elif [[ "${ghprbActualCommit}" != "" ]]; then


### PR DESCRIPTION
There was missing space between the tests. It results to "test1.kstest2.ks" strings which weren't found.