### PR TITLE
Make sure all folders are accessible for remote results

### DIFF
--- a/scripts/run_kickstart_tests.sh
+++ b/scripts/run_kickstart_tests.sh
@@ -347,6 +347,7 @@ if [[ "$TEST_REMOTES" != "" ]]; then
         if [[ ${KEEPIT} > 0 ]]; then
             ssh kstest@${remote} sudo chown -R kstest:kstest /var/tmp/kstest-\*
             ssh kstest@${remote} sudo chmod -R a+r /var/tmp/kstest-\*
+            ssh kstest@${remote} sudo find /var/tmp/kstest-\* -type d -exec chmod 755 {} +
             scp -r kstest@${remote}:/var/tmp/kstest-\* /var/tmp/
         fi
 


### PR DESCRIPTION
Otherwise we might not be able the correctly transfer all
the result if they have weird access rights, which does
happen due to how some of the logs are created during the
installation and then fetched via libguestfs.