### PR TITLE
Use 2GB RAM by default again

### DIFF
--- a/scripts/launcher/lib/configuration.py
+++ b/scripts/launcher/lib/configuration.py
@@ -151,7 +151,7 @@ class VirtualConfiguration(object):
         self._tmp = "/var/tmp"
         self._keep_image = True
         self._vcpu_count = 1
-        self._ram = 1024
+        self._ram = 2048
         self._vnc = None
         self._kernel_args = None
         self._timeout = None


### PR DESCRIPTION
It was changed to 1GB by mistake due to recent changes in the code.