### PR TITLE
network: add test for onboot policy

### DIFF
--- a/onboot-bootopts-pre.ks.in
+++ b/onboot-bootopts-pre.ks.in
@@ -1,7 +1,11 @@
-#test name: network-static
+#test name: onboot-bootopts-pre
 url @KSTEST_URL@
 install
-network --device=ens4 --bootproto static --ip @KSTEST_STATIC_IP@ --netmask @KSTEST_STATIC_NETMASK@ --gateway @KSTEST_STATIC_GATEWAY@ --onboot=no
+
+%include /tmp/ksinclude
+%pre
+echo "network --device=ens4 --bootproto dhcp --onboot=no" >> /tmp/ksinclude
+%end
 
 bootloader --timeout=1
 zerombr
@@ -17,15 +21,22 @@ shutdown
 %packages
 %end
 
+%post --nochroot
+
+@KSINCLUDE@ post-nochroot-lib-network.sh
+
+check_gui_configurations ens3 ens4
+
+%end
+
 %post
 
 @KSINCLUDE@ post-lib-network.sh
 
-check_device_ifcfg_value ens4 IPADDR @KSTEST_STATIC_IP@
+check_device_ifcfg_value ens3 ONBOOT yes
 check_device_ifcfg_value ens4 ONBOOT no
 check_device_connected ens3 yes
 check_device_connected ens4 yes
-check_device_ipv4_address ens4 @KSTEST_STATIC_IP@
 
 # No error was written to /root/RESULT file, everything is OK
 if [[ ! -e /root/RESULT ]]; then

--- a/onboot-bootopts-pre.sh
+++ b/onboot-bootopts-pre.sh
@@ -33,38 +33,8 @@ kernel_args() {
     echo vnc debug=1 inst.debug ip=dhcp
 }
 
-prepare() {
-    local ks=$1
-    local tmpdir=$2
-
-    ### Create dedicated network to prevent IP address conflicts for parallel tests
-
-    local network=$(basename ${tmpdir})
-
-    local scriptdir=${PWD}/scripts
-    local ips="$(${scriptdir}/create-network.py "${network}")"
-    local ip="$(echo "$ips" | cut -d ' ' -f 1)"
-    local netmask="$(echo "$ips" | cut -d ' ' -f 2)"
-    local gateway="$(echo "$ips" | cut -d ' ' -f 3)"
-
-    # Substitute IP ranges of created network in kickstart
-    sed -i -e s#@KSTEST_STATIC_IP@#${ip}# -e s#@KSTEST_STATIC_NETMASK@#${netmask}# -e s#@KSTEST_STATIC_GATEWAY@#${gateway}# ${ks}
-
-    echo ${ks}
-}
-
 # Arguments for virt-install --network options
 prepare_network() {
-    local tmpdir=$1
-    local network=$(basename ${tmpdir})
-    echo "network:${network}"
-    echo "network:${network}"
-}
-
-cleanup() {
-    local tmpdir=$1
-
-    ### Destroy dedicated network
-    local network=$(basename ${tmpdir})
-    virsh net-destroy ${network}
+    echo "network:default"
+    echo "network:default"
 }


### PR DESCRIPTION
In rhel we make sure at least one the devices activated during installations
has ONBOOT set to yes.

This test handles the case where ONBOOT was set to yes for additional device
because we were looking only on ONBOOT values in ksdata and a device activated
via boot options without ks configuration is not in ksdata for automatic
installations (ie if network spoke is not visited) so we were wrongly assuming
there is no device with ONBOOT=yes.

Note: the originally failing test for this issue was network-static, but
network-static is now replaced by more comprehensive network-static-2 tests and
this issue will be tested by this new test.