### PR TITLE
Fix log files permissions before fetching remote test results.

### DIFF
--- a/scripts/run_kickstart_tests.sh
+++ b/scripts/run_kickstart_tests.sh
@@ -338,6 +338,7 @@ if [[ "$TEST_REMOTES" != "" ]]; then
     # over the place.
     for remote in ${TEST_REMOTES}; do
         if [[ ${KEEPIT} > 0 ]]; then
+            ssh kstest@${remote} sudo chown -R kstest:kstest /var/tmp/kstest-\*
             scp -r kstest@${remote}:/var/tmp/kstest-\* /var/tmp/
         fi
 


### PR DESCRIPTION
virt-copy-out seems to set too restrictive file and dir permissions for
fetching them from remote test host.