### PR TITLE
Fix lvm-raid-1 test be reducing space requirement

### DIFF
--- a/lvm-raid-1.ks.in
+++ b/lvm-raid-1.ks.in
@@ -7,9 +7,9 @@ bootloader --timeout=1
 zerombr
 clearpart --all --initlabel
 part /boot --fstype=ext4 --size=500
-part raid.01 --size=8000 --ondisk=sda
-part raid.02 --size=8000 --ondisk=sdb
-part raid.03 --size=8000 --ondisk=sdc
+part raid.01 --size=7500 --ondisk=sda
+part raid.02 --size=7500 --ondisk=sdb
+part raid.03 --size=7500 --ondisk=sdc
 raid pv.01 --level=RAID5 --device=pv.01 raid.01 raid.02 raid.03
 volgroup fedora pv.01
 logvol swap --name=swap --vgname=fedora --size=500 --fstype=swap


### PR DESCRIPTION
There were 8G disks and the raid in kickstart file created partitions for 8000 size. Test was failing because the partitions can't be created.