### PR TITLE
Add tests for module installation

### DIFF
--- a/fedora-live-image-build.ks.in
+++ b/fedora-live-image-build.ks.in
@@ -1,0 +1,443 @@
+# live image build test based on F29 live image kickstart
+# - for now just having it run to the end with all of its
+#   complex post scripts should be enough
+
+url @KSTEST_URL@
+
+#version=DEVEL
+# X Window System configuration information
+xconfig  --startxonboot
+# Keyboard layouts
+keyboard 'us'
+# Root password
+rootpw --iscrypted --lock locked
+# System language
+lang en_US.UTF-8
+# Shutdown after installation
+shutdown
+# System timezone
+timezone US/Eastern
+# Network information
+network  --bootproto=dhcp --device=link --activate
+#repo --name="koji-override-0" --baseurl=http://kojipkgs.fedoraproject.org/compose/rawhide/Fedora-Rawhide-20180727.n.1/compose/Everything/$basearch/os
+#repo --name="koji-override-1" --baseurl=http://kojipkgs.fedoraproject.org/compose/rawhide/Fedora-Rawhide-20180727.n.1/compose/Workstation/$basearch/os
+# Use network installation
+#url --url="http://kojipkgs.fedoraproject.org/compose/rawhide/Fedora-Rawhide-20180727.n.1/compose/Workstation/$basearch/os"
+# System authorization information
+auth --useshadow --passalgo=sha512
+# Firewall configuration
+firewall --enabled --service=mdns
+# SELinux configuration
+selinux --enforcing
+
+# System services
+services --disabled="sshd" --enabled="NetworkManager,ModemManager"
+# System bootloader configuration
+bootloader --location=none
+# Clear the Master Boot Record
+zerombr
+# Partition clearing information
+clearpart --all
+# Disk partitioning information
+part / --fstype="ext4" --size=5120
+part / --size=6656
+
+%post
+# FIXME: it'd be better to get this installed from a package
+cat > /etc/rc.d/init.d/livesys << EOF
+#!/bin/bash
+#
+# live: Init script for live image
+#
+# chkconfig: 345 00 99
+# description: Init script for live image.
+### BEGIN INIT INFO
+# X-Start-Before: display-manager chronyd
+### END INIT INFO
+
+. /etc/init.d/functions
+
+if ! strstr "\`cat /proc/cmdline\`" rd.live.image || [ "\$1" != "start" ]; then
+    exit 0
+fi
+
+if [ -e /.liveimg-configured ] ; then
+    configdone=1
+fi
+
+exists() {
+    which \$1 >/dev/null 2>&1 || return
+    \$*
+}
+
+livedir="LiveOS"
+for arg in \`cat /proc/cmdline\` ; do
+  if [ "\${arg##rd.live.dir=}" != "\${arg}" ]; then
+    livedir=\${arg##rd.live.dir=}
+    return
+  fi
+  if [ "\${arg##live_dir=}" != "\${arg}" ]; then
+    livedir=\${arg##live_dir=}
+    return
+  fi
+done
+
+# enable swaps unless requested otherwise
+swaps=\`blkid -t TYPE=swap -o device\`
+if ! strstr "\`cat /proc/cmdline\`" noswap && [ -n "\$swaps" ] ; then
+  for s in \$swaps ; do
+    action "Enabling swap partition \$s" swapon \$s
+  done
+fi
+if ! strstr "\`cat /proc/cmdline\`" noswap && [ -f /run/initramfs/live/\${livedir}/swap.img ] ; then
+  action "Enabling swap file" swapon /run/initramfs/live/\${livedir}/swap.img
+fi
+
+mountPersistentHome() {
+  # support label/uuid
+  if [ "\${homedev##LABEL=}" != "\${homedev}" -o "\${homedev##UUID=}" != "\${homedev}" ]; then
+    homedev=\`/sbin/blkid -o device -t "\$homedev"\`
+  fi
+
+  # if we're given a file rather than a blockdev, loopback it
+  if [ "\${homedev##mtd}" != "\${homedev}" ]; then
+    # mtd devs don't have a block device but get magic-mounted with -t jffs2
+    mountopts="-t jffs2"
+  elif [ ! -b "\$homedev" ]; then
+    loopdev=\`losetup -f\`
+    if [ "\${homedev##/run/initramfs/live}" != "\${homedev}" ]; then
+      action "Remounting live store r/w" mount -o remount,rw /run/initramfs/live
+    fi
+    losetup \$loopdev \$homedev
+    homedev=\$loopdev
+  fi
+
+  # if it's encrypted, we need to unlock it
+  if [ "\$(/sbin/blkid -s TYPE -o value \$homedev 2>/dev/null)" = "crypto_LUKS" ]; then
+    echo
+    echo "Setting up encrypted /home device"
+    plymouth ask-for-password --command="cryptsetup luksOpen \$homedev EncHome"
+    homedev=/dev/mapper/EncHome
+  fi
+
+  # and finally do the mount
+  mount \$mountopts \$homedev /home
+  # if we have /home under what's passed for persistent home, then
+  # we should make that the real /home.  useful for mtd device on olpc
+  if [ -d /home/home ]; then mount --bind /home/home /home ; fi
+  [ -x /sbin/restorecon ] && /sbin/restorecon /home
+  if [ -d /home/liveuser ]; then USERADDARGS="-M" ; fi
+}
+
+findPersistentHome() {
+  for arg in \`cat /proc/cmdline\` ; do
+    if [ "\${arg##persistenthome=}" != "\${arg}" ]; then
+      homedev=\${arg##persistenthome=}
+      return
+    fi
+  done
+}
+
+if strstr "\`cat /proc/cmdline\`" persistenthome= ; then
+  findPersistentHome
+elif [ -e /run/initramfs/live/\${livedir}/home.img ]; then
+  homedev=/run/initramfs/live/\${livedir}/home.img
+fi
+
+# if we have a persistent /home, then we want to go ahead and mount it
+if ! strstr "\`cat /proc/cmdline\`" nopersistenthome && [ -n "\$homedev" ] ; then
+  action "Mounting persistent /home" mountPersistentHome
+fi
+
+if [ -n "\$configdone" ]; then
+  exit 0
+fi
+
+# add liveuser user with no passwd
+action "Adding live user" useradd \$USERADDARGS -c "Live System User" liveuser
+passwd -d liveuser > /dev/null
+usermod -aG wheel liveuser > /dev/null
+
+# Remove root password lock
+passwd -d root > /dev/null
+
+# turn off firstboot for livecd boots
+systemctl --no-reload disable firstboot-text.service 2> /dev/null || :
+systemctl --no-reload disable firstboot-graphical.service 2> /dev/null || :
+systemctl stop firstboot-text.service 2> /dev/null || :
+systemctl stop firstboot-graphical.service 2> /dev/null || :
+
+# don't use prelink on a running live image
+sed -i 's/PRELINKING=yes/PRELINKING=no/' /etc/sysconfig/prelink &>/dev/null || :
+
+# turn off mdmonitor by default
+systemctl --no-reload disable mdmonitor.service 2> /dev/null || :
+systemctl --no-reload disable mdmonitor-takeover.service 2> /dev/null || :
+systemctl stop mdmonitor.service 2> /dev/null || :
+systemctl stop mdmonitor-takeover.service 2> /dev/null || :
+
+# don't enable the gnome-settings-daemon packagekit plugin
+gsettings set org.gnome.software download-updates 'false' || :
+
+# don't start cron/at as they tend to spawn things which are
+# disk intensive that are painful on a live image
+systemctl --no-reload disable crond.service 2> /dev/null || :
+systemctl --no-reload disable atd.service 2> /dev/null || :
+systemctl stop crond.service 2> /dev/null || :
+systemctl stop atd.service 2> /dev/null || :
+
+# turn off abrtd on a live image
+systemctl --no-reload disable abrtd.service 2> /dev/null || :
+systemctl stop abrtd.service 2> /dev/null || :
+
+# Don't sync the system clock when running live (RHBZ #1018162)
+sed -i 's/rtcsync//' /etc/chrony.conf
+
+# Mark things as configured
+touch /.liveimg-configured
+
+# add static hostname to work around xauth bug
+# https://bugzilla.redhat.com/show_bug.cgi?id=679486
+# the hostname must be something else than 'localhost'
+# https://bugzilla.redhat.com/show_bug.cgi?id=1370222
+echo "localhost-live" > /etc/hostname
+
+EOF
+
+# bah, hal starts way too late
+cat > /etc/rc.d/init.d/livesys-late << EOF
+#!/bin/bash
+#
+# live: Late init script for live image
+#
+# chkconfig: 345 99 01
+# description: Late init script for live image.
+
+. /etc/init.d/functions
+
+if ! strstr "\`cat /proc/cmdline\`" rd.live.image || [ "\$1" != "start" ] || [ -e /.liveimg-late-configured ] ; then
+    exit 0
+fi
+
+exists() {
+    which \$1 >/dev/null 2>&1 || return
+    \$*
+}
+
+touch /.liveimg-late-configured
+
+# read some variables out of /proc/cmdline
+for o in \`cat /proc/cmdline\` ; do
+    case \$o in
+    ks=*)
+        ks="--kickstart=\${o#ks=}"
+        ;;
+    xdriver=*)
+        xdriver="\${o#xdriver=}"
+        ;;
+    esac
+done
+
+# if liveinst or textinst is given, start anaconda
+if strstr "\`cat /proc/cmdline\`" liveinst ; then
+   plymouth --quit
+   /usr/sbin/liveinst \$ks
+fi
+if strstr "\`cat /proc/cmdline\`" textinst ; then
+   plymouth --quit
+   /usr/sbin/liveinst --text \$ks
+fi
+
+# configure X, allowing user to override xdriver
+if [ -n "\$xdriver" ]; then
+   cat > /etc/X11/xorg.conf.d/00-xdriver.conf <<FOE
+Section "Device"
+	Identifier	"Videocard0"
+	Driver	"\$xdriver"
+EndSection
+FOE
+fi
+
+EOF
+
+chmod 755 /etc/rc.d/init.d/livesys
+/sbin/restorecon /etc/rc.d/init.d/livesys
+/sbin/chkconfig --add livesys
+
+chmod 755 /etc/rc.d/init.d/livesys-late
+/sbin/restorecon /etc/rc.d/init.d/livesys-late
+/sbin/chkconfig --add livesys-late
+
+# enable tmpfs for /tmp
+systemctl enable tmp.mount
+
+# make it so that we don't do writing to the overlay for things which
+# are just tmpdirs/caches
+# note https://bugzilla.redhat.com/show_bug.cgi?id=1135475
+cat >> /etc/fstab << EOF
+vartmp   /var/tmp    tmpfs   defaults   0  0
+EOF
+
+# work around for poor key import UI in PackageKit
+rm -f /var/lib/rpm/__db*
+releasever=$(rpm -q --qf '%{version}\n' --whatprovides system-release)
+basearch=$(uname -i)
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+echo "Packages within this LiveCD"
+rpm -qa
+# Note that running rpm recreates the rpm db files which aren't needed or wanted
+rm -f /var/lib/rpm/__db*
+
+# go ahead and pre-make the man -k cache (#455968)
+/usr/bin/mandb
+
+# make sure there aren't core files lying around
+rm -f /core*
+
+# remove random seed, the newly installed instance should make it's own
+rm -f /var/lib/systemd/random-seed
+
+# convince readahead not to collect
+# FIXME: for systemd
+
+echo 'File created by kickstart. See systemd-update-done.service(8).' \
+    | tee /etc/.updated >/var/.updated
+
+# Drop the rescue kernel and initramfs, we don't need them on the live media itself.
+# See bug 1317709
+rm -f /boot/*-rescue*
+
+# Disable network service here, as doing it in the services line
+# fails due to RHBZ #1369794
+/sbin/chkconfig network off
+
+# Remove machine-id on pre generated images
+rm -f /etc/machine-id
+touch /etc/machine-id
+
+%end
+
+%post --nochroot
+cp $INSTALL_ROOT/usr/share/licenses/*-release/* $LIVE_ROOT/
+
+# only works on x86, x86_64
+if [ "$(uname -i)" = "i386" -o "$(uname -i)" = "x86_64" ]; then
+  if [ ! -d $LIVE_ROOT/LiveOS ]; then mkdir -p $LIVE_ROOT/LiveOS ; fi
+  cp /usr/bin/livecd-iso-to-disk $LIVE_ROOT/LiveOS
+fi
+
+%end
+
+%post
+
+cat >> /etc/rc.d/init.d/livesys << EOF
+
+
+# disable gnome-software automatically downloading updates
+cat >> /usr/share/glib-2.0/schemas/org.gnome.software.gschema.override << FOE
+[org.gnome.software]
+download-updates=false
+FOE
+
+# don't autostart gnome-software session service
+rm -f /etc/xdg/autostart/gnome-software-service.desktop
+
+# disable the gnome-software shell search provider
+cat >> /usr/share/gnome-shell/search-providers/org.gnome.Software-search-provider.ini << FOE
+DefaultDisabled=true
+FOE
+
+# don't run gnome-initial-setup
+mkdir ~liveuser/.config
+touch ~liveuser/.config/gnome-initial-setup-done
+
+# suppress anaconda spokes redundant with gnome-initial-setup
+cat >> /etc/sysconfig/anaconda << FOE
+[NetworkSpoke]
+visited=1
+
+[PasswordSpoke]
+visited=1
+
+[UserSpoke]
+visited=1
+FOE
+
+# make the installer show up
+if [ -f /usr/share/applications/liveinst.desktop ]; then
+  # Show harddisk install in shell dash
+  sed -i -e 's/NoDisplay=true/NoDisplay=false/' /usr/share/applications/liveinst.desktop ""
+  # need to move it to anaconda.desktop to make shell happy
+  mv /usr/share/applications/liveinst.desktop /usr/share/applications/anaconda.desktop
+
+  cat >> /usr/share/glib-2.0/schemas/org.gnome.shell.gschema.override << FOE
+[org.gnome.shell]
+favorite-apps=['firefox.desktop', 'evolution.desktop', 'rhythmbox.desktop', 'shotwell.desktop', 'org.gnome.Nautilus.desktop', 'anaconda.desktop']
+FOE
+
+  # Make the welcome screen show up
+  if [ -f /usr/share/anaconda/gnome/fedora-welcome.desktop ]; then
+    mkdir -p ~liveuser/.config/autostart
+    cp /usr/share/anaconda/gnome/fedora-welcome.desktop /usr/share/applications/
+    cp /usr/share/anaconda/gnome/fedora-welcome.desktop ~liveuser/.config/autostart/
+  fi
+
+  # Copy Anaconda branding in place
+  if [ -d /usr/share/lorax/product/usr/share/anaconda ]; then
+    cp -a /usr/share/lorax/product/* /
+  fi
+fi
+
+# rebuild schema cache with any overrides we installed
+glib-compile-schemas /usr/share/glib-2.0/schemas
+
+# set up auto-login
+cat > /etc/gdm/custom.conf << FOE
+[daemon]
+AutomaticLoginEnable=True
+AutomaticLogin=liveuser
+FOE
+
+# Turn off PackageKit-command-not-found while uninstalled
+if [ -f /etc/PackageKit/CommandNotFound.conf ]; then
+  sed -i -e 's/^SoftwareSourceSearch=true/SoftwareSourceSearch=false/' /etc/PackageKit/CommandNotFound.conf
+fi
+
+# make sure to set the right permissions and selinux contexts
+chown -R liveuser:liveuser /home/liveuser/
+restorecon -R /home/liveuser/
+
+EOF
+
+%end
+
+%packages
+@anaconda-tools
+@base-x
+@core
+@firefox
+@fonts
+@gnome-desktop
+@guest-desktop-agents
+@hardware-support
+@libreoffice
+@multimedia
+@networkmanager-submodules
+@printing
+@workstation-product
+aajohan-comfortaa-fonts
+anaconda
+anaconda-install-env-deps
+dracut-live
+glibc-all-langpacks
+kernel
+kernel-modules
+kernel-modules-extra
+memtest86+
+syslinux
+-@dial-up
+-@input-methods
+-@standard
+-gfs2-utils
+-reiserfs-utils
+%end

--- a/fedora-live-image-build.sh
+++ b/fedora-live-image-build.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="packaging fedora-only"
+
+. ${KSTESTDIR}/functions.sh

--- a/module-enable-many.ks.in
+++ b/module-enable-many.ks.in
@@ -1,0 +1,119 @@
+#test name: module-enable-many
+#
+# test enabling many different modules at once
+
+url @KSTEST_URL@
+repo --name=modular @KSTEST_MODULAR_URL@
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+module --name=nodejs --stream=10
+module --name=django --stream=1.6
+module --name=postgresql --stream=9.6
+module --name=mysql --stream=5.7
+module --name=docker --stream=2017.0
+module --name=gimp --stream=2.10
+
+%packages
+@^Fedora Server Edition
+kernel
+vim
+%end
+
+%post
+# modules have some packages defined as their API in their profiles,
+# we can check for those to be (or not to be installed) to see if the
+# module has (or has not) been installed
+
+# the vim standalone package
+rpm -q vim-minimal
+if [[ $? != 0 ]]; then
+    echo '*** vim-minimal package requested but not installed' >> /root/RESULT
+fi
+
+# it is also nice to have kernel
+rpm -q kernel
+if [[ $? != 0 ]]; then
+    echo '*** kernel package not installed' >> /root/RESULT
+fi
+
+rpm -q nodejs
+if [[ $? == 0 ]]; then
+    echo '*** nodejs for module only enabled nodejs installed' >> /root/RESULT
+fi
+
+rpm -q python2-django
+if [[ $? == 0 ]]; then
+    echo '*** python2-django for the only enabled django module installed' >> /root/RESULT
+fi
+
+rpm -q postgresql
+if [[ $? == 0 ]]; then
+    echo '*** postgresql for the only enabled postgresql module installed' >> /root/RESULT
+fi
+
+rpm -q community-mysql
+if [[ $? == 0 ]]; then
+    echo '*** community-mysql for the only enabled mysql module installed' >> /root/RESULT
+fi
+
+rpm -q docker
+if [[ $? == 0 ]]; then
+    echo '*** docker for the only enabled docker module installed' >> /root/RESULT
+fi
+
+rpm -q docker-distribution
+if [[ $? == 0 ]]; then
+    echo '*** docker-community for only enabled the docker module installed' >> /root/RESULT
+fi
+
+rpm -q gimp
+if [[ $? == 0 ]]; then
+    echo '*** gimp for the only enabled gimp module installed' >> /root/RESULT
+fi
+
+# next we will check if the module is seen as enabled/installed from the
+# metadata/DNF point of view
+
+# log a "dnf module list" call for debugging purposes
+dnf module list
+
+# all installed modules should be also enabled
+dnf module list --enabled django | grep django || echo "django module not marked as enabled" >> /root/RESULT
+dnf module list --enabled nodejs | grep nodejs || echo "nodejs module not marked as enabled" >> /root/RESULT
+dnf module list --enabled postgresql | grep postgresql  || echo "postgresql module not marked as enabled" >> /root/RESULT
+dnf module list --enabled mysql | grep mysql || echo "mysql module not marked as enabled" >> /root/RESULT
+dnf module list --enabled docker | grep docker || echo "docker module not marked as enabled" >> /root/RESULT
+dnf module list --enabled gimp | grep gimp || echo "gimp module not marked as enabled" >> /root/RESULT
+
+# check all modules are also marked as installed
+dnf module list --installed django | grep django && echo "django module marked as installed" >> /root/RESULT
+dnf module list --installed nodejs | grep nodejs && echo "nodejs module marked as installed" >> /root/RESULT
+dnf module list --installed postgresql | grep ostgresql && echo "postgresql module marked as installed" >> /root/RESULT
+dnf module list --installed mysql | grep mysql && echo "mysql module marked as installed" >> /root/RESULT
+dnf module list --installed docker | grep docker && echo "docker module marked as installed" >> /root/RESULT
+dnf module list --installed gimp | grep gimp && echo "gimp module marked as installed" >> /root/RESULT
+
+if [ ! -f /root/RESULT ]
+then
+    # no result file (no errors) -> success
+    echo SUCCESS > /root/RESULT
+else
+    # some errors happened
+    exit 1
+fi
+
+
+
+%end

--- a/module-enable-many.sh
+++ b/module-enable-many.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2014  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Chris Lumens <clumens@redhat.com>
+
+TESTTYPE="packaging modularity fedora-only"
+
+. ${KSTESTDIR}/functions.sh

--- a/module-enable-one-module-multiple-streams.ks.in
+++ b/module-enable-one-module-multiple-streams.ks.in
@@ -1,0 +1,82 @@
+#test name: module-install
+#
+# try enabling one module multiple times
+# - with diferent stream specififcations
+#
+# current expected behavior
+# - fails with traceback when the module command is being processed
+#
+# dnf.module.exception.NoModuleException: No such module: nodejs:8
+#
+# - it's always nodejs:8 regardless of the order of module command ordering
+
+url @KSTEST_URL@
+repo --name=modular @KSTEST_MODULAR_URL@
+
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+module --name=nodejs --stream=10
+module --name=nodejs --stream=8
+
+%packages
+@^Fedora Server Edition
+# lets use a no-default profile to see if it is correctly set afterwards
+kernel
+vim
+%end
+
+%post
+# modules have some packages defined as their API in their profiles,
+# we can check for those to be (or not to be installed) to see if the
+# module has (or has not) been installed
+
+# the vim standalone package
+rpm -q vim-minimal
+if [[ $? != 0 ]]; then
+    echo '*** vim-minimal package requested but not installed' >> /root/RESULT
+fi
+
+# it is also nice to have kernel
+rpm -q kernel
+if [[ $? != 0 ]]; then
+    echo '*** kernel package not installed' >> /root/RESULT
+fi
+
+# the nodejs module should be just enabled, so the API package should *not*
+# be installed
+
+rpm -q nodejs
+if [[ $? == 0 ]]; then
+    echo '*** nodejs package for nodejs module installed (module should be only enabled)' >> /root/RESULT
+fi
+
+# next we will check if the module is seen as enabled/installed from the
+# metadata/DNF point of view
+dnf module list --enabled nodejs | grep nodejs || echo "*** nodejs module not marked as enabled" >> /root/RESULT
+dnf module list --installed nodejs | grep nodejs && echo "*** nodejs module marked as installed (should be just enabled)" >> /root/RESULT
+
+# check the stream
+dnf module list --enabled nodejs | grep "8 \[e\]" || echo "*** nodejs stream id 8 not marked as enabled" >> /root/RESULT
+
+if [ ! -f /root/RESULT ]
+then
+    # no result file (no errors) -> success
+    echo SUCCESS > /root/RESULT
+else
+    # some errors happened
+    exit 1
+fi
+
+%end

--- a/module-enable-one-module-multiple-streams.sh
+++ b/module-enable-one-module-multiple-streams.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2014  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="knownfailure packaging modularity fedora-only"
+
+. ${KSTESTDIR}/functions.sh

--- a/module-enable-one-module-multiple-times.ks.in
+++ b/module-enable-one-module-multiple-times.ks.in
@@ -1,0 +1,76 @@
+#test name: module-install
+#
+# try enabling one module multiple times
+# - with same stream spec
+
+url @KSTEST_URL@
+repo --name=modular @KSTEST_MODULAR_URL@
+
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+module --name=nodejs --stream=10
+module --name=nodejs --stream=10
+module --name=nodejs --stream=10
+
+%packages
+@^Fedora Server Edition
+# lets use a no-default profile to see if it is correctly set afterwards
+kernel
+vim
+%end
+
+%post
+# modules have some packages defined as their API in their profiles,
+# we can check for those to be (or not to be installed) to see if the
+# module has (or has not) been installed
+
+# the vim standalone package
+rpm -q vim-minimal
+if [[ $? != 0 ]]; then
+    echo '*** vim-minimal package requested but not installed' >> /root/RESULT
+fi
+
+# it is also nice to have kernel
+rpm -q kernel
+if [[ $? != 0 ]]; then
+    echo '*** kernel package not installed' >> /root/RESULT
+fi
+
+# the nodejs module should be just enabled, so the API package should *not*
+# be installed
+
+rpm -q nodejs
+if [[ $? == 0 ]]; then
+    echo '*** nodejs package for nodejs module installed (module should be only enabled)' >> /root/RESULT
+fi
+
+# next we will check if the module is seen as enabled/installed from the
+# metadata/DNF point of view
+dnf module list --enabled nodejs | grep nodejs || echo "*** nodejs module not marked as enabled" >> /root/RESULT
+dnf module list --installed nodejs | grep nodejs && echo "*** nodejs module marked as installed (should be just enabled)" >> /root/RESULT
+
+# check the stream
+dnf module list --enabled nodejs | grep "10 \[e\]" || echo "*** nodejs stream id 10 not marked as enabled" >> /root/RESULT
+
+if [ ! -f /root/RESULT ]
+then
+    # no result file (no errors) -> success
+    echo SUCCESS > /root/RESULT
+else
+    # some errors happened
+    exit 1
+fi
+
+%end

--- a/module-enable-one-module-multiple-times.sh
+++ b/module-enable-one-module-multiple-times.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2014  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="packaging modularity"
+
+. ${KSTESTDIR}/functions.sh

--- a/module-enable-one-stream-install-different-stream.ks.in
+++ b/module-enable-one-stream-install-different-stream.ks.in
@@ -1,0 +1,81 @@
+#test name: module-install
+#
+# generic module install test:
+# - enable one module with a stream
+# - install the same module with a different stream
+#
+# expected result for this stream missmatch
+# - stream id from module command is used
+# - module spec in packages section is ignored if it specifies a different stream id
+#
+# This test is basically checking the current behavior holds that we can catch any changes,
+# both intended and unintended.
+
+url @KSTEST_URL@
+repo --name=modular @KSTEST_MODULAR_URL@
+
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+module --name=nodejs --stream=10
+
+%packages
+@^Fedora Server Edition
+# lets use a no-default profile to see if it is correctly set afterwards
+@nodejs:8/development
+kernel
+vim
+%end
+
+%post
+# modules have some packages defined as their API in their profiles,
+# we can check for those to be (or not to be installed) to see if the
+# module has (or has not) been installed
+
+# the vim standalone package
+rpm -q vim-minimal
+if [[ $? != 0 ]]; then
+    echo '*** vim-minimal package requested but not installed' >> /root/RESULT
+fi
+
+# it is also nice to have kernel
+rpm -q kernel
+if [[ $? != 0 ]]; then
+    echo '*** kernel package not installed' >> /root/RESULT
+fi
+
+# module should be just enabled due to the miss-match
+rpm -q nodejs
+if [[ $? != 0 ]]; then
+    echo '*** nodejs package for nodejs module should be installed' >> /root/RESULT
+fi
+
+# next we will check if the module is seen as enabled/installed from the
+# metadata/DNF point of view
+dnf module list --enabled nodejs | grep nodejs || echo "*** nodejs module not marked as enabled" >> /root/RESULT
+dnf module list --installed nodejs | grep nodejs || echo "*** nodejs module not marked as installed" >> /root/RESULT
+
+# check the stream
+dnf module list --enabled nodejs | grep "8 \[e\]" || echo "*** nodejs stream id 8 not marked as enabled (stream id from packages section should win)" >> /root/RESULT
+
+if [ ! -f /root/RESULT ]
+then
+    # no result file (no errors) -> success
+    echo SUCCESS > /root/RESULT
+else
+    # some errors happened
+    exit 1
+fi
+
+%end

--- a/module-enable-one-stream-install-different-stream.sh
+++ b/module-enable-one-stream-install-different-stream.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2014  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="packaging modularity"
+
+. ${KSTESTDIR}/functions.sh

--- a/module-ignoremissing.ks.in
+++ b/module-ignoremissing.ks.in
@@ -1,0 +1,29 @@
+#version=DEVEL
+#test name: module-ignoremissing
+#
+# what we are testing there:
+# - that missing modules are ignored if --ignoremissing is used
+# - that such an installation finishes successfully
+url @KSTEST_URL@
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+autopart
+
+keyboard us
+lang en_US.UTF-8
+timezone America/New_York --utc
+rootpw testcase
+shutdown
+
+%packages --ignoremissing
+@fake-module:fakestream/fakeprofile
+%end
+
+%post
+# If we made it this far, assume it's a success
+echo SUCCESS > /root/RESULT
+%end

--- a/module-ignoremissing.sh
+++ b/module-ignoremissing.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Chris Lumens <clumens@redhat.com>
+
+TESTTYPE="packaging modularity"
+
+. ${KSTESTDIR}/functions.sh

--- a/module-install-1.ks.in
+++ b/module-install-1.ks.in
@@ -1,0 +1,82 @@
+#test name: module-install
+#
+# generic module install test:
+# - enable one module
+# - install a second module
+
+url @KSTEST_URL@
+repo --name=modular @KSTEST_MODULAR_URL@
+
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+module --name=nodejs --stream=10
+
+%packages
+@^Fedora Server Edition
+@django:1.6/default
+kernel
+vim
+%end
+
+%post
+# modules have some packages defined as their API in their profiles,
+# we can check for those to be (or not to be installed) to see if the
+# module has (or has not) been installed
+
+# the vim standalone package
+rpm -q vim-minimal
+if [[ $? != 0 ]]; then
+    echo '*** vim-minimal package requested but not installed' >> /root/RESULT
+fi
+
+# it is also nice to have kernel
+rpm -q kernel
+if [[ $? != 0 ]]; then
+    echo '*** kernel package not installed' >> /root/RESULT
+fi
+
+# the nodejs module should be just enabled, so the API package should *not*
+# be installed
+
+rpm -q nodejs
+if [[ $? == 0 ]]; then
+    echo '*** nodejs installed, but module should just be enabled' >> /root/RESULT
+fi
+
+# the django module is installed, so it's API packages should be as well
+rpm -q python2-django
+if [[ $? != 0 ]]; then
+    echo '*** python2-django for the django module not installed' >> /root/RESULT
+fi
+
+# next we will check if the module is seen as enabled/installed from the
+# metadata/DNF point of view
+
+dnf module list --enabled nodejs | grep nodejs || echo "*** nodejs module not marked as enabled" >> /root/RESULT
+dnf module list --enabled django | grep django || echo "*** django module not marked as enabled" >> /root/RESULT
+dnf module list --installed django | grep django || echo "*** django module not marked as installed" >> /root/RESULT
+
+if [ ! -f /root/RESULT ]
+then
+    # no result file (no errors) -> success
+    echo SUCCESS > /root/RESULT
+else
+    # some errors happened
+    exit 1
+fi
+
+
+
+%end

--- a/module-install-1.sh
+++ b/module-install-1.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2014  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="packaging modularity fedora-only"
+
+. ${KSTESTDIR}/functions.sh

--- a/module-install-2.ks.in
+++ b/module-install-2.ks.in
@@ -1,0 +1,82 @@
+#test name: module-install
+#
+# generic module install test:
+# - enable one module (different one this time)
+# - install a second module (different one this time)
+
+url @KSTEST_URL@
+repo --name=modular @KSTEST_MODULAR_URL@
+
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+module --name=django --stream=1.6
+
+%packages
+@^Fedora Server Edition
+@nodejs:10/default
+kernel
+vim
+%end
+
+%post
+# modules have some packages defined as their API in their profiles,
+# we can check for those to be (or not to be installed) to see if the
+# module has (or has not) been installed
+
+# the vim standalone package
+rpm -q vim-minimal
+if [[ $? != 0 ]]; then
+    echo '*** vim-minimal package requested but not installed' >> /root/RESULT
+fi
+
+# it is also nice to have kernel
+rpm -q kernel
+if [[ $? != 0 ]]; then
+    echo '*** kernel package not installed' >> /root/RESULT
+fi
+
+# the nodejs module should be just enabled, so the API package should *not*
+# be installed
+
+rpm -q nodejs
+if [[ $? != 0 ]]; then
+    echo '*** nodejs package for nodejs module not installed' >> /root/RESULT
+fi
+
+# the django module is installed, so it's API packages should be as well
+rpm -q python2-django
+if [[ $? == 0 ]]; then
+    echo '*** python2-django installed but django module should be just enabled' >> /root/RESULT
+fi
+
+# next we will check if the module is seen as enabled/installed from the
+# metadata/DNF point of view
+
+dnf module list --enabled django | grep django || echo "*** django module not marked as enabled" >> /root/RESULT
+dnf module list --enabled nodejs | grep nodejs || echo "*** nodejs module not marked as enabled" >> /root/RESULT
+dnf module list --installed nodejs | grep nodejs || echo "*** nodejs module not marked as installed" >> /root/RESULT
+
+if [ ! -f /root/RESULT ]
+then
+    # no result file (no errors) -> success
+    echo SUCCESS > /root/RESULT
+else
+    # some errors happened
+    exit 1
+fi
+
+
+
+%end

--- a/module-install-2.sh
+++ b/module-install-2.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2014  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="packaging modularity fedora-only"
+
+. ${KSTESTDIR}/functions.sh

--- a/module-install-3.ks.in
+++ b/module-install-3.ks.in
@@ -1,0 +1,76 @@
+#test name: module-install
+#
+# generic module install test:
+# - enable one module with a stream
+# - install the same module with same stream
+
+url @KSTEST_URL@
+repo --name=modular @KSTEST_MODULAR_URL@
+
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+module --name=nodejs --stream=10
+
+%packages
+@^Fedora Server Edition
+# lets use a no-default profile to see if it is correctly set afterwards
+@nodejs:10/development
+kernel
+vim
+%end
+
+%post
+# modules have some packages defined as their API in their profiles,
+# we can check for those to be (or not to be installed) to see if the
+# module has (or has not) been installed
+
+# the vim standalone package
+rpm -q vim-minimal
+if [[ $? != 0 ]]; then
+    echo '*** vim-minimal package requested but not installed' >> /root/RESULT
+fi
+
+# it is also nice to have kernel
+rpm -q kernel
+if [[ $? != 0 ]]; then
+    echo '*** kernel package not installed' >> /root/RESULT
+fi
+
+# the nodejs module should be just enabled, so the API package should *not*
+# be installed
+
+rpm -q nodejs
+if [[ $? != 0 ]]; then
+    echo '*** nodejs package for nodejs module not installed' >> /root/RESULT
+fi
+
+# next we will check if the module is seen as enabled/installed from the
+# metadata/DNF point of view
+dnf module list --enabled nodejs | grep nodejs || echo "*** nodejs module not marked as enabled" >> /root/RESULT
+dnf module list --installed nodejs | grep nodejs || echo "*** nodejs module not marked as installed" >> /root/RESULT
+
+# check the stream and profile as well
+dnf module list --installed nodejs | grep "development \[i\]" || echo "*** nodejs module development profile not marked as installed" >> /root/RESULT
+
+if [ ! -f /root/RESULT ]
+then
+    # no result file (no errors) -> success
+    echo SUCCESS > /root/RESULT
+else
+    # some errors happened
+    exit 1
+fi
+
+%end

--- a/module-install-3.sh
+++ b/module-install-3.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2014  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="packaging modularity fedora-only"
+
+. ${KSTESTDIR}/functions.sh

--- a/module-install-4.ks.in
+++ b/module-install-4.ks.in
@@ -1,0 +1,76 @@
+#test name: module-install
+#
+# generic module install test:
+# - enable one module with a stream
+# - install the same module with a different stream
+
+url @KSTEST_URL@
+repo --name=modular @KSTEST_MODULAR_URL@
+
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+module --name=nodejs --stream=10
+
+%packages
+@^Fedora Server Edition
+# lets use a no-default profile to see if it is correctly set afterwards
+@nodejs:8/development
+kernel
+vim
+%end
+
+%post
+# modules have some packages defined as their API in their profiles,
+# we can check for those to be (or not to be installed) to see if the
+# module has (or has not) been installed
+
+# the vim standalone package
+rpm -q vim-minimal
+if [[ $? != 0 ]]; then
+    echo '*** vim-minimal package requested but not installed' >> /root/RESULT
+fi
+
+# it is also nice to have kernel
+rpm -q kernel
+if [[ $? != 0 ]]; then
+    echo '*** kernel package not installed' >> /root/RESULT
+fi
+
+# the nodejs module should be just enabled, so the API package should *not*
+# be installed
+
+rpm -q nodejs
+if [[ $? != 0 ]]; then
+    echo '*** nodejs package for nodejs module not installed' >> /root/RESULT
+fi
+
+# next we will check if the module is seen as enabled/installed from the
+# metadata/DNF point of view
+dnf module list --enabled nodejs | grep nodejs || echo "*** nodejs module not marked as enabled" >> /root/RESULT
+dnf module list --installed nodejs | grep nodejs || echo "*** nodejs module not marked as installed" >> /root/RESULT
+
+# check the stream and profile as well
+dnf module list --installed nodejs | grep "development \[i\]" || echo "*** nodejs module development profile not marked as installed" >> /root/RESULT
+
+if [ ! -f /root/RESULT ]
+then
+    # no result file (no errors) -> success
+    echo SUCCESS > /root/RESULT
+else
+    # some errors happened
+    exit 1
+fi
+
+%end

--- a/module-install-4.sh
+++ b/module-install-4.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2014  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="packaging modularity fedora-only
+
+. ${KSTESTDIR}/functions.sh

--- a/module-install-many.ks.in
+++ b/module-install-many.ks.in
@@ -1,0 +1,114 @@
+#test name: module-install-many
+#
+# test installing many different modules at once
+
+url @KSTEST_URL@
+repo --name=modular @KSTEST_MODULAR_URL@
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+@^Fedora Server Edition
+@nodejs:10/default
+@django:1.6/default
+@postgresql:9.6/default
+@mysql:5.7/default
+@scala:2.10/default
+@gimp:2.10/default
+kernel
+vim
+%end
+
+%post
+# modules have some packages defined as their API in their profiles,
+# we can check for those to be (or not to be installed) to see if the
+# module has (or has not) been installed
+
+# the vim standalone package
+rpm -q vim-minimal
+if [[ $? != 0 ]]; then
+    echo '*** vim-minimal package requested but not installed' >> /root/RESULT
+fi
+
+# it is also nice to have kernel
+rpm -q kernel
+if [[ $? != 0 ]]; then
+    echo '*** kernel package not installed' >> /root/RESULT
+fi
+
+rpm -q nodejs
+if [[ $? != 0 ]]; then
+    echo '*** nodejs for module nodejs not installed' >> /root/RESULT
+fi
+
+rpm -q python2-django
+if [[ $? != 0 ]]; then
+    echo '*** python2-django for the django module not installed' >> /root/RESULT
+fi
+
+rpm -q postgresql
+if [[ $? != 0 ]]; then
+    echo '*** postgresql for the postgresql module not installed' >> /root/RESULT
+fi
+
+rpm -q community-mysql
+if [[ $? != 0 ]]; then
+    echo '*** community-mysql for the mysql module not installed' >> /root/RESULT
+fi
+
+rpm -q scala
+if [[ $? != 0 ]]; then
+    echo '*** scala for the scala module not installed' >> /root/RESULT
+fi
+
+rpm -q gimp
+if [[ $? != 0 ]]; then
+    echo '*** gimp for the gimp module not installed' >> /root/RESULT
+fi
+
+# next we will check if the module is seen as enabled/installed from the
+# metadata/DNF point of view
+
+# log a "dnf module list" call for debugging purposes
+dnf module list
+
+# all installed modules should be also enabled
+dnf module list --enabled django | grep django || echo "*** django module not marked as enabled" >> /root/RESULT
+dnf module list --enabled nodejs | grep nodejs || echo "*** nodejs module not marked as enabled" >> /root/RESULT
+dnf module list --enabled postgresql | grep postgresql  || echo "*** postgresql module not marked as enabled" >> /root/RESULT
+dnf module list --enabled mysql | grep mysql || echo "*** mysql module not marked as enabled" >> /root/RESULT
+dnf module list --enabled scala | grep scala  || echo "*** scala module not marked as enabled" >> /root/RESULT
+dnf module list --enabled gimp | grep gimp  || echo "*** gimp module not marked as enabled" >> /root/RESULT
+
+# check all modules are also marked as installed
+dnf module list --installed django | grep django || echo "*** django module not marked as installed" >> /root/RESULT
+dnf module list --installed nodejs | grep nodejs || echo "*** nodejs module not marked as installed" >> /root/RESULT
+dnf module list --installed postgresql | grep postgresql  || echo "*** postgresql module not marked as installed" >> /root/RESULT
+dnf module list --installed mysql | grep mysql || echo "*** mysql module not marked as installed" >> /root/RESULT
+dnf module list --installed scala | grep scala  || echo "*** scala module not marked as installed" >> /root/RESULT
+dnf module list --installed gimp | grep gimp  || echo "*** gimp module not marked as installed" >> /root/RESULT
+
+
+if [ ! -f /root/RESULT ]
+then
+    # no result file (no errors) -> success
+    echo SUCCESS > /root/RESULT
+else
+    # some errors happened
+    exit 1
+fi
+
+
+
+%end

--- a/module-install-many.sh
+++ b/module-install-many.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2014  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="packaging modularity fedora-only"
+
+. ${KSTESTDIR}/functions.sh

--- a/module-install-no-stream-no-profile.ks.in
+++ b/module-install-no-stream-no-profile.ks.in
@@ -1,0 +1,132 @@
+#test name: module-enable-many
+#
+# test installing many modules without stream & profile specififcation
+# NOTE: this is not really testable on Rawhide right now as there are
+#       no modules with a default stream
+
+url @KSTEST_URL@
+repo --name=modular @KSTEST_MODULAR_URL@
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+@^Fedora Server Edition
+kernel
+vim
+@nodejs
+@postgresql
+@mongodb
+@mysql
+@gimp
+%end
+
+%post
+# modules have some packages defined as their API in their profiles,
+# we can check for those to be (or not to be installed) to see if the
+# module has (or has not) been installed
+
+# the vim standalone package
+rpm -q vim-minimal
+if [[ $? != 0 ]]; then
+    echo '*** vim-minimal package requested but not installed' >> /root/RESULT
+fi
+
+# it is also nice to have kernel
+rpm -q kernel
+if [[ $? != 0 ]]; then
+    echo '*** kernel package not installed' >> /root/RESULT
+fi
+
+rpm -q nodejs
+if [[ $? != 0 ]]; then
+    echo '*** nodejs for module nodejs default profile not installed' >> /root/RESULT
+fi
+
+rpm -q nodejs-devel
+if [[ $? == 0 ]]; then
+    echo '*** nodejs-devel for module nodejs default profile installed' >> /root/RESULT
+fi
+
+rpm -q postgresql-server
+if [[ $? != 0 ]]; then
+    echo '*** postgresql-server for the postgresql module default profile not installed' >> /root/RESULT
+fi
+
+rpm -q postgresql
+if [[ $? == 0 ]]; then
+    echo '*** postgresql for the postgresql module default profile installed' >> /root/RESULT
+fi
+
+rpm -q mongodb-server
+if [[ $? != 0 ]]; then
+    echo '*** mongodb-server for the mongodb module default profile not installed' >> /root/RESULT
+fi
+
+rpm -q mongodb
+if [[ $? != 0 ]]; then
+    echo '*** mongodb for the mongodb module default profile not installed' >> /root/RESULT
+fi
+
+rpm -q community-mysql-server
+if [[ $? != 0 ]]; then
+    echo '*** community-mysql-server for the mysql module default profile not installed' >> /root/RESULT
+fi
+
+rpm -q community-mysql
+if [[ $? != 0 ]]; then
+    echo '*** community-mysql for the mysql module default profile installed' >> /root/RESULT
+fi
+
+rpm -q gimp
+if [[ $? != 0 ]]; then
+    echo '*** gimp for the gimp module default profile not installed' >> /root/RESULT
+fi
+
+rpm -q gimp-devel
+if [[ $? == 0 ]]; then
+    echo '*** gimp-devel for the gimp module default profile installed' >> /root/RESULT
+fi
+
+# next we will check if the module is seen as enabled/installed from the
+# metadata/DNF point of view
+
+# log a "dnf module list" call for debugging purposes
+dnf module list
+
+# all installed modules should be also enabled
+dnf module list --enabled nodejs | grep nodejs || echo "nodejs module not marked as enabled" >> /root/RESULT
+dnf module list --enabled postgresql | grep postgresql  || echo "postgresql module not marked as enabled" >> /root/RESULT
+dnf module list --enabled mongodb | grep mongodb  || echo "mongodb module not marked as enabled" >> /root/RESULT
+dnf module list --enabled mysql | grep mysql || echo "mysql module not marked as enabled" >> /root/RESULT
+dnf module list --enabled gimp | grep gimp || echo "gimp module not marked as enabled" >> /root/RESULT
+
+# check all modules are also marked as installed with the correct profile
+dnf module list --installed nodejs | grep "default \[i\]" && echo "nodejs module profile not marked as installed" >> /root/RESULT
+dnf module list --installed postgresql | grep "default \[i\]" && echo "postgresql module profile not marked as installed" >> /root/RESULT
+dnf module list --installed mongodb | grep "default \[i\]" && echo "mongodb profile not marked as installed" >> /root/RESULT
+dnf module list --installed mysql | grep "default \[i\]" && echo "mysql module profile not marked as installed" >> /root/RESULT
+dnf module list --installed gimp | grep "default \[i\]"&& echo "gimp module profile not marked as installed" >> /root/RESULT
+
+#TODO: test default profile is correctly used
+
+if [ ! -f /root/RESULT ]
+then
+    # no result file (no errors) -> success
+    echo SUCCESS > /root/RESULT
+else
+    # some errors happened
+    exit 1
+fi
+
+%end

--- a/module-install-no-stream-no-profile.sh
+++ b/module-install-no-stream-no-profile.sh
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2014  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="knownfailure packaging modularity fedora-only"
+# there are currently no modules with a default streams in Fedora
+
+. ${KSTESTDIR}/functions.sh

--- a/module-install-one-module-multiple-profiles.ks.in
+++ b/module-install-one-module-multiple-profiles.ks.in
@@ -1,0 +1,79 @@
+#test name: module-install
+#
+# specify one module in packages section twice with same stream but different profiles
+#
+# expected result
+# - ?
+
+url @KSTEST_URL@
+repo --name=modular @KSTEST_MODULAR_URL@
+
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+@^Fedora Server Edition
+# lets use a non-default profile to see if it is correctly set afterwards
+@nodejs:10/default
+@nodejs:10/development
+kernel
+vim
+%end
+
+%post
+# modules have some packages defined as their API in their profiles,
+# we can check for those to be (or not to be installed) to see if the
+# module has (or has not) been installed
+
+# the vim standalone package
+rpm -q vim-minimal
+if [[ $? != 0 ]]; then
+    echo '*** vim-minimal package requested but not installed' >> /root/RESULT
+fi
+
+# it is also nice to have kernel
+rpm -q kernel
+if [[ $? != 0 ]]; then
+    echo '*** kernel package not installed' >> /root/RESULT
+fi
+
+# the nodejs module should be just enabled, so the API package should *not*
+# be installed
+
+rpm -q nodejs
+if [[ $? != 0 ]]; then
+    echo '*** nodejs package for nodejs module not installed' >> /root/RESULT
+fi
+
+# next we will check if the module is seen as enabled/installed from the
+# metadata/DNF point of view
+dnf module list --enabled nodejs | grep nodejs || echo "*** nodejs module not marked as enabled" >> /root/RESULT
+dnf module list --installed nodejs | grep nodejs || echo "*** nodejs module not marked as installed" >> /root/RESULT
+
+# check the profile
+dnf module list --installed nodejs | grep "default \[i\]" || echo "*** nodejs module default profile not marked as installed" >> /root/RESULT
+
+# check the stream
+dnf module list --enabled nodejs | grep "10 \[e\]" || echo "*** nodejs stream id 10 not marked as enabled" >> /root/RESULT
+
+if [ ! -f /root/RESULT ]
+then
+    # no result file (no errors) -> success
+    echo SUCCESS > /root/RESULT
+else
+    # some errors happened
+    exit 1
+fi
+
+%end

--- a/module-install-one-module-multiple-profiles.sh
+++ b/module-install-one-module-multiple-profiles.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2014  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="packaging modularity fedora-only"
+
+. ${KSTESTDIR}/functions.sh

--- a/module-install-one-module-multiple-streams-and-profiles.ks.in
+++ b/module-install-one-module-multiple-streams-and-profiles.ks.in
@@ -1,0 +1,79 @@
+#test name: module-install
+#
+# specify one module in packages section twice with different streams & profiles
+#
+# expected result
+# - ?
+
+url @KSTEST_URL@
+repo --name=modular @KSTEST_MODULAR_URL@
+
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+@^Fedora Server Edition
+# lets use a no-default profile to see if it is correctly set afterwards
+@nodejs:10/default
+@nodejs:8/development
+kernel
+vim
+%end
+
+%post
+# modules have some packages defined as their API in their profiles,
+# we can check for those to be (or not to be installed) to see if the
+# module has (or has not) been installed
+
+# the vim standalone package
+rpm -q vim-minimal
+if [[ $? != 0 ]]; then
+    echo '*** vim-minimal package requested but not installed' >> /root/RESULT
+fi
+
+# it is also nice to have kernel
+rpm -q kernel
+if [[ $? != 0 ]]; then
+    echo '*** kernel package not installed' >> /root/RESULT
+fi
+
+# the nodejs module should be just enabled, so the API package should *not*
+# be installed
+
+rpm -q nodejs
+if [[ $? != 0 ]]; then
+    echo '*** nodejs package for nodejs module not installed' >> /root/RESULT
+fi
+
+# next we will check if the module is seen as enabled/installed from the
+# metadata/DNF point of view
+dnf module list --enabled nodejs | grep nodejs || echo "*** nodejs module not marked as enabled" >> /root/RESULT
+dnf module list --installed nodejs | grep nodejs || echo "*** nodejs module not marked as installed" >> /root/RESULT
+
+# check the stream
+dnf module list --installed nodejs | grep "default \[i\]" || echo "*** nodejs module default profile not marked as installed" >> /root/RESULT
+
+# check the stream
+dnf module list --installed nodejs | grep "10 \[e\]" || echo "*** nodejs stream id 10 not marked as enabled" >> /root/RESULT
+
+if [ ! -f /root/RESULT ]
+then
+    # no result file (no errors) -> success
+    echo SUCCESS > /root/RESULT
+else
+    # some errors happened
+    exit 1
+fi
+
+%end

--- a/module-install-one-module-multiple-streams-and-profiles.sh
+++ b/module-install-one-module-multiple-streams-and-profiles.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2014  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="knownfailure packaging modularity fedora-only"
+
+. ${KSTESTDIR}/functions.sh

--- a/module-install-one-module-multiple-streams.ks.in
+++ b/module-install-one-module-multiple-streams.ks.in
@@ -1,0 +1,81 @@
+#test name: module-install
+#
+# specify one module in packages section twice with different streams
+#
+# expected result
+# - apparently no crash
+# - highest stream id apparently takes prefference
+#   (which is weird as stream ids should not be comparable for higher/lower)
+
+url @KSTEST_URL@
+repo --name=modular @KSTEST_MODULAR_URL@
+
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+@^Fedora Server Edition
+# lets use a no-default profile to see if it is correctly set afterwards
+@nodejs:8/default
+@nodejs:10/default
+kernel
+vim
+%end
+
+%post
+# modules have some packages defined as their API in their profiles,
+# we can check for those to be (or not to be installed) to see if the
+# module has (or has not) been installed
+
+# the vim standalone package
+rpm -q vim-minimal
+if [[ $? != 0 ]]; then
+    echo '*** vim-minimal package requested but not installed' >> /root/RESULT
+fi
+
+# it is also nice to have kernel
+rpm -q kernel
+if [[ $? != 0 ]]; then
+    echo '*** kernel package not installed' >> /root/RESULT
+fi
+
+# the nodejs module should be just enabled, so the API package should *not*
+# be installed
+
+rpm -q nodejs
+if [[ $? != 0 ]]; then
+    echo '*** nodejs package for nodejs module not installed' >> /root/RESULT
+fi
+
+# next we will check if the module is seen as enabled/installed from the
+# metadata/DNF point of view
+dnf module list --enabled nodejs | grep nodejs || echo "*** nodejs module not marked as enabled" >> /root/RESULT
+dnf module list --installed nodejs | grep nodejs || echo "*** nodejs module not marked as installed" >> /root/RESULT
+
+# check the stream
+dnf module list --installed nodejs | grep "default \[i\]" || echo "*** nodejs module default profile not marked as installed" >> /root/RESULT
+
+# check the stream
+dnf module list --installed nodejs | grep "10 \[e\]" || echo "*** nodejs stream id 10 not marked as enabled" >> /root/RESULT
+
+if [ ! -f /root/RESULT ]
+then
+    # no result file (no errors) -> success
+    echo SUCCESS > /root/RESULT
+else
+    # some errors happened
+    exit 1
+fi
+
+%end

--- a/module-install-one-module-multiple-streams.sh
+++ b/module-install-one-module-multiple-streams.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2014  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="knownfailure packaging modularity fedora-only"
+
+. ${KSTESTDIR}/functions.sh

--- a/module-install-without-profile.ks.in
+++ b/module-install-without-profile.ks.in
@@ -1,0 +1,125 @@
+#test name: module-enable-many
+#
+# test installing many modules with stream but not profiles specification
+# - a default profile should be selected automatically based on module
+#   metadata
+
+url @KSTEST_URL@
+repo --name=modular @KSTEST_MODULAR_URL@
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+@^Fedora Server Edition
+kernel
+vim
+@nodejs:10
+@postgresql:9.6
+@mongodb:3.4
+@mysql:5.7
+@gimp:2.10
+%end
+
+%post
+# modules have some packages defined as their API in their profiles,
+# we can check for those to be (or not to be installed) to see if the
+# module has (or has not) been installed
+
+# the vim standalone package
+rpm -q vim-minimal
+if [[ $? != 0 ]]; then
+    echo '*** vim-minimal package requested but not installed' >> /root/RESULT
+fi
+
+# it is also nice to have kernel
+rpm -q kernel
+if [[ $? != 0 ]]; then
+    echo '*** kernel package not installed' >> /root/RESULT
+fi
+
+rpm -q nodejs
+if [[ $? != 0 ]]; then
+    echo '*** nodejs for module nodejs default profile not installed' >> /root/RESULT
+fi
+
+rpm -q nodejs-devel
+if [[ $? == 0 ]]; then
+    echo '*** nodejs-devel for module nodejs default profile installed' >> /root/RESULT
+fi
+
+rpm -q postgresql-server
+if [[ $? != 0 ]]; then
+    echo '*** postgresql-server for the postgresql module default profile not installed' >> /root/RESULT
+fi
+
+rpm -q mongodb-server
+if [[ $? != 0 ]]; then
+    echo '*** mongodb-server for the mongodb module default profile not installed' >> /root/RESULT
+fi
+
+rpm -q mongodb
+if [[ $? != 0 ]]; then
+    echo '*** mongodb for the mongodb module default profile not installed' >> /root/RESULT
+fi
+
+rpm -q community-mysql-server
+if [[ $? != 0 ]]; then
+    echo '*** community-mysql-server for the mysql module default profile not installed' >> /root/RESULT
+fi
+
+rpm -q community-mysql
+if [[ $? != 0 ]]; then
+    echo '*** community-mysql for the mysql module default profile installed' >> /root/RESULT
+fi
+
+rpm -q gimp
+if [[ $? != 0 ]]; then
+    echo '*** gimp for the gimp module default profile not installed' >> /root/RESULT
+fi
+
+rpm -q gimp-devel
+if [[ $? == 0 ]]; then
+    echo '*** gimp-devel for the gimp module default profile installed' >> /root/RESULT
+fi
+
+# next we will check if the module is seen as enabled/installed from the
+# metadata/DNF point of view
+
+# log a "dnf module list" call for debugging purposes
+dnf module list
+
+# all installed modules should be also enabled
+dnf module list --enabled nodejs | grep nodejs || echo "*** nodejs module not marked as enabled" >> /root/RESULT
+dnf module list --enabled postgresql | grep postgresql  || echo "*** postgresql module not marked as enabled" >> /root/RESULT
+dnf module list --enabled mongodb | grep mongodb  || echo "*** mongodb module not marked as enabled" >> /root/RESULT
+dnf module list --enabled mysql | grep mysql || echo "*** mysql module not marked as enabled" >> /root/RESULT
+dnf module list --enabled gimp | grep gimp || echo "*** gimp module not marked as enabled" >> /root/RESULT
+
+# check all modules are also marked as installed with the correct profile
+dnf module list --installed nodejs | grep "default \[i\]" || echo "*** nodejs module profile not marked as installed" >> /root/RESULT
+dnf module list --installed postgresql | grep "default \[i\]" || echo "*** postgresql module profile not marked as installed" >> /root/RESULT
+dnf module list --installed mongodb | grep "default \[i\]" || echo "*** mongodb profile not marked as installed" >> /root/RESULT
+dnf module list --installed mysql | grep "default \[i\]" || echo "*** mysql module profile not marked as installed" >> /root/RESULT
+dnf module list --installed gimp | grep "default \[i\]" || echo "*** gimp module profile not marked as installed" >> /root/RESULT
+
+if [ ! -f /root/RESULT ]
+then
+    # no result file (no errors) -> success
+    echo SUCCESS > /root/RESULT
+else
+    # some errors happened
+    exit 1
+fi
+
+%end

--- a/module-install-without-profile.sh
+++ b/module-install-without-profile.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2014  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="packaging modularity fedora-only"
+
+. ${KSTESTDIR}/functions.sh

--- a/module-non-default-profiles.ks.in
+++ b/module-non-default-profiles.ks.in
@@ -1,0 +1,115 @@
+#test name: module-enable-many
+#
+# test installing many modules with non-default profiles
+
+url @KSTEST_URL@
+repo --name=modular @KSTEST_MODULAR_URL@
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+@^Fedora Server Edition
+kernel
+vim
+@nodejs:10/development
+@postgresql:9.6/server
+@mongodb:3.4/server
+@mysql:5.7/server
+@gimp:2.10/devel
+%end
+
+%post
+# modules have some packages defined as their API in their profiles,
+# we can check for those to be (or not to be installed) to see if the
+# module has (or has not) been installed
+
+# the vim standalone package
+rpm -q vim-minimal
+if [[ $? != 0 ]]; then
+    echo '*** vim-minimal package requested but not installed' >> /root/RESULT
+fi
+
+# it is also nice to have kernel
+rpm -q kernel
+if [[ $? != 0 ]]; then
+    echo '*** kernel package not installed' >> /root/RESULT
+fi
+
+rpm -q nodejs
+if [[ $? != 0 ]]; then
+    echo '*** nodejs for module nodejs profile server not installed' >> /root/RESULT
+fi
+
+rpm -q nodejs-devel
+if [[ $? != 0 ]]; then
+    echo '*** nodejs-devel for module nodejs profile development not installed' >> /root/RESULT
+fi
+
+rpm -q postgresql-server
+if [[ $? != 0 ]]; then
+    echo '*** postgresql-server for the postgresql module profile server not installed' >> /root/RESULT
+fi
+
+rpm -q mongodb-server
+if [[ $? != 0 ]]; then
+    echo '*** mongodb-server for the mongodb module profile server not installed' >> /root/RESULT
+fi
+
+rpm -q mongodb
+if [[ $? == 0 ]]; then
+    echo '*** mongodb for the mongodb module profile server installed' >> /root/RESULT
+fi
+
+rpm -q community-mysql-server
+if [[ $? != 0 ]]; then
+    echo '*** community-mysql-server for the mysql module profile server not installed' >> /root/RESULT
+fi
+
+rpm -q gimp-devel
+if [[ $? != 0 ]]; then
+    echo '*** gimp-devel for the gimp module profile devel not installed' >> /root/RESULT
+fi
+
+# next we will check if the module is seen as enabled/installed from the
+# metadata/DNF point of view
+
+# log a "dnf module list" call for debugging purposes
+dnf module list
+
+# all installed modules should be also enabled
+dnf module list --enabled nodejs | grep nodejs || echo "*** nodejs module not marked as enabled" >> /root/RESULT
+dnf module list --enabled postgresql | grep postgresql  || echo "*** postgresql module not marked as enabled" >> /root/RESULT
+dnf module list --enabled mongodb | grep mongodb  || echo "*** mongodb module not marked as enabled" >> /root/RESULT
+dnf module list --enabled mysql | grep mysql || echo "*** mysql module not marked as enabled" >> /root/RESULT
+dnf module list --enabled gimp | grep gimp || echo "*** gimp module not marked as enabled" >> /root/RESULT
+
+# check all modules are also marked as installed with the correct profile
+dnf module list --installed nodejs | grep "development \[i\]" || echo "*** nodejs module profile development not marked as installed" >> /root/RESULT
+# the following profiles can't be checked due to an elide bug in DNF output
+# https://bugzilla.redhat.com/show_bug.cgi?id=1602017
+#dnf module list --installed mongodb | grep "server \[i\]" || echo "*** mongodb profile server not marked as installed" >> /root/RESULT
+#dnf module list --installed mysql | grep "server \[i\]" || echo "*** mysql module profile server not marked as installed" >> /root/RESULT
+#dnf module list --installed postgresql | grep "server \[i\]" || echo "*** postgresql module profile server not marked as installed" >> /root/RESULT
+#dnf module list --installed gimp | grep "devel \[i\]" || echo "*** gimp module profile devel not marked as installed" >> /root/RESULT
+
+if [ ! -f /root/RESULT ]
+then
+    # no result file (no errors) -> success
+    echo SUCCESS > /root/RESULT
+else
+    # some errors happened
+    exit 1
+fi
+
+%end

--- a/module-non-default-profiles.sh
+++ b/module-non-default-profiles.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2014  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="packaging modularity fedora-only"
+
+. ${KSTESTDIR}/functions.sh

--- a/scripts/defaults.sh
+++ b/scripts/defaults.sh
@@ -3,5 +3,9 @@
 # Where's the package repo for tests that don't care about testing the package
 # source.  This may be slow (especially for large numbers of tests) and you may
 # want to define your own.
+#
+# CAUTION: the sed expression we currently use does not like white-space in the strings
+
 export KSTEST_URL='--mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-rawhide\\&arch=$basearch'
+export KSTEST_MODULAR_URL='--mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=rawhide-modular\\&arch=$basearch'
 export KSTEST_FTP_URL='ftp://mirror.utexas.edu/pub/fedora/linux/development/rawhide/Everything/$basearch/os/'

--- a/scripts/launcher/lib/log_handler.py
+++ b/scripts/launcher/lib/log_handler.py
@@ -32,6 +32,8 @@ class VirtualLogRequestHandler(LogRequestHandler):
     added_simple_tests = [
         "Payload setup error:",
         "Out of memory:",
+        "The following group or module is missing:",
+        "Stream was not specified for a module",
     ]
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
This PR is still a work-in-progress and should only be merged after all the relevant bits and pieces needed for kickstart based module installation support have landed in DNF and anaconda.