### PR TITLE
Disable iscsi-bind test.

### DIFF
--- a/iscsi-bind.sh
+++ b/iscsi-bind.sh
@@ -17,5 +17,7 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+TESTTYPE="knownfailure iscsi"
+
 . ${KSTESTDIR}/iscsi.sh
 


### PR DESCRIPTION
Same as iscsi and ibft test, but we need to define the TESTTYPE in the file,
including it via iscsi.sh is not enough for filtering by the
run_kickstart_tests.sh script.