### PR TITLE
Add a customizable log request handler

### DIFF
--- a/scripts/launcher/lib/log_handler.py
+++ b/scripts/launcher/lib/log_handler.py
@@ -1,0 +1,37 @@
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+#
+from pylorax.monitor import LogRequestHandler
+
+
+class VirtualLogRequestHandler(LogRequestHandler):
+
+    # Specify the error lines you want to ignore.
+    ignored_simple_tests = [
+        # "Call Trace:"
+    ]
+
+    def iserror(self, line):
+
+        # Skip ignored simple tests.
+        for t in self.ignored_simple_tests:
+            if t in line:
+                return
+
+        super().iserror(line)

--- a/scripts/launcher/lib/virtual_controller.py
+++ b/scripts/launcher/lib/virtual_controller.py
@@ -41,6 +41,7 @@ from pylorax.monitor import LogMonitor
 from pylorax.mount import IsoMountpoint
 
 from .configuration import VirtualConfiguration
+from .log_handler import VirtualLogRequestHandler
 from .validator import replace_new_lines
 from .shell_launcher import ProcessLauncher
 from .test_logging import get_logger
@@ -221,7 +222,12 @@ class VirtualManager(object):
         image.
         """
         iso_mount = IsoMountpoint(self._conf.iso_path, self._conf.location)
-        log_monitor = LogMonitor(install_log, timeout=self._conf.timeout)
+
+        log_monitor = LogMonitor(
+            install_log,
+            timeout=self._conf.timeout,
+            log_request_handler_class=VirtualLogRequestHandler
+        )
 
         kernel_args = ""
         if self._conf.kernel_args:


### PR DESCRIPTION
Added a new customizable log request handler that will be used
instead of the default one. It enables to specify error lines
that should be ignored during a kickstart test run.