### PR TITLE
Fix the packages-excludedocs testcase

### DIFF
--- a/packages-excludedocs.ks.in
+++ b/packages-excludedocs.ks.in
@@ -26,6 +26,16 @@ shutdown
 %end
 
 %post
+# The xz package  stores license files in the docs folder
+# so they are still installed even if we tell DNF to
+# not install docs.
+#
+# Reported as: https://bugzilla.redhat.com/show_bug.cgi?id=1590873
+#
+# For now let's just remove these files so that the test will pass.
+rm -f /usr/share/doc/xz/COPYING
+rm -f /usr/share/doc/xz/COPYING.GPLv2
+
 if [ ! -d /usr/share/doc ]; then
     echo SUCCESS > /root/RESULT
 else


### PR DESCRIPTION
The xz package incorrectly stores its license files in path
where only documentation should be stored.

A bug[0] has been opened for this issue.

It is currently unclear how long fixing the packaging will take,
so lets just work around this issue for now.

[0] https://bugzilla.redhat.com/show_bug.cgi?id=1590873