### PR TITLE
Small fixes and improvements

### DIFF
--- a/encrypt-device.ks.in
+++ b/encrypt-device.ks.in
@@ -35,7 +35,7 @@ if [ $? != 0 ]; then
     echo "discard not enabled for root_lv" >> /home/RESULT
 fi
 
-if [ ! -e /root/RESULT ]; then
-    echo SUCCESS > /root/RESULT
+if [ ! -e /home/RESULT ]; then
+    echo SUCCESS > /home/RESULT
 fi
 %end

--- a/packages-excludedocs.ks.in
+++ b/packages-excludedocs.ks.in
@@ -42,8 +42,8 @@ else
         fi
     else
         echo "there are files in /usr/share/doc" > /root/RESULT
-        echo >> /root/RESULT
-        find /usr/share/doc >> /root/RESULT
+        echo "" >> /root/RESULT
+        find /usr/share/doc -type f >> /root/RESULT
     fi
 fi
 %end

--- a/proxy-kickstart.sh
+++ b/proxy-kickstart.sh
@@ -21,6 +21,7 @@
 TESTTYPE="method proxy"
 
 . ${KSTESTDIR}/functions.sh
+. ${KSTESTDIR}/functions-proxy.sh
 
 prepare() {
     ks=$1

--- a/screen-access-advanced.ks.in
+++ b/screen-access-advanced.ks.in
@@ -48,7 +48,7 @@ echo "${generated_config}" > etc/sysconfig/anaconda
 %post --nochroot --interpreter /bin/bash
 
 log_pattern=\
-"anaconda: Spoke [a-zA-Z]\+ will not be displayed \
+"Spoke [a-zA-Z]\+ will not be displayed \
 because it has already been visited before.$"
 
 expected_spokes=\
@@ -63,9 +63,16 @@ mkdir -p "${ANA_INSTALL_PATH}/root"
 skipped_spokes=$( \
   cat "/tmp/anaconda.log" \
 | grep -oe "${log_pattern}" \
-| awk '{print $3;}' \
+| awk '{print $2;}' \
 | sort \
 )
+
+echo "SKIPPED SPOKES:"
+echo "$skipped_spokes"
+echo ""
+echo "EXPECTED SPOKES:"
+echo "$expected_spokes"
+echo ""
 
 # Compare with the expected spokes.
 diff <( echo "${skipped_spokes}" ) <( echo "${expected_spokes}" )

--- a/screen-access.sh
+++ b/screen-access.sh
@@ -24,6 +24,9 @@ TESTTYPE="logs"
 # The content of /etc/sysconfig/anaconda without comments.
 expected_config=\
 "
+[BlivetGuiSpoke]
+visited = 1
+
 [CustomPartitioningSpoke]
 visited = 1
 
@@ -49,7 +52,10 @@ visited = 1
 visited = 1
 
 [StorageSpoke]
-visited = 1"
+visited = 1
+
+[General]
+post_install_tools_disabled = 1"
 
 validate() {
     disksdir=$1
@@ -70,11 +76,19 @@ validate() {
         real_config=$(grep -vE "^#" "${disksdir}/anaconda.sysconfig")
 
         # Compare with the expected content.
-        diff <( echo "$real_config" ) <( echo "$expected_config" )
+        diff <( echo "$real_config" ) <( echo "$expected_config" ) >/dev/null
 
         # If it is different, then fail.
         if [[ $? != 0 ]]; then
             echo '*** /etc/sysconfig/anaconda is different.'
+
+            echo "CONFIG:"
+            echo "$real_config"
+            echo ""
+            echo "EXPECTED CONFIG:"
+            echo "$expected_config"
+            echo ""
+
             return 1
         fi
     fi

--- a/scripts/kstest-runner
+++ b/scripts/kstest-runner
@@ -51,7 +51,7 @@ class VirtualInstall(object):
     Run virt-install using an iso and a kickstart
     """
     def __init__(self, iso, ks_paths, disk_paths,
-                 kernel_args=None, memory=1024, vnc=None,
+                 kernel_args=None, memory=2048, vnc=None,
                  log_check=None, virtio_host="127.0.0.1", virtio_port=6080,
                  nics=None, boot=None):
         """
@@ -76,7 +76,7 @@ class VirtualInstall(object):
         # add --graphics none later
         # add whatever serial cmds are needed later
         args = ["-n", self.virt_name,
-                "-r", str(memory),
+                "--memory", str(memory),
                 "--noautoconsole"]
 
         # CHECKME This seems to be necessary because of ipxe ibft chain booting,
@@ -279,7 +279,7 @@ def main():
 
     # Group of arguments to pass to virt-install
     virt_group = parser.add_argument_group("virt-install arguments")
-    virt_group.add_argument("--ram", metavar="MEMORY", type=int, default=1024,
+    virt_group.add_argument("--ram", metavar="MEMORY", type=int, default=2048,
                             help="Memory to allocate for installer in megabytes.")
     virt_group.add_argument("--vnc",
                             help="Passed to --graphics command")

--- a/scripts/run_one_ks.sh
+++ b/scripts/run_one_ks.sh
@@ -119,7 +119,7 @@ runone() {
                        ${add_args} \
                        --tmp ${tmpdir} \
                        --logfile ${tmpdir}/livemedia.log \
-                       --ram 1024 \
+                       --ram 2048 \
                        --vnc vnc \
                        --timeout 60 \
                        ${disk_args} \

--- a/scripts/run_one_ks.sh
+++ b/scripts/run_one_ks.sh
@@ -105,10 +105,10 @@ runone() {
     fi
 
     disks=$(prepare_disks ${tmpdir})
-    disk_args=$(for d in $disks; do echo --disk $d,cache=unsafe; done)
+    disk_args=$(for d in $disks; do echo "--disk $d,cache=unsafe"; done)
 
     nics=$(prepare_network ${tmpdir})
-    network_args=$(for n in $nics; do echo --nic $n; done)
+    network_args=$(for n in $nics; do echo "--nic $n"; done)
 
     add_args=$(additional_runner_args)
 


### PR DESCRIPTION
I was able to succesfully run all kickstart tests except for these:
* lvm tests fail with a kernel warning "possible circular locking dependency detected"
* proxy-auth fails to set up the installation source
* packages-excludedocs fails because there are files in /usr/share/doc/xz/
* nfs-repo-and-addon, ibft, iscsi