### PR TITLE
Fix bindtomac-network-device-mac-pre

### DIFF
--- a/bindtomac-network-device-mac-pre.ks.in
+++ b/bindtomac-network-device-mac-pre.ks.in
@@ -26,13 +26,11 @@ shutdown
 
 @KSINCLUDE@ post-lib-network.sh
 
-# --device=<MAC> is used to specify the interface, not to bind the
-# connection to the MAC address
-check_ifcfg_key_exists ens3 HWADDR no
+check_ifcfg_key_exists ens3 HWADDR yes
 check_ifcfg_exists ens3-1 no
 check_device_connected ens3 yes
 
-check_ifcfg_key_exists ens4 HWADDR no
+check_ifcfg_key_exists ens4 HWADDR yes
 check_ifcfg_exists ens4-1 no
 check_device_connected ens4 yes
 


### PR DESCRIPTION
For bindtomac HWADDR *should* be in the ifcfg file