### PR TITLE
Fix network --noipv4 tests.

### DIFF
--- a/network-noipv4-httpks.ks.in
+++ b/network-noipv4-httpks.ks.in
@@ -52,23 +52,8 @@ function check_device_ifcfg_value() {
     fi
 }
 
-function check_device_connected() {
-    local nic="$1"
-    local expected_result="$2"
-    local exit_code=0
-    if [[ ${expected_result} == "no" ]]; then
-        exit_code=1
-    fi
-
-    nmcli -t -f DEVICE,STATE dev | grep "${nic}:connected"
-    if [[ $? -ne ${exit_code} ]]; then
-        echo "*** Device ${nic} connected:${expected_result} check failed" >> /root/RESULT
-    fi
-}
-
 device_ifcfg_key_missing ens4 BOOTPROTO
 device_ifcfg_key_missing ens5 BOOTPROTO
-check_device_connected ens5 yes
 
 # No error was written to /root/RESULT file, everything is OK
 if [[ ! -e /root/RESULT ]]; then

--- a/network-noipv4-httpks.rhel.ks.in
+++ b/network-noipv4-httpks.rhel.ks.in
@@ -55,23 +55,8 @@ function check_device_ifcfg_value() {
     fi
 }
 
-function check_device_connected() {
-    local nic="$1"
-    local expected_result="$2"
-    local exit_code=0
-    if [[ ${expected_result} == "no" ]]; then
-        exit_code=1
-    fi
-
-    nmcli -t -f DEVICE,STATE dev | grep "${nic}:connected"
-    if [[ $? -ne ${exit_code} ]]; then
-        echo "*** Device ${nic} connected:${expected_result} check failed" >> /root/RESULT
-    fi
-}
-
 check_device_ifcfg_value ens4 BOOTPROTO none
 check_device_ifcfg_value ens5 BOOTPROTO none
-check_device_connected ens5 yes
 
 # No error was written to /root/RESULT file, everything is OK
 if [[ ! -e /root/RESULT ]]; then

--- a/network-noipv4-pre.ks.in
+++ b/network-noipv4-pre.ks.in
@@ -55,23 +55,8 @@ function check_device_ifcfg_value() {
     fi
 }
 
-function check_device_connected() {
-    local nic="$1"
-    local expected_result="$2"
-    local exit_code=0
-    if [[ ${expected_result} == "no" ]]; then
-        exit_code=1
-    fi
-
-    nmcli -t -f DEVICE,STATE dev | grep "${nic}:connected"
-    if [[ $? -ne ${exit_code} ]]; then
-        echo "*** Device ${nic} connected:${expected_result} check failed" >> /root/RESULT
-    fi
-}
-
 device_ifcfg_key_missing ens4 BOOTPROTO
 device_ifcfg_key_missing ens5 BOOTPROTO
-check_device_connected ens5 yes
 
 # No error was written to /root/RESULT file, everything is OK
 if [[ ! -e /root/RESULT ]]; then


### PR DESCRIPTION
We shouldn't check connected state on --noipv4 configured device.  Or do it in
a better way, taking into account (and perhaps controlling) also ipv6
connetivity on the device, but that is for another test.