### PR TITLE
Check that 'discard' is used for a new encrypted LV

### DIFF
--- a/encrypt-device.ks.in
+++ b/encrypt-device.ks.in
@@ -27,7 +27,15 @@ shutdown
 root_lv_type=$(blkid -ovalue -sTYPE /dev/mapper/vg01-root_lv)
 if [ "$root_lv_type" != "crypto_LUKS" ]; then
     echo "root LV is not encrypted" > /home/RESULT
-else
-    echo SUCCESS > /home/RESULT
+fi
+
+# check that the encrypted partition has discard enabled (#1421596)
+grep -q discard /etc/crypttab
+if [ $? != 0 ]; then
+    echo "discard not enabled for root_lv" >> /home/RESULT
+fi
+
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
 fi
 %end


### PR DESCRIPTION
As requested in the F26 change
https://fedoraproject.org//wiki/Changes/EnableTrimOnDmCrypt.

Related: rhbz#1421596

Note: this needs to wait for https://github.com/rhinstaller/blivet/pull/550