### PR TITLE
Disable ibft, iscsi and iscsi-bind tests.

### DIFF
--- a/ibft.sh
+++ b/ibft.sh
@@ -24,7 +24,7 @@
 #   - just use sanboot in ipxe script:
 #     sanboot iscsi:${target_ip}:::0:${wwn}
 
-TESTTYPE="iscsi"
+TESTTYPE="knownfailure iscsi"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/iscsi.sh
+++ b/iscsi.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE="iscsi"
+TESTTYPE="knownfailure iscsi"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
They have some host dependencies and should be debugged before running them as
they used to have problems with connection to iscsi targets when I worked on
them back then.