### PR TITLE
Add updates images support

### DIFF
--- a/scripts/run_one_ks.sh
+++ b/scripts/run_one_ks.sh
@@ -93,7 +93,13 @@ runone() {
         ks_args="--ks ${ksfile}"
     fi
 
+    # set kernel arguments
     kargs=$(kernel_args)
+    # set updates image link if -u parameter was used
+    if [[ "${UPDATES}" != "" ]]; then
+        kargs="$kargs inst.updates=${UPDATES}"
+    fi
+
     if [[ "${kargs}" != "" ]]; then
         kargs="--kernel-args \"$kargs\""
     fi
@@ -167,16 +173,17 @@ if [[ ${EUID} != 0 ]]; then
     exit 77
 fi
 
-while getopts ":i:k:" opt; do
+while getopts ":i:k:u:" opt; do
     case $opt in
         i)
             IMAGE=$OPTARG
             ;;
-
         k)
             KEEPIT=$OPTARG
             ;;
-
+        u)
+            UPDATES=$OPTARG
+            ;;
         *)
             echo "Usage: run_one_ks.sh -i ISO [-k KEEPIT] ks-test.sh"
             exit 1


### PR DESCRIPTION
``Usage: ./scripts/run_kickstart_tests.sh -i [boot.iso] -k [1|2] -u [link to updates.img] [test.sh...]``

Updates image must be on the reachable server in network for VM.

The `-u` option is then past to the inst.updates kernel arguments for the VM. This feature can break tests and give you non-valid results, but it is much quicker then building your own `boot.iso`.