### PR TITLE
Skip tests that are not executable.

### DIFF
--- a/autopart-fstype.sh
+++ b/autopart-fstype.sh
@@ -19,4 +19,5 @@
 
 TESTTYPE="autopart"
 
+
 . ${KSTESTDIR}/functions.sh

--- a/functions.sh
+++ b/functions.sh
@@ -179,6 +179,7 @@ create_iscsi_target() {
     echo ${target_ip}
 }
 
+
 remove_iscsi_target() {
     local wwn=$1
     local backstore=$2

--- a/scripts/run_kickstart_tests.sh
+++ b/scripts/run_kickstart_tests.sh
@@ -202,6 +202,12 @@ elif [[ "${ghprbActualCommit}" != "" ]]; then
     # And then add the .sh suffix back on to everything in $candidates.  That will
     # give us the list of tests to be run.
     for c in ${candidates}; do
+
+        # Skip files that are not executable.
+        if [[ ! -x "${c}.sh" ]]; then
+            continue
+        fi
+
         tests+="${c}.sh "
     done
 


### PR DESCRIPTION
When we look for tests in a commit, we should skip files that
are not executable (like functions.sh).