### PR TITLE
Add missing coverage test to proxy-cmdline KS test

### DIFF
--- a/proxy-cmdline.sh
+++ b/proxy-cmdline.sh
@@ -26,7 +26,7 @@ prereqs() {
 }
 
 kernel_args() {
-    echo vnc inst.proxy=http://127.0.0.1:8080
+    echo vnc inst.proxy=http://127.0.0.1:8080 inst.debug
 }
 
 prepare() {


### PR DESCRIPTION
Parameters `debug=1` and `inst.debug` are required to enable coverage tests.

---------------------------------
This test will fail because of bug which is fixed in PR https://github.com/rhinstaller/kickstart-tests/pull/38 .