### PR TITLE
Improve testing of --ignoremissing

### DIFF
--- a/groups-ignoremissing.ks.in
+++ b/groups-ignoremissing.ks.in
@@ -1,9 +1,9 @@
 #version=DEVEL
-#test name: packages-ignoremissing
+#test name: groups-ignoremissing
 #
 # what we are testing there:
-# - that missing packages are ignored if --ignoremissing is used
-# - that such an installation finishes
+# - that missing groups are ignored if --ignoremissing is used
+# - that such an installation finishes successfully
 url @KSTEST_URL@
 install
 network --bootproto=dhcp
@@ -20,7 +20,7 @@ rootpw testcase
 shutdown
 
 %packages --ignoremissing
-fake-package-name
+@fake-group-name
 %end
 
 %post

--- a/groups-ignoremissing.sh
+++ b/groups-ignoremissing.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Chris Lumens <clumens@redhat.com>
+
+TESTTYPE="packaging"
+
+. ${KSTESTDIR}/functions.sh

--- a/packages-and-groups-ignoremissing.ks.in
+++ b/packages-and-groups-ignoremissing.ks.in
@@ -1,0 +1,53 @@
+#version=DEVEL
+#test name: packages-and-groups-ignoremissing
+#
+# what we are testing there:
+# - that multiple missing packages & groups (at the same time) are ignored
+#   if --ignoremissing is used
+# - that regular packages and groups requested at the same time
+#   are installed correctly
+# - that such an installation finishes successfully
+url @KSTEST_URL@
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+autopart
+
+keyboard us
+lang en_US.UTF-8
+timezone America/New_York --utc
+rootpw testcase
+shutdown
+
+%packages --ignoremissing
+fake-package-name-1
+fake-package-name-2
+@fake-group-name-1
+@fake-group-name-2
+vim
+@c-development
+%end
+
+%post
+rpm -q vim-minimal
+if [[ $? != 0 ]]; then
+    echo '*** vim package was not installed' >> /root/RESULT
+fi
+
+rpm -q gcc
+if [[ $? != 0 ]]; then
+    echo '*** gcc should have been installed via the c-development package group' >> /root/RESULT
+fi
+
+if [ ! -f /root/RESULT ]
+then
+    # no result file (no errors) -> success
+    echo SUCCESS > /root/RESULT
+else
+    # some errors happened
+    exit 1
+fi
+%end

--- a/packages-and-groups-ignoremissing.sh
+++ b/packages-and-groups-ignoremissing.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Chris Lumens <clumens@redhat.com>
+
+TESTTYPE="packaging"
+
+. ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Add two more tests cases for the --ignoremissing option
for the %packages section in kickstart:
- test --ignoremissing works correctly also with missing groups
- test mixed scenario with missing packages, groups & existing packages/groups
  that should be be installed

Also note describing what the given tests is supposed to be doing.