### PR TITLE
Fix tests which don't want to inject KS file to initrd

### DIFF
--- a/bindtomac-ifname-httpks.sh
+++ b/bindtomac-ifname-httpks.sh
@@ -44,9 +44,11 @@ prepare() {
     start_httpd ${tmpdir}/http $tmpdir
 
     echo ks_url=${httpd_url}ks.cfg > ${tmpdir}/ks_url
-    # Return empty path to kickstart file which will result in ks not
-    # being injected into initrd.
-    echo ""
+    echo "${ks}"
+}
+
+inject_ks_to_initrd() {
+    echo "false"
 }
 
 cleanup() {

--- a/bindtomac-network-device-mac-httpks.sh
+++ b/bindtomac-network-device-mac-httpks.sh
@@ -44,9 +44,11 @@ prepare() {
     start_httpd ${tmpdir}/http $tmpdir
 
     echo ks_url=${httpd_url}ks.cfg > ${tmpdir}/ks_url
-    # Return empty path to kickstart file which will result in ks not
-    # being injected into initrd.
-    echo ""
+    echo "${ks}"
+}
+
+inject_ks_to_initrd() {
+    echo "false"
 }
 
 cleanup() {

--- a/bond-vlan-httpks.sh
+++ b/bond-vlan-httpks.sh
@@ -63,10 +63,11 @@ prepare() {
     start_httpd ${tmpdir}/http $tmpdir
 
     echo ks_url=${httpd_url}ks.cfg > ${tmpdir}/ks_url
-    # Return empty path to kickstart file which will result in ks not
-    # being injected into initrd.
+    echo "${ks}"
+}
 
-    echo ""
+inject_ks_to_initrd() {
+    echo "false"
 }
 
 cleanup() {

--- a/bond2-httpks.sh
+++ b/bond2-httpks.sh
@@ -48,9 +48,11 @@ prepare() {
     start_httpd ${tmpdir}/http $tmpdir
 
     echo ks_url=${httpd_url}ks.cfg > ${tmpdir}/ks_url
-    # Return empty path to kickstart file which will result in ks not
-    # being injected into initrd.
-    echo ""
+    echo "${ks}"
+}
+
+inject_ks_to_initrd() {
+    echo "false"
 }
 
 cleanup() {

--- a/bridge-httpks.sh
+++ b/bridge-httpks.sh
@@ -44,9 +44,11 @@ prepare() {
     start_httpd ${tmpdir}/http $tmpdir
 
     echo ks_url=${httpd_url}ks.cfg > ${tmpdir}/ks_url
-    # Return empty path to kickstart file which will result in ks not
-    # being injected into initrd.
-    echo ""
+    echo "${ks}"
+}
+
+inject_ks_to_initrd() {
+    echo "false"
 }
 
 cleanup() {

--- a/bridged-bond-httpks.sh
+++ b/bridged-bond-httpks.sh
@@ -46,9 +46,11 @@ prepare() {
     start_httpd ${tmpdir}/http $tmpdir
 
     echo ks_url=${httpd_url}ks.cfg > ${tmpdir}/ks_url
-    # Return empty path to kickstart file which will result in ks not
-    # being injected into initrd.
-    echo ""
+    echo "${ks}"
+}
+
+inject_ks_to_initrd() {
+    echo "false"
 }
 
 cleanup() {

--- a/functions.sh
+++ b/functions.sh
@@ -22,6 +22,13 @@ prereqs() {
     echo
 }
 
+inject_ks_to_initrd() {
+    # Return true to inject kickstart to initrd. If false is specified than other way to
+    # use kickstart must be used.
+    # returns: "true" or "false"
+    echo "true"
+}
+
 kernel_args() {
     echo vnc debug=1 inst.debug
 }

--- a/ibft.sh
+++ b/ibft.sh
@@ -167,9 +167,11 @@ initrd ${httpd_url}initrd.img
 boot
 EOF
 
-    # Return empty path to kickstart file which will result in ks not
-    # being injected into initrd.
-    echo ""
+    echo "${ks}"
+}
+
+inject_ks_to_initrd() {
+    echo "false"
 }
 
 cleanup() {

--- a/ifname-httpks.sh
+++ b/ifname-httpks.sh
@@ -44,9 +44,11 @@ prepare() {
     start_httpd ${tmpdir}/http $tmpdir
 
     echo ks_url=${httpd_url}ks.cfg > ${tmpdir}/ks_url
-    # Return empty path to kickstart file which will result in ks not
-    # being injected into initrd.
-    echo ""
+    echo "${ks}"
+}
+
+inject_ks_to_initrd() {
+    echo "false"
 }
 
 cleanup() {

--- a/network-bootopts-static-legacy-httpks.sh
+++ b/network-bootopts-static-legacy-httpks.sh
@@ -68,10 +68,11 @@ prepare() {
     start_httpd ${tmpdir}/http $tmpdir
 
     echo ks_url=${httpd_url}ks.cfg > ${tmpdir}/ks_url
-    # Return empty path to kickstart file which will result in ks not
-    # being injected into initrd.
+    echo "${ks}"
+}
 
-    echo ""
+inject_ks_to_initrd() {
+    echo "false"
 }
 
 # Arguments for virt-install --network options

--- a/network-device-bootif-httpks.sh
+++ b/network-device-bootif-httpks.sh
@@ -44,9 +44,11 @@ prepare() {
     start_httpd ${tmpdir}/http $tmpdir
 
     echo ks_url=${httpd_url}ks.cfg > ${tmpdir}/ks_url
-    # Return empty path to kickstart file which will result in ks not
-    # being injected into initrd.
-    echo ""
+    echo "${ks}"
+}
+
+inject_ks_to_initrd() {
+    echo "false"
 }
 
 cleanup() {

--- a/network-device-default-httpks.sh
+++ b/network-device-default-httpks.sh
@@ -44,9 +44,11 @@ prepare() {
     start_httpd ${tmpdir}/http $tmpdir
 
     echo ks_url=${httpd_url}ks.cfg > ${tmpdir}/ks_url
-    # Return empty path to kickstart file which will result in ks not
-    # being injected into initrd.
-    echo ""
+    echo "${ks}"
+}
+
+inject_ks_to_initrd() {
+    echo "false"
 }
 
 cleanup() {

--- a/network-device-default-ksdevice-httpks.sh
+++ b/network-device-default-ksdevice-httpks.sh
@@ -44,9 +44,11 @@ prepare() {
     start_httpd ${tmpdir}/http $tmpdir
 
     echo ks_url=${httpd_url}ks.cfg > ${tmpdir}/ks_url
-    # Return empty path to kickstart file which will result in ks not
-    # being injected into initrd.
-    echo ""
+    echo "${ks}"
+}
+
+inject_ks_to_initrd() {
+    echo "false"
 }
 
 cleanup() {

--- a/network-device-mac-httpks.sh
+++ b/network-device-mac-httpks.sh
@@ -44,9 +44,11 @@ prepare() {
     start_httpd ${tmpdir}/http $tmpdir
 
     echo ks_url=${httpd_url}ks.cfg > ${tmpdir}/ks_url
-    # Return empty path to kickstart file which will result in ks not
-    # being injected into initrd.
-    echo ""
+    echo "${ks}"
+}
+
+inject_ks_to_initrd() {
+    echo "false"
 }
 
 cleanup() {

--- a/network-missing-ifcfg-httpks.sh
+++ b/network-missing-ifcfg-httpks.sh
@@ -45,9 +45,11 @@ prepare() {
     start_httpd ${tmpdir}/http $tmpdir
 
     echo ks_url=${httpd_url}ks.cfg > ${tmpdir}/ks_url
-    # Return empty path to kickstart file which will result in ks not
-    # being injected into initrd.
-    echo ""
+    echo "${ks}"
+}
+
+inject_ks_to_initrd() {
+    echo "false"
 }
 
 # Arguments for virt-install --network options

--- a/network-noipv4-httpks.sh
+++ b/network-noipv4-httpks.sh
@@ -46,9 +46,11 @@ prepare() {
     start_httpd ${tmpdir}/http $tmpdir
 
     echo ks_url=${httpd_url}ks.cfg > ${tmpdir}/ks_url
-    # Return empty path to kickstart file which will result in ks not
-    # being injected into initrd.
-    echo ""
+    echo "${ks}"
+}
+
+inject_ks_to_initrd() {
+    echo "false"
 }
 
 cleanup() {

--- a/network-static-2-httpks.sh
+++ b/network-static-2-httpks.sh
@@ -67,10 +67,11 @@ prepare() {
     start_httpd ${tmpdir}/http $tmpdir
 
     echo ks_url=${httpd_url}ks.cfg > ${tmpdir}/ks_url
-    # Return empty path to kickstart file which will result in ks not
-    # being injected into initrd.
+    echo "${ks}"
+}
 
-    echo ""
+inject_ks_to_initrd() {
+    echo "false"
 }
 
 # Arguments for virt-install --network options

--- a/network-static-httpks.sh
+++ b/network-static-httpks.sh
@@ -59,10 +59,11 @@ prepare() {
     start_httpd ${tmpdir}/http $tmpdir
 
     echo ks_url=${httpd_url}ks.cfg > ${tmpdir}/ks_url
-    # Return empty path to kickstart file which will result in ks not
-    # being injected into initrd.
+    echo "${ks}"
+}
 
-    echo ""
+inject_ks_to_initrd() {
+    echo "false"
 }
 
 # Arguments for virt-install --network options

--- a/onboot-activate-httpks.sh
+++ b/onboot-activate-httpks.sh
@@ -51,9 +51,11 @@ prepare() {
     start_httpd ${tmpdir}/http $tmpdir
 
     echo ks_url=${httpd_url}ks.cfg > ${tmpdir}/ks_url
-    # Return empty path to kickstart file which will result in ks not
-    # being injected into initrd.
-    echo ""
+    echo "${ks}"
+}
+
+inject_ks_to_initrd() {
+    echo "false"
 }
 
 cleanup() {

--- a/scripts/launcher/lib/launcher_interface.sh
+++ b/scripts/launcher/lib/launcher_interface.sh
@@ -88,6 +88,10 @@ case $1 in
         cleanup ${tmpdir}
         ret=$?
         ;;
+    inject_ks_to_initrd)
+        msg=$(inject_ks_to_initrd)
+        ret=$?
+        ;;
     prepare)
         msg=$(prepare ${ks} ${tmpdir})
         ret=$?

--- a/scripts/launcher/lib/shell_launcher.py
+++ b/scripts/launcher/lib/shell_launcher.py
@@ -132,6 +132,9 @@ class ShellLauncher(ProcessLauncher):
     def run_validate(self):
         return self._run_shell_func("validate")
 
+    def run_inject_ks_to_initrd(self):
+        return self._run_shell_func("inject_ks_to_initrd")
+
     def _run_shell_func(self, func_name):
         cmd_args = []
         script_path = os.path.join(self._conf.script_path, SHELL_INTERFACE_PATH)

--- a/scripts/launcher/lib/shell_launcher.py
+++ b/scripts/launcher/lib/shell_launcher.py
@@ -31,6 +31,10 @@ log = get_logger()
 SHELL_INTERFACE_PATH = "launcher_interface.sh"
 
 
+class ShellProcessError(Exception):
+    pass
+
+
 class ShellOutput(object):
 
     def __init__(self, subprocess_out):
@@ -108,32 +112,72 @@ class ShellLauncher(ProcessLauncher):
         self._conf = configuration
         self._tmp_dir = tmp_dir
 
-    def run_prepare(self):
-        return self._run_shell_func("prepare")
+    def prepare(self):
+        out = self._run_shell_func("prepare")
+        out.check_ret_code_with_exception()
+        return out.stdout
 
-    def run_cleanup(self):
+    def cleanup(self):
         return self._run_shell_func("cleanup")
 
-    def run_prepare_disks(self):
-        return self._run_shell_func("prepare_disks")
+    def prepare_disks(self):
+        out = self._run_shell_func("prepare_disks")
+        ret = []
 
-    def run_prepare_network(self):
-        return self._run_shell_func("prepare_network")
+        out.check_ret_code_with_exception()
 
-    def run_kernel_args(self):
-        return self._run_shell_func("kernel_args")
+        for d in out.stdout_as_array:
+            ret.append("{},cache=unsafe".format(d))
 
-    def run_additional_runner_args(self):
-        return self._run_shell_func("additional_runner_args")
+        return ret
 
-    def run_boot_args(self):
-        return self._run_shell_func("boot_args")
+    def prepare_network(self):
+        out = self._run_shell_func("prepare_network")
+        ret = []
 
-    def run_validate(self):
+        out.check_ret_code_with_exception()
+
+        for n in out.stdout_as_array:
+            ret.append(n)
+
+        return ret
+
+    def kernel_args(self):
+        out = self._run_shell_func("kernel_args")
+
+        out.check_ret_code_with_exception()
+        return out.stdout
+
+    def additional_runner_args(self):
+        out = self._run_shell_func("additional_runner_args")
+        ret = []
+
+        out.check_ret_code_with_exception()
+        for arg in out.stdout_as_array:
+            ret.append(arg)
+
+        return ret
+
+    def boot_args(self):
+        out = self._run_shell_func("boot_args")
+        out.check_ret_code_with_exception()
+        return out.stdout_as_array
+
+    def validate(self):
         return self._run_shell_func("validate")
 
-    def run_inject_ks_to_initrd(self):
-        return self._run_shell_func("inject_ks_to_initrd")
+    def inject_ks_to_initrd(self):
+        out = self._run_shell_func("inject_ks_to_initrd")
+
+        out.check_ret_code_with_exception()
+
+        if out.stdout == "true":
+            return True
+        elif out.stdout == "false":
+            return False
+        else:
+            raise ShellProcessError("Shell function inject_ks_to_initrd must return 'true' or "
+                                    "'false' but returned {}".format(out.stdout))
 
     def _run_shell_func(self, func_name):
         cmd_args = []

--- a/scripts/launcher/run_one_test.py
+++ b/scripts/launcher/run_one_test.py
@@ -68,7 +68,7 @@ class Runner(object):
             shell_out = self._shell.run_prepare()
             shell_out.check_ret_code_with_exception()
             self._ks_file = shell_out.stdout
-        except subprocess.CalledProcessError as e:
+        except subprocess.CalledProcessError:
             self._result_formatter.report_result(result=False, msg="Test prep failed")
             self._shell.run_cleanup()
             return False

--- a/scripts/launcher/run_one_test.py
+++ b/scripts/launcher/run_one_test.py
@@ -46,10 +46,6 @@ from lib.test_logging import setup_logger, get_logger
 log = get_logger()
 
 
-class BadParameterError(Exception):
-    pass
-
-
 class Runner(object):
 
     def __init__(self, configuration, tmp_dir):
@@ -69,19 +65,17 @@ class Runner(object):
         self._copy_image_to_tmp()
 
         try:
-            shell_out = self._shell.run_prepare()
-            shell_out.check_ret_code_with_exception()
-            self._ks_file = shell_out.stdout
+            self._ks_file = self._shell.prepare()
         except subprocess.CalledProcessError:
             self._result_formatter.report_result(result=False, msg="Test prep failed")
-            self._shell.run_cleanup()
+            self._shell.cleanup()
             return False
 
         self._validator = KickstartValidator(self._conf.ks_test_name, self._ks_file)
         self._validator.check_ks_substitution()
         if not self._validator.result:
             self._validator.report_result()
-            self._shell.run_cleanup()
+            self._shell.cleanup()
             return False
 
         return True
@@ -94,19 +88,19 @@ class Runner(object):
         if not self._prepare_test():
             return 99
 
-        kernel_args = self._get_kernel_args()
+        kernel_args = self._shell.kernel_args()
 
         if self._conf.updates_img_path:
             kernel_args += " inst.updates={}".format(self._conf.updates_img_path)
 
-        disk_args = self._collect_disks()
-        nics_args = self._collect_network()
-        boot_args = self._get_boot_args()
+        disk_args = self._shell.prepare_disks()
+        nics_args = self._shell.prepare_network()
+        boot_args = self._shell.boot_args()
 
         target_boot_iso = os.path.join(self._tmp_dir, self._conf.boot_image_name)
 
         ks = []
-        if self._should_inject_ks_to_initrd():
+        if self._shell.inject_ks_to_initrd():
             ks.append(self._ks_file)
 
         v_conf = VirtualConfiguration(target_boot_iso, ks)
@@ -133,72 +127,15 @@ class Runner(object):
 
         if not validator.result:
             validator.report_result()
-            self._shell.run_cleanup()
+            self._shell.cleanup()
             return validator.return_code
 
         ret = self._validate_result()
         if ret.check_ret_code():
             self._result_formatter.report_result(True, "test done")
 
-        self._shell.run_cleanup()
+        self._shell.cleanup()
         return ret.return_code
-
-    def _should_inject_ks_to_initrd(self):
-        out = self._shell.run_inject_ks_to_initrd()
-
-        out.check_ret_code_with_exception()
-
-        if out.stdout == "true":
-            return True
-        elif out.stdout == "false":
-            return False
-        else:
-            raise BadParameterError("Shell function inject_ks_to_initrd must return 'true' or "
-                                    "'false' but returned {}".format(out.stdout))
-
-    def _collect_disks(self):
-        ret = []
-
-        out = self._shell.run_prepare_disks()
-        out.check_ret_code_with_exception()
-
-        for d in out.stdout_as_array:
-            ret.append("{},cache=unsafe".format(d))
-
-        return ret
-
-    def _collect_network(self):
-        ret = []
-
-        out = self._shell.run_prepare_network()
-        out.check_ret_code_with_exception()
-
-        for n in out.stdout_as_array:
-            ret.append(n)
-
-        return ret
-
-    def _get_runner_args(self):
-        ret = []
-
-        out = self._shell.run_additional_runner_args()
-        out.check_ret_code_with_exception()
-        for arg in out.stdout_as_array:
-            ret.append(arg)
-
-        return ret
-
-    def _get_kernel_args(self):
-        out = self._shell.run_kernel_args()
-
-        out.check_ret_code_with_exception()
-        return out.stdout
-
-    def _get_boot_args(self):
-        out = self._shell.run_boot_args()
-
-        out.check_ret_code_with_exception()
-        return out.stdout_as_array
 
     def _validate_logs(self, virt_configuration):
         validator = LogValidator(self._conf.ks_test_name)
@@ -210,7 +147,7 @@ class Runner(object):
         return validator
 
     def _validate_result(self):
-        output = self._shell.run_validate()
+        output = self._shell.validate()
 
         if not output.check_ret_code():
             msg = "Validation failed with return code {}".format(output.return_code)

--- a/team-httpks.sh
+++ b/team-httpks.sh
@@ -55,9 +55,11 @@ prepare() {
     start_httpd ${tmpdir}/http $tmpdir
 
     echo ks_url=${httpd_url}ks.cfg > ${tmpdir}/ks_url
-    # Return empty path to kickstart file which will result in ks not
-    # being injected into initrd.
-    echo ""
+    echo "${ks}"
+}
+
+inject_ks_to_initrd() {
+    echo "false"
 }
 
 cleanup() {


### PR DESCRIPTION
Introduce new shell function `inject_ks_to_initrd` to replace old non-working solution which returned empty string from the `prepare` function.