### PR TITLE
network: add test for onboot policy

### DIFF
--- a/onboot-bootopts-pre.ks.in
+++ b/onboot-bootopts-pre.ks.in
@@ -1,0 +1,45 @@
+#test name: onboot-bootopts-pre
+url @KSTEST_URL@
+install
+
+%include /tmp/ksinclude
+%pre
+echo "network --device=ens4 --bootproto dhcp --onboot=no" >> /tmp/ksinclude
+%end
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+%post --nochroot
+
+@KSINCLUDE@ post-nochroot-lib-network.sh
+
+check_gui_configurations ens3 ens4
+
+%end
+
+%post
+
+@KSINCLUDE@ post-lib-network.sh
+
+check_device_ifcfg_value ens3 ONBOOT yes
+check_device_ifcfg_value ens4 ONBOOT no
+check_device_connected ens3 yes
+check_device_connected ens4 yes
+
+# No error was written to /root/RESULT file, everything is OK
+if [[ ! -e /root/RESULT ]]; then
+   echo SUCCESS > /root/RESULT
+fi
+%end

--- a/onboot-bootopts-pre.sh
+++ b/onboot-bootopts-pre.sh
@@ -1,0 +1,40 @@
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
+
+# This is actually testing application of kickstart network commands in
+# anaconda (which would normally be triggered by defining networking in %pre
+# and %including it into kickstart).  It is caused by network kickstart
+# commands not being applied in dracut because for ks=file:/ks.cfg (kickstart
+# injected in initrd) network devices are not found in sysfs in the time of
+# parsing the kickstart.
+
+TESTTYPE="network"
+
+. ${KSTESTDIR}/functions.sh
+
+
+kernel_args() {
+    echo vnc debug=1 inst.debug ip=dhcp
+}
+
+# Arguments for virt-install --network options
+prepare_network() {
+    echo "network:default"
+    echo "network:default"
+}


### PR DESCRIPTION
In rhel we make sure at least one the devices activated during installations
has ONBOOT set to yes.

This test handles the case where ONBOOT was set to yes for additional device
because we were looking only on ONBOOT values in ksdata and a device activated
via boot options without ks configuration is not in ksdata for automatic
installations (ie if network spoke is not visited) so we were wrongly assuming
there is no device with ONBOOT=yes.

Note: the originally failing test for this issue was network-static, but
network-static is now replaced by more comprehensive network-static-2 tests and
this issue will be tested by this new test.