### PR TITLE
Do not add --nic to network configuration

### DIFF
--- a/scripts/launcher/run_one_test.py
+++ b/scripts/launcher/run_one_test.py
@@ -153,7 +153,6 @@ class Runner(object):
         out.check_ret_code_with_exception()
 
         for n in out.stdout_as_array:
-            ret.append("--nic")
             ret.append(n)
 
         return ret


### PR DESCRIPTION
This was used to pass network configuration to kstest-runner. It is no
longer required and this is causing network tests to fail.