### PR TITLE
Add initial geolocation kickstart test

### DIFF
--- a/geolocation-off-by-default-with-ks.ks.in
+++ b/geolocation-off-by-default-with-ks.ks.in
@@ -1,0 +1,50 @@
+#test name: geolocation-off-by-default-with-ks
+url @KSTEST_URL@
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+%post
+
+# Geolocation should be off by default during a kickstart installation.
+# This can be tested by checking if the sensitive-info log contains
+# any results from a geolocation lookup - there should not be any
+# during a default kickstart installation.
+
+# first check the anaconda log
+if grep -q "Geolocation started:" /tmp/anaconda.log; then
+  echo "error: geolocation started during default kickstart installation" >> /root/RESULT
+fi
+if grep -q "got results from geolocation" /tmp/anaconda.log; then
+  echo "error: got results from geolocation during default kickstart installation" >> /root/RESULT
+fi
+
+# then the sensitive-info log where geolocation record lookup results
+if grep -q "geolocation result:" /tmp/sensitive-info.log; then
+  echo "error: geolocation result found during default kickstart installation" >> /root/RESULT
+fi
+if grep -q "territory:" /tmp/sensitive-info.log; then
+  echo "error: geolocated territory found during default kickstart installation" >> /root/RESULT
+fi
+if grep -q "timezone:" /tmp/sensitive-info.log; then
+  echo "error: geolocated timezone found during default kickstart installation" >> /root/RESULT
+fi
+
+# No error was written to /root/RESULT file, everything is OK
+if [[ ! -e /root/RESULT ]]; then
+    echo SUCCESS > /root/RESULT
+fi
+%end

--- a/geolocation-off-by-default-with-ks.sh
+++ b/geolocation-off-by-default-with-ks.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="network logs"
+
+. ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
This kickstart test is very simple and basically just checks
that the geolocation lookup is skipped during a kickstart installation.

Once the support for enabling geolocation during kickstart installation
is backported to Fedora we can add more tests that test the opposite,
eq. that the geolocation lookup happens & influences the installation
environment.