### PR TITLE
Dependency install script & always add RNG device

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,11 @@ First you need to install the needed dependencies:
 
 On Fedora the dependencies can be installed with dnf like this::
 
-  sudo dnf install lorax-lmc-virt libguestfs-tools libvirt-python3 virt-install parallel
+  sudo dnf install lorax-lmc-virt libguestfs-tools python3-libvirt virt-install parallel
+
+Or with the install_dependencies_fedora.sh script:
+
+  ./scripts/install_dependencies_fedora.sh
 
 You also need to start libvirt service to be able to use virt-install::
 

--- a/scripts/install_dependencies_fedora.sh
+++ b/scripts/install_dependencies_fedora.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "installing depndencies needed to run kickstart tests"
+sudo dnf install libguestfs-tools virt-install lorax-lmc-virt parallel python3-libvirt
+echo "done"

--- a/scripts/kstest-runner
+++ b/scripts/kstest-runner
@@ -77,7 +77,8 @@ class VirtualInstall(object):
         # add whatever serial cmds are needed later
         args = ["-n", self.virt_name,
                 "--memory", str(memory),
-                "--noautoconsole"]
+                "--noautoconsole",
+                "--rng", "/dev/random"]
 
         # CHECKME This seems to be necessary because of ipxe ibft chain booting,
         # otherwise the vm is created but it does not boot into installation


### PR DESCRIPTION
The first commit adds a script for installing dependencies needed for running kickstart tests on Fedora & fixes related docs.

The second commit makes sure a virtual RNG is always added to the virtual machines we create to run kickstart tests, or else kernel 4.16+ will basically hang at boot.