### PR TITLE
Fix & improve some of the packaging tests

### DIFF
--- a/groups-and-envs-2.ks.in
+++ b/groups-and-envs-2.ks.in
@@ -37,45 +37,47 @@ shutdown
 # Testing #1 - lrzsz is only part of dial-up, and should not be installed.
 rpm -q lrzsz
 if [[ $? == 0 ]]; then
-    echo '*** dial-up group should not have been installed' > /root/RESULT
-    exit 1
+    echo '*** dial-up group should not have been installed' >> /root/RESULT
 fi
 
 # Testing #2 - meshlab is only part of 3d-printing, and should not
 # be installed.
 rpm -q meshlab
 if [[ $? == 0 ]]; then
-    echo '*** 3d-printing group should not have been installed' > /root/RESULT
-    exit 1
+    echo '*** 3d-printing group should not have been installed' >> /root/RESULT
 fi
 
 # Testing #3 - fedora-dockerfiles is only part of container-management, where
 # it is optional, so it should be installed.
 rpm -q fedora-dockerfiles
 if [[ $? != 0 ]]; then
-    echo '*** fedora-dockerfiles was not installed' > /root/RESULT
-    exit 1
+    echo '*** fedora-dockerfiles was not installed' >> /root/RESULT
 fi
 
 # Testing #4 - rpm-build is mandatory so it should be installed.  rpmdevtools is
 # default so it should not.  rpmlint is optional so it should not.
 rpm -q rpm-build
 if [[ $? != 0 ]]; then
-    echo '*** Mandatory package from rpm-development-tools was not installed' > /root/RESULT
-    exit 1
+    echo '*** Mandatory package from rpm-development-tools was not installed' >> /root/RESULT
 else
     rpm -q rpmdevtools
     if [[ $? == 0 ]]; then
-        echo '*** Default package from rpm-development-tools should not have been installed' > /root/RESULT
-        exit 1
+        echo '*** Default package from rpm-development-tools should not have been installed' >> /root/RESULT
     else
         rpm -q rpmlint
         if [[ $? == 0 ]]; then
-            echo '*** Optional package from rpm-development-tools should not have been installed' > /root/RESULT
-            exit 1
+            echo '*** Optional package from rpm-development-tools should not have been installed' >> /root/RESULT
         fi
     fi
 fi
 
-echo SUCCESS > /root/RESULT
+if [ ! -f /root/RESULT ]
+then
+    # no result file (no errors) -> success
+    echo SUCCESS > /root/RESULT
+else
+    # some errors happened
+    exit 1
+fi
+
 %end

--- a/groups-and-envs-2.ks.in
+++ b/groups-and-envs-2.ks.in
@@ -1,4 +1,10 @@
 #test name: groups-and-envs-2
+# what we are testing there:
+# - that we can exclude groups which are a part of an environment
+# - that we can exclude groups we have specified in ourselves
+#   (this could be important for multiple ksincluded %packages sections)
+# - that the --optional flag for package groups is working
+# - that the --nodefaults flag for package groups is working
 url @KSTEST_URL@
 install
 network --bootproto=dhcp
@@ -47,11 +53,21 @@ if [[ $? == 0 ]]; then
     echo '*** 3d-printing group should not have been installed' >> /root/RESULT
 fi
 
-# Testing #3 - fedora-dockerfiles is only part of container-management, where
-# it is optional, so it should be installed.
-rpm -q fedora-dockerfiles
+# Testing #3 - buildah, podman, origin-clients are optional part of container-management,
+# so should be installed when the --optional flag is passed for the group spec
+rpm -q buildah
 if [[ $? != 0 ]]; then
-    echo '*** fedora-dockerfiles was not installed' >> /root/RESULT
+    echo '*** buildah was not installed for @container-management --optional' >> /root/RESULT
+fi
+
+rpm -q podman
+if [[ $? != 0 ]]; then
+    echo '*** podman was not installed for @container-management --optional' >> /root/RESULT
+fi
+
+rpm -q origin-clients
+if [[ $? != 0 ]]; then
+    echo '*** origin-clients was not installed for @container-management --optional' >> /root/RESULT
 fi
 
 # Testing #4 - rpm-build is mandatory so it should be installed.  rpmdevtools is

--- a/packages-and-groups-1.ks.in
+++ b/packages-and-groups-1.ks.in
@@ -39,36 +39,39 @@ kacst*
 # Testing #1 - gcc should be installed, but not valgrind
 rpm -q gcc
 if [[ $? != 0 ]]; then
-    echo '*** c-development group was not installed' > /root/RESULT
-    exit 1
+    echo '*** c-development group was not installed' >> /root/RESULT
 fi
 
 rpm -q valgrind
 if [[ $? == 0 ]]; then
-    echo '*** valgrind package should not have been installed' > /root/RESULT
-    exit 1
+    echo '*** valgrind package should not have been installed' >> /root/RESULT
 fi
 
 # Testing #2 - qemu-kvm should not be installed.
 rpm -q qemu-kvm
 if [[ $? == 0 ]]; then
-    echo '*** qemu-kvm package should not have been installed' > /root/RESULT
-    exit 1
+    echo '*** qemu-kvm package should not have been installed' >> /root/RESULT
 fi
 
 # Testing #3 - kacst font stuff should be installed.
 count=$(rpm -qa kacst\* | wc -l)
 if [[ $count -lt 5 ]]; then
-    echo '*** kacst glob was not installed' > /root/RESULT
-    exit 1
+    echo '*** kacst glob was not installed' >> /root/RESULT
 fi
 
 # Testing #4 - ibus stuff should not be installed.
 count=$(rpm -qa ibus\* | wc -l)
 if [[ $count -gt 0 ]]; then
-    echo '*** ibus glob should not have been installed' > /root/RESULT
+    echo '*** ibus glob should not have been installed' >> /root/RESULT
+fi
+
+if [ ! -f /root/RESULT ]
+then
+    # no result file (no errors) -> success
+    echo SUCCESS > /root/RESULT
+else
+    # some errors happened
     exit 1
 fi
 
-echo SUCCESS > /root/RESULT
 %end


### PR DESCRIPTION
The first patch improves how we record test failures for our packaging tests by recording _all_ errors to the RESULT file instead of just recording the first error and quiting the %post script immediately. This can be helpful foe identifying all errors at once without re-running the test multiple times.

The second patch fixes test failure in the groups-and-envs-2 test caused by a package being dropped from comps.