### PR TITLE
Adapt to changes in LVM cache size handling

### DIFF
--- a/lvm-cache-1.ks.in
+++ b/lvm-cache-1.ks.in
@@ -99,11 +99,11 @@ if [ $? != 0 ]; then
     echo "*** home LV is not cached" >> /root/RESULT
 fi
 
-# verify size of root LV's cache
+# verify size of root LV's cache (1500 - 8 [pmspare])
 root_cache_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/root_cache | sed -r 's/\s*([0-9]+)\..*/\1/')
 root_cache_md_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/root_cache_cmeta | sed -r 's/\s*([0-9]+)\..*/\1/')
 root_cache_all=$(($root_cache_size + $root_cache_md_size))
-if [ "$root_cache_all" != "1500" ]; then
+if [ "$root_cache_all" != "1492" ]; then
     echo "*** root LV's cache has incorrect size" >> /root/RESULT
 fi
 

--- a/lvm-cache-2.ks.in
+++ b/lvm-cache-2.ks.in
@@ -101,11 +101,11 @@ if [ $? != 0 ]; then
     echo "*** home LV is not cached" >> /root/RESULT
 fi
 
-# verify size of root LV's cache
+# verify size of root LV's cache (1000 - 8 [pmspare])
 root_cache_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/root_cache | sed -r 's/\s*([0-9]+)\..*/\1/')
 root_cache_md_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/root_cache_cmeta | sed -r 's/\s*([0-9]+)\..*/\1/')
 root_cache_all=$(($root_cache_size + $root_cache_md_size))
-if [ "$root_cache_all" != "1000" ]; then
+if [ "$root_cache_all" != "992" ]; then
     echo "*** root LV's cache has incorrect size" >> /root/RESULT
 fi
 


### PR DESCRIPTION
Blivet now makes sure that the overall space required for the LVM cache(s)
equals the value passed as the requested cache size. Thus size of the metadata
space is subtracted from the cache's size and for the first cache defined the
same applies also to the size of the pmspare space.