### PR TITLE
noipv4 tests: noipv4 device activated in stage2 is not connected

### DIFF
--- a/network-noipv4-httpks.ks.in
+++ b/network-noipv4-httpks.ks.in
@@ -31,7 +31,9 @@ else
     device_ifcfg_key_missing ens5 BOOTPROTO
 fi
 
-check_device_connected ens5 yes
+# TODO create test with virtual network having ipv6 enabled (ipv6 only connection)
+#      libvirt default net does not have ipv6 enabled
+check_device_connected ens5 no
 check_device_has_ipv4_address ens5 no
 
 # No error was written to /root/RESULT file, everything is OK

--- a/network-noipv4-pre.ks.in
+++ b/network-noipv4-pre.ks.in
@@ -28,7 +28,9 @@ shutdown
 
 device_ifcfg_key_missing ens4 BOOTPROTO
 device_ifcfg_key_missing ens5 BOOTPROTO
-check_device_connected ens5 yes
+# TODO create test with virtual network having ipv6 enabled (ipv6 only connection)
+#      libvirt default net does not have ipv6 enabled
+check_device_connected ens5 no
 check_device_has_ipv4_address ens5 no
 
 # No error was written to /root/RESULT file, everything is OK


### PR DESCRIPTION
Because libvirt default network we are using does not have automatic ipv6
configuration enabled.