### PR TITLE
Test the install method hmc with a fake support for SE/HMC

### DIFF
--- a/hmc.ks.in
+++ b/hmc.ks.in
@@ -1,0 +1,56 @@
+#version=DEVEL
+#test name: hmc
+
+# This test is for testing the install method hmc.
+#
+# This install method can be used only on s390x with SE/HMC, so to be able
+# to test it, we use fake scripts, that will mount DVD the usual way instead.
+# This test requires a full DVD ISO, so it is marked as a known failure.
+
+# Enable hmc in a kickstart file or use inst.repo=hmc.
+hmc
+
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+autopart
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+@core
+%end
+
+%pre
+
+# Create the fake /usr/sbin/lshmc
+cat > /usr/sbin/lshmc <<__EOT__
+#!/bin/bash
+# This is a fake script for testing HMC.
+exit 0
+__EOT__
+
+chmod +x /usr/sbin/lshmc
+
+# Create the fake /usr/bin/hmcdrvfs $repodir
+cat > /usr/bin/hmcdrvfs <<__EOT__
+#!/bin/bash
+# This is a fake script for testing HMC.
+mount /dev/cdrom \$1
+exit 0
+__EOT__
+
+chmod +x /usr/bin/hmcdrvfs
+
+%end
+
+%post
+echo SUCCESS > /root/RESULT
+%end

--- a/hmc.sh
+++ b/hmc.sh
@@ -1,0 +1,35 @@
+#
+# Copyright (C) 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+
+TESTTYPE="knownfailure"
+
+. ${KSTESTDIR}/functions.sh
+
+kernel_args() {
+    # Enable to test the boot option.
+    # echo inst.repo=hmc
+
+    # Enable for manual testing.
+    # echo vnc=0 debug=1 inst.nokill
+
+    # Choose UI for manual testing.
+    # echo inst.text
+    # echo inst.graphical
+}
+


### PR DESCRIPTION
This install method can be used only on s390x with SE/HMC. To be
able to test it, we use fake scripts that will mount DVD the usual
way.

This test requires a full DVD ISO, so it is marked as a known failure.
It can be used only for accessing the packages on the DVD. It cannot
be used to get stage2.

Related: rhbz#1289918