### PR TITLE
Add tests for autopart --fstype and --nohome

### DIFF
--- a/autopart-fstype.ks.in
+++ b/autopart-fstype.ks.in
@@ -1,0 +1,34 @@
+#test name: autopart-fstype
+url @KSTEST_URL@
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+autopart --type=plain --fstype="ext2"
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+%post
+# Check the fstype of the root.
+root_fstype="$( \
+      lsblk -o MOUNTPOINT,FSTYPE --noheadings \
+    | awk '$1 ~ /^\/$/ { print $2; }' \
+)"
+
+if [ "$root_fstype" != "ext2" ]; then
+    echo "fstype of root is incorrect: $root_fstype)" >> /root/RESULT
+fi
+
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+%end

--- a/autopart-fstype.sh
+++ b/autopart-fstype.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+
+TESTTYPE="autopart"
+
+. ${KSTESTDIR}/functions.sh

--- a/autopart-nohome.ks.in
+++ b/autopart-nohome.ks.in
@@ -1,0 +1,60 @@
+#test name: autopart-nohome
+url @KSTEST_URL@
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+
+# Include the generated autopart command.
+%include /tmp/ksinclude
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+%pre
+# Generate the autopart command.
+autopart="autopart --type=plain --nohome"
+
+if [ "@KSTEST_OS_NAME@" == "fedora" ]; then
+    autopart="$autopart --noboot --noswap"
+fi
+
+echo "$autopart" >/tmp/ksinclude
+%end
+
+%post
+# Check the non-existence of partitions.
+check_partition() {
+    local name=$1 pattern=$2
+
+    kname="$( \
+          lsblk -o TYPE,MOUNTPOINT,KNAME --noheadings \
+        | awk -v pattern="$pattern" '$1 ~ /^part$/ && $2 ~ pattern { print $3; }' \
+    )"
+
+    if [ -n "$kname" ]; then
+        echo "$name partition shouldn't exist: $kname" >> /root/RESULT
+    fi
+}
+
+# Check /home, /boot and swap.
+check_partition "/home" '^/home$'
+
+if [ "@KSTEST_OS_NAME@" == "fedora" ]; then
+    check_partition "/boot" '^/boot$'
+    check_partition "swap" '^\\[SWAP\\]$'
+fi
+
+# The test was successful.
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+%end

--- a/autopart-nohome.sh
+++ b/autopart-nohome.sh
@@ -1,0 +1,29 @@
+#
+# Copyright (C) 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+
+TESTTYPE="autopart"
+
+. ${KSTESTDIR}/functions.sh
+
+prepare_disks() {
+    tmpdir=$1
+
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-a.img 60G
+    echo ${tmpdir}/disk-a.img
+}

--- a/functions.sh
+++ b/functions.sh
@@ -87,7 +87,8 @@ validate_RESULT() {
 }
 
 validate() {
-    return $(validate_RESULT $1)
+    validate_RESULT $1
+    return $?
 }
 
 cleanup() {


### PR DESCRIPTION
Test the autopart options --fstype and --nohome. 
On Fedora, there will be tested also --noboot and --noswap.

Fixed the return value of validate.
The validate function should return a status, not a message.