### PR TITLE
Fix hostname test on RHEL system

### DIFF
--- a/hostname.sh
+++ b/hostname.sh
@@ -20,26 +20,3 @@
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh
-
-validate() {
-    disksdir=$1
-    args=$(for d in ${disksdir}/disk-*img; do echo -a ${d}; done)
-
-    # Grab the coverage results out of the installed system while it still
-    # exists.
-    virt-copy-out ${args} /root/anaconda.coverage ${disksdir}
-
-    # There should be a /root/RESULT file with results in it.  Check
-    # its contents and decide whether the test finally succeeded or
-    # not.
-    result=$(virt-cat ${args} -m /dev/mapper/fedora_testhostname-root /root/RESULT)
-    if [[ $? != 0 ]]; then
-        status=1
-        echo '*** /root/RESULT does not exist in VM image.'
-    elif [[ "${result}" != "SUCCESS" ]]; then
-        status=1
-        echo "${result}"
-    fi
-
-    return ${status}
-}


### PR DESCRIPTION
Hostname test do not need `validate()` in the shell script, because it's using autopart.
This `validate()` worked only for Fedora system because of disk name prefix `fedora-*`.