### PR TITLE
Add tests for LUKS2 options

### DIFF
--- a/autopart-luks-1.ks.in
+++ b/autopart-luks-1.ks.in
@@ -1,0 +1,53 @@
+#test name: autopart-luks-1
+
+url @KSTEST_URL@
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+
+# Test LUKS 1.
+autopart --type=lvm --encrypted --passphrase="passphrase" --luks-version=luks1
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+%post
+
+# Set the crypted device.
+crypted="/dev/sda2"
+
+# Check if the type of /dev/sda2 is crypto_LUKS.
+type="$(blkid -o value -s TYPE ${crypted})"
+
+if [[ "$type" != "crypto_LUKS" ]] ; then
+    echo "*** unexpected type ${type} of ${crypted}" > /root/RESULT
+    exit 1
+fi
+
+# Check if the LUKS version of /dev/sda2 is luks1.
+result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "Version:") print $2; }' )"
+
+if [[ "$result" != "1" ]] ; then
+    echo "*** unexpected LUKS version for ${crypted}: ${result}" > /root/RESULT
+    exit 1
+fi
+
+# Try to use the passphrase.
+echo "passphrase" | cryptsetup luksOpen --test-passphrase "${crypted}"
+
+if [[ $? != 0 ]] ; then
+    echo "*** cannot open ${crypted} with the passphrase" > /root/RESULT
+    exit 1
+fi
+
+echo 'SUCCESS' > /root/RESULT
+%end

--- a/autopart-luks-1.sh
+++ b/autopart-luks-1.sh
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+
+TESTTYPE="autopart storage luks"
+
+. ${KSTESTDIR}/functions.sh
+
+copy_file() {
+    disks="$1"
+    file="$2"
+    dir="$3"
+
+    echo "passphrase" | \
+    guestfish --keys-from-stdin --ro ${disks} -i copy-out ${file} ${dir}
+}

--- a/autopart-luks-2.ks.in
+++ b/autopart-luks-2.ks.in
@@ -1,0 +1,53 @@
+#test name: autopart-luks-2
+
+url @KSTEST_URL@
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+
+# Test LUKS 2 with defaults.
+autopart --type=lvm --encrypted --passphrase="passphrase" --luks-version=luks2
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+%post
+
+# Set the crypted device.
+crypted="/dev/sda2"
+
+# Check if the type of /dev/sda2 is crypto_LUKS.
+type="$(blkid -o value -s TYPE ${crypted})"
+
+if [[ "$type" != "crypto_LUKS" ]] ; then
+    echo "*** unexpected type ${type} of ${crypted}" > /root/RESULT
+    exit 1
+fi
+
+# Check if the LUKS version of /dev/sda2 is luks2.
+result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "Version:") print $2; }' )"
+
+if [[ "$result" != "2" ]] ; then
+    echo "*** unexpected LUKS version for ${crypted}: ${result}" > /root/RESULT
+    exit 1
+fi
+
+# Try to use the passphrase.
+echo "passphrase" | cryptsetup luksOpen --test-passphrase "${crypted}"
+
+if [[ $? != 0 ]] ; then
+    echo "*** cannot open ${crypted} with the passphrase" > /root/RESULT
+    exit 1
+fi
+
+echo 'SUCCESS' > /root/RESULT
+%end

--- a/autopart-luks-2.sh
+++ b/autopart-luks-2.sh
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+
+TESTTYPE="autopart storage luks"
+
+. ${KSTESTDIR}/functions.sh
+
+copy_file() {
+    disks="$1"
+    file="$2"
+    dir="$3"
+
+    echo "passphrase" | \
+    guestfish --keys-from-stdin --ro ${disks} -i copy-out ${file} ${dir}
+}

--- a/autopart-luks-3.ks.in
+++ b/autopart-luks-3.ks.in
@@ -1,0 +1,40 @@
+#test name: autopart-luks-3
+
+url @KSTEST_URL@
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+
+# Test LUKS 2 with pbkdf2 and limited iterations.
+autopart --type=lvm --encrypted --passphrase="passphrase" --luks-version=luks2 --pbkdf=pbkdf2 --pbkdf-time=10
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+%post
+
+# Set the crypted device.
+crypted="/dev/sda2"
+
+# Check the PBKDF of /dev/sda2.
+result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "PBKDF:") print $2; }' )"
+
+if [[ "$result" != "pbkdf2" ]] ; then
+    echo "*** unexpected PBKDF for ${crypted}: ${result}" >> /root/RESULT
+fi
+
+# The test was successful.
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+
+%end

--- a/autopart-luks-3.sh
+++ b/autopart-luks-3.sh
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+
+TESTTYPE="autopart storage luks"
+
+. ${KSTESTDIR}/functions.sh
+
+copy_file() {
+    disks="$1"
+    file="$2"
+    dir="$3"
+
+    echo "passphrase" | \
+    guestfish --keys-from-stdin --ro ${disks} -i copy-out ${file} ${dir}
+}

--- a/autopart-luks-4.ks.in
+++ b/autopart-luks-4.ks.in
@@ -1,0 +1,47 @@
+#test name: autopart-luks-4
+
+url @KSTEST_URL@
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+
+# Test LUKS 2 with argon2i and limited memory.
+autopart --type=lvm --encrypted --passphrase="passphrase" --luks-version=luks2 --pbkdf=argon2i --pbkdf-memory=64
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+%post
+
+# Set the crypted device.
+crypted="/dev/sda2"
+
+# Check the PBKDF of /dev/sda2.
+result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "PBKDF:") print $2; }' )"
+
+if [[ "$result" != "argon2i" ]] ; then
+    echo "*** unexpected PBKDF for ${crypted}: ${result}" >> /root/RESULT
+fi
+
+# Check the memory of /dev/sda2.
+result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "Memory:") print $2; }' )"
+
+if [[ "$result" != "64" ]] ; then
+    echo "*** unexpected memory for ${crypted}: ${result}" >> /root/RESULT
+fi
+
+# The test was successful.
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+
+%end

--- a/autopart-luks-4.sh
+++ b/autopart-luks-4.sh
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+
+TESTTYPE="autopart storage luks"
+
+. ${KSTESTDIR}/functions.sh
+
+copy_file() {
+    disks="$1"
+    file="$2"
+    dir="$3"
+
+    echo "passphrase" | \
+    guestfish --keys-from-stdin --ro ${disks} -i copy-out ${file} ${dir}
+}

--- a/autopart-luks-5.ks.in
+++ b/autopart-luks-5.ks.in
@@ -1,0 +1,54 @@
+#test name: autopart-luks-5
+
+url @KSTEST_URL@
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+
+# Test LUKS 2 with argon2id and limited time.
+autopart --type=lvm --encrypted --passphrase="passphrase" --luks-version=luks2 --pbkdf=argon2id --pbkdf-iterations=4 --pbkdf-memory=64
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+%post
+
+# Set the crypted device.
+crypted="/dev/sda2"
+
+# Check the PBKDF of /dev/sda2.
+result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "PBKDF:") print $2; }' )"
+
+if [[ "$result" != "argon2id" ]] ; then
+    echo "*** unexpected PBKDF for ${crypted}: ${result}" >> /root/RESULT
+fi
+
+# Check the iterations of /dev/sda2.
+result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "Time" && $2 == "cost:") print $3; }' )"
+
+if [[ "$result" != "4" ]] ; then
+    echo "*** unexpected iterations for ${crypted}: ${result}" >> /root/RESULT
+fi
+
+# Check the memory of /dev/sda2.
+result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "Memory:") print $2; }' )"
+
+if [[ "$result" != "64" ]] ; then
+    echo "*** unexpected memory for ${crypted}: ${result}" >> /root/RESULT
+fi
+
+# The test was successful.
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+
+%end

--- a/autopart-luks-5.sh
+++ b/autopart-luks-5.sh
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+
+TESTTYPE="autopart storage luks"
+
+. ${KSTESTDIR}/functions.sh
+
+copy_file() {
+    disks="$1"
+    file="$2"
+    dir="$3"
+
+    echo "passphrase" | \
+    guestfish --keys-from-stdin --ro ${disks} -i copy-out ${file} ${dir}
+}

--- a/lvm-luks-1.ks.in
+++ b/lvm-luks-1.ks.in
@@ -1,0 +1,62 @@
+#test name: lvm-luks-1
+
+url @KSTEST_URL@
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+
+# Test LUKS 2 with default values.
+# FIXME: remove the --pbkdf-time option
+
+part /boot --fstype="ext4" --size=1024
+part pv.1 --fstype="lvmpv" --size=9215
+
+volgroup fedora pv.1
+
+logvol / --name=root --vgname=fedora --fstype="ext4" --grow --size=1024 --encrypted --passphrase="passphrase" --luks-version=luks1
+logvol swap --name=swap --vgname=fedora --fstype="swap" --size=1023
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+%post
+
+# Set the crypted device.
+crypted="/dev/mapper/fedora-root"
+
+# Check if the type of the crypted device is crypto_LUKS.
+type="$(blkid -o value -s TYPE ${crypted})"
+
+if [[ "$type" != "crypto_LUKS" ]] ; then
+    echo "*** unexpected type ${type} of ${crypted}" >> /root/RESULT
+fi
+
+# Check if the LUKS version is luks1.
+result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "Version:") print $2; }' )"
+
+if [[ "$result" != "1" ]] ; then
+    echo "*** unexpected LUKS version for ${crypted}: ${result}" >> /root/RESULT
+fi
+
+# Try to use the passphrase.
+echo "passphrase" | cryptsetup luksOpen --test-passphrase "${crypted}"
+
+if [[ $? != 0 ]] ; then
+    echo "*** cannot open ${crypted} with the passphrase" >> /root/RESULT
+fi
+
+# The test was successful.
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+
+%end

--- a/lvm-luks-1.sh
+++ b/lvm-luks-1.sh
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+
+TESTTYPE="storage lvm luks"
+
+. ${KSTESTDIR}/functions.sh
+
+copy_file() {
+    disks="$1"
+    file="$2"
+    dir="$3"
+
+    echo "passphrase" | \
+    guestfish --keys-from-stdin --ro ${disks} -i copy-out ${file} ${dir}
+}

--- a/lvm-luks-2.ks.in
+++ b/lvm-luks-2.ks.in
@@ -1,0 +1,61 @@
+#test name: lvm-luks-2
+
+url @KSTEST_URL@
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+
+# Test LUKS 2 with default values.
+
+part /boot --fstype="ext4" --size=1024
+part pv.1 --fstype="lvmpv" --size=9215
+
+volgroup fedora pv.1
+
+logvol / --name=root --vgname=fedora --fstype="ext4" --grow --size=1024 --encrypted --passphrase="passphrase" --luks-version=luks2
+logvol swap --name=swap --vgname=fedora --fstype="swap" --size=1023
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+%post
+
+# Set the crypted device.
+crypted="/dev/mapper/fedora-root"
+
+# Check if the type of the crypted device is crypto_LUKS.
+type="$(blkid -o value -s TYPE ${crypted})"
+
+if [[ "$type" != "crypto_LUKS" ]] ; then
+    echo "*** unexpected type ${type} of ${crypted}" >> /root/RESULT
+fi
+
+# Check if the LUKS version is luks2.
+result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "Version:") print $2; }' )"
+
+if [[ "$result" != "2" ]] ; then
+    echo "*** unexpected LUKS version for ${crypted}: ${result}" >> /root/RESULT
+fi
+
+# Try to use the passphrase.
+echo "passphrase" | cryptsetup luksOpen --test-passphrase "${crypted}"
+
+if [[ $? != 0 ]] ; then
+    echo "*** cannot open ${crypted} with the passphrase" >> /root/RESULT
+fi
+
+# The test was successful.
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+
+%end

--- a/lvm-luks-2.sh
+++ b/lvm-luks-2.sh
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+
+TESTTYPE="storage lvm luks"
+
+. ${KSTESTDIR}/functions.sh
+
+copy_file() {
+    disks="$1"
+    file="$2"
+    dir="$3"
+
+    echo "passphrase" | \
+    guestfish --keys-from-stdin --ro ${disks} -i copy-out ${file} ${dir}
+}

--- a/lvm-luks-3.ks.in
+++ b/lvm-luks-3.ks.in
@@ -1,0 +1,47 @@
+#test name: lvm-luks-3
+
+url @KSTEST_URL@
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+
+# Test LUKS 2 with pbkdf2 and the --pbkdf-time option.
+
+part /boot --fstype="ext4" --size=1024
+part pv.1 --fstype="lvmpv" --size=9215
+
+volgroup fedora pv.1
+
+logvol / --name=root --vgname=fedora --fstype="ext4" --grow --size=1024 --encrypted --passphrase="passphrase" --luks-version=luks2 --pbkdf=pbkdf2 --pbkdf-time=10
+logvol swap --name=swap --vgname=fedora --fstype="swap" --size=1023
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+%post
+
+# Set the crypted device.
+crypted="/dev/mapper/fedora-root"
+
+# Check the PBKDF of /dev/sda2.
+result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "PBKDF:") print $2; }' )"
+
+if [[ "$result" != "pbkdf2" ]] ; then
+    echo "*** unexpected PBKDF for ${crypted}: ${result}" >> /root/RESULT
+fi
+
+# The test was successful.
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+
+%end

--- a/lvm-luks-3.sh
+++ b/lvm-luks-3.sh
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+
+TESTTYPE="storage lvm luks"
+
+. ${KSTESTDIR}/functions.sh
+
+copy_file() {
+    disks="$1"
+    file="$2"
+    dir="$3"
+
+    echo "passphrase" | \
+    guestfish --keys-from-stdin --ro ${disks} -i copy-out ${file} ${dir}
+}

--- a/lvm-luks-4.ks.in
+++ b/lvm-luks-4.ks.in
@@ -1,0 +1,61 @@
+#test name: lvm-luks-4
+
+url @KSTEST_URL@
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+
+# Test LUKS 2 with argon2i and options --pbkdf-iterations and --pbkdf-memory.
+
+part /boot --fstype="ext4" --size=1024
+part pv.1 --fstype="lvmpv" --size=9215
+
+volgroup fedora pv.1
+
+logvol / --name=root --vgname=fedora --fstype="ext4" --grow --size=1024 --encrypted --passphrase="passphrase" --luks-version=luks2 --pbkdf=argon2i --pbkdf-iterations=4 --pbkdf-memory=64
+logvol swap --name=swap --vgname=fedora --fstype="swap" --size=1023
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+%post
+
+# Set the crypted device.
+crypted="/dev/mapper/fedora-root"
+
+# Check the PBKDF.
+result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "PBKDF:") print $2; }' )"
+
+if [[ "$result" != "argon2i" ]] ; then
+    echo "*** unexpected PBKDF for ${crypted}: ${result}" >> /root/RESULT
+fi
+
+# Check the iterations.
+result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "Time" && $2 == "cost:") print $3; }' )"
+
+if [[ "$result" != "4" ]] ; then
+    echo "*** unexpected iterations for ${crypted}: ${result}" >> /root/RESULT
+fi
+
+# Check the memory.
+result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "Memory:") print $2; }' )"
+
+if [[ "$result" != "64" ]] ; then
+    echo "*** unexpected memory for ${crypted}: ${result}" >> /root/RESULT
+fi
+
+# The test was successful.
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+
+%end

--- a/lvm-luks-4.sh
+++ b/lvm-luks-4.sh
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+
+TESTTYPE="storage lvm luks"
+
+. ${KSTESTDIR}/functions.sh
+
+copy_file() {
+    disks="$1"
+    file="$2"
+    dir="$3"
+
+    echo "passphrase" | \
+    guestfish --keys-from-stdin --ro ${disks} -i copy-out ${file} ${dir}
+}

--- a/part-luks-1.ks.in
+++ b/part-luks-1.ks.in
@@ -1,0 +1,57 @@
+#test name: part-luks-1
+
+url @KSTEST_URL@
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+
+# Test LUKS 1 with default values.
+
+part / --fstype="ext4" --size=8191 --encrypted --passphrase="passphrase" --luks-version=luks1
+part /boot --fstype="ext4" --size=1024
+part swap --fstype="swap" --size=1024
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+%post
+
+# Set the crypted device.
+crypted="/dev/sda2"
+
+# Check if the type of the crypted device is crypto_LUKS.
+type="$(blkid -o value -s TYPE ${crypted})"
+
+if [[ "$type" != "crypto_LUKS" ]] ; then
+    echo "*** unexpected type ${type} of ${crypted}" >> /root/RESULT
+fi
+
+# Check if the LUKS version is luks1.
+result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "Version:") print $2; }' )"
+
+if [[ "$result" != "1" ]] ; then
+    echo "*** unexpected LUKS version for ${crypted}: ${result}" >> /root/RESULT
+fi
+
+# Try to use the passphrase.
+echo "passphrase" | cryptsetup luksOpen --test-passphrase "${crypted}"
+
+if [[ $? != 0 ]] ; then
+    echo "*** cannot open ${crypted} with the passphrase" >> /root/RESULT
+fi
+
+# The test was successful.
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+
+%end

--- a/part-luks-1.sh
+++ b/part-luks-1.sh
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+
+TESTTYPE="storage partition luks"
+
+. ${KSTESTDIR}/functions.sh
+
+copy_file() {
+    disks="$1"
+    file="$2"
+    dir="$3"
+
+    echo "passphrase" | \
+    guestfish --keys-from-stdin --ro ${disks} -i copy-out ${file} ${dir}
+}

--- a/part-luks-2.ks.in
+++ b/part-luks-2.ks.in
@@ -1,0 +1,57 @@
+#test name: part-luks-2
+
+url @KSTEST_URL@
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+
+# Test LUKS 2 with default values.
+
+part / --fstype="ext4" --size=8191 --encrypted --passphrase="passphrase" --luks-version=luks2
+part /boot --fstype="ext4" --size=1024
+part swap --fstype="swap" --size=1024
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+%post
+
+# Set the crypted device.
+crypted="/dev/sda2"
+
+# Check if the type of the crypted device is crypto_LUKS.
+type="$(blkid -o value -s TYPE ${crypted})"
+
+if [[ "$type" != "crypto_LUKS" ]] ; then
+    echo "*** unexpected type ${type} of ${crypted}" >> /root/RESULT
+fi
+
+# Check if the LUKS version is luks2.
+result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "Version:") print $2; }' )"
+
+if [[ "$result" != "2" ]] ; then
+    echo "*** unexpected LUKS version for ${crypted}: ${result}" >> /root/RESULT
+fi
+
+# Try to use the passphrase.
+echo "passphrase" | cryptsetup luksOpen --test-passphrase "${crypted}"
+
+if [[ $? != 0 ]] ; then
+    echo "*** cannot open ${crypted} with the passphrase" >> /root/RESULT
+fi
+
+# The test was successful.
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+
+%end

--- a/part-luks-2.sh
+++ b/part-luks-2.sh
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+
+TESTTYPE="storage partition luks"
+
+. ${KSTESTDIR}/functions.sh
+
+copy_file() {
+    disks="$1"
+    file="$2"
+    dir="$3"
+
+    echo "passphrase" | \
+    guestfish --keys-from-stdin --ro ${disks} -i copy-out ${file} ${dir}
+}

--- a/part-luks-3.ks.in
+++ b/part-luks-3.ks.in
@@ -1,0 +1,43 @@
+#test name: part-luks-3
+
+url @KSTEST_URL@
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+
+# Test LUKS 2 with pbkdf2 and the --pbkdf-time option.
+
+part / --fstype="ext4" --size=8191 --encrypted --passphrase="passphrase" --luks-version=luks2 --pbkdf=pbkdf2 --pbkdf-time=10
+part /boot --fstype="ext4" --size=1024
+part swap --fstype="swap" --size=1024
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+%post
+
+# Set the crypted device.
+crypted="/dev/sda2"
+
+# Check the PBKDF of /dev/sda2.
+result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "PBKDF:") print $2; }' )"
+
+if [[ "$result" != "pbkdf2" ]] ; then
+    echo "*** unexpected PBKDF for ${crypted}: ${result}" >> /root/RESULT
+fi
+
+# The test was successful.
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+
+%end

--- a/part-luks-3.sh
+++ b/part-luks-3.sh
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+
+TESTTYPE="storage partition luks"
+
+. ${KSTESTDIR}/functions.sh
+
+copy_file() {
+    disks="$1"
+    file="$2"
+    dir="$3"
+
+    echo "passphrase" | \
+    guestfish --keys-from-stdin --ro ${disks} -i copy-out ${file} ${dir}
+}

--- a/part-luks-4.ks.in
+++ b/part-luks-4.ks.in
@@ -1,0 +1,57 @@
+#test name: part-luks-4
+
+url @KSTEST_URL@
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+
+# Test LUKS 2 with argon2i and options --pbkdf-iterations and --pbkdf-memory.
+
+part / --fstype="ext4" --size=8191 --encrypted --passphrase="passphrase" --luks-version=luks2 --pbkdf=argon2i --pbkdf-iterations=4 --pbkdf-memory=64
+part /boot --fstype="ext4" --size=1024
+part swap --fstype="swap" --size=1024
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+%post
+
+# Set the crypted device.
+crypted="/dev/sda2"
+
+# Check the PBKDF.
+result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "PBKDF:") print $2; }' )"
+
+if [[ "$result" != "argon2i" ]] ; then
+    echo "*** unexpected PBKDF for ${crypted}: ${result}" >> /root/RESULT
+fi
+
+# Check the iterations.
+result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "Time" && $2 == "cost:") print $3; }' )"
+
+if [[ "$result" != "4" ]] ; then
+    echo "*** unexpected iterations for ${crypted}: ${result}" >> /root/RESULT
+fi
+
+# Check the memory.
+result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "Memory:") print $2; }' )"
+
+if [[ "$result" != "64" ]] ; then
+    echo "*** unexpected memory for ${crypted}: ${result}" >> /root/RESULT
+fi
+
+# The test was successful.
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+
+%end

--- a/part-luks-4.sh
+++ b/part-luks-4.sh
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+
+TESTTYPE="storage partition luks"
+
+. ${KSTESTDIR}/functions.sh
+
+copy_file() {
+    disks="$1"
+    file="$2"
+    dir="$3"
+
+    echo "passphrase" | \
+    guestfish --keys-from-stdin --ro ${disks} -i copy-out ${file} ${dir}
+}

--- a/raid-luks-1.ks.in
+++ b/raid-luks-1.ks.in
@@ -1,0 +1,60 @@
+#version=DEVEL
+#test name: raid-luks-1
+
+url @KSTEST_URL@
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+clearpart --all --initlabel
+
+# Test LUKS 1 with default values.
+
+part /boot --fstype="ext4" --size=1024
+part swap --fstype="swap" --size=2048
+part raid.1 --fstype="mdmember" --ondisk=sda --size=7167
+part raid.2 --fstype="mdmember" --ondisk=sdb --size=7167
+
+raid / --device=root --fstype="ext4" --level=RAID1 --encrypted --passphrase="passphrase" --luks-version=luks1 raid.1 raid.2
+
+keyboard us
+lang en_US.UTF-8
+timezone America/New_York --utc
+rootpw testcase
+shutdown
+
+%packages
+%end
+
+%post
+
+# Set the crypted device.
+crypted="/dev/md/root"
+
+# Check if the type of the crypted device is crypto_LUKS.
+type="$(blkid -o value -s TYPE ${crypted})"
+
+if [[ "$type" != "crypto_LUKS" ]] ; then
+    echo "*** unexpected type ${type} of ${crypted}" >> /root/RESULT
+fi
+
+# Check if the LUKS version is luks1.
+result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "Version:") print $2; }' )"
+
+if [[ "$result" != "1" ]] ; then
+    echo "*** unexpected LUKS version for ${crypted}: ${result}" >> /root/RESULT
+fi
+
+# Try to use the passphrase.
+echo "passphrase" | cryptsetup luksOpen --test-passphrase "${crypted}"
+
+if [[ $? != 0 ]] ; then
+    echo "*** cannot open ${crypted} with the passphrase" >> /root/RESULT
+fi
+
+# The test was successful.
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+
+%end

--- a/raid-luks-1.sh
+++ b/raid-luks-1.sh
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+
+TESTTYPE="storage raid luks"
+
+. ${KSTESTDIR}/functions.sh
+
+prepare_disks() {
+    tmpdir=$1
+
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-a.img 10G
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-b.img 10G
+    echo ${tmpdir}/disk-a.img ${tmpdir}/disk-b.img
+}
+
+copy_file() {
+    disks="$1"
+    file="$2"
+    dir="$3"
+
+    echo "passphrase" | \
+    guestfish --keys-from-stdin --ro ${disks} -i copy-out ${file} ${dir}
+}

--- a/raid-luks-2.ks.in
+++ b/raid-luks-2.ks.in
@@ -1,0 +1,60 @@
+#version=DEVEL
+#test name: raid-luks-2
+
+url @KSTEST_URL@
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+clearpart --all --initlabel
+
+# Test LUKS 2 with default values.
+
+part /boot --fstype="ext4" --size=1024
+part swap --fstype="swap" --size=2048
+part raid.1 --fstype="mdmember" --ondisk=sda --size=7167
+part raid.2 --fstype="mdmember" --ondisk=sdb --size=7167
+
+raid / --device=root --fstype="ext4" --level=RAID1 --encrypted --passphrase="passphrase" --luks-version=luks2 raid.1 raid.2
+
+keyboard us
+lang en_US.UTF-8
+timezone America/New_York --utc
+rootpw testcase
+shutdown
+
+%packages
+%end
+
+%post
+
+# Set the crypted device.
+crypted="/dev/md/root"
+
+# Check if the type of the crypted device is crypto_LUKS.
+type="$(blkid -o value -s TYPE ${crypted})"
+
+if [[ "$type" != "crypto_LUKS" ]] ; then
+    echo "*** unexpected type ${type} of ${crypted}" >> /root/RESULT
+fi
+
+# Check if the LUKS version is luks2.
+result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "Version:") print $2; }' )"
+
+if [[ "$result" != "2" ]] ; then
+    echo "*** unexpected LUKS version for ${crypted}: ${result}" >> /root/RESULT
+fi
+
+# Try to use the passphrase.
+echo "passphrase" | cryptsetup luksOpen --test-passphrase "${crypted}"
+
+if [[ $? != 0 ]] ; then
+    echo "*** cannot open ${crypted} with the passphrase" >> /root/RESULT
+fi
+
+# The test was successful.
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+
+%end

--- a/raid-luks-2.sh
+++ b/raid-luks-2.sh
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+
+TESTTYPE="storage raid luks"
+
+. ${KSTESTDIR}/functions.sh
+
+prepare_disks() {
+    tmpdir=$1
+
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-a.img 10G
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-b.img 10G
+    echo ${tmpdir}/disk-a.img ${tmpdir}/disk-b.img
+}
+
+copy_file() {
+    disks="$1"
+    file="$2"
+    dir="$3"
+
+    echo "passphrase" | \
+    guestfish --keys-from-stdin --ro ${disks} -i copy-out ${file} ${dir}
+}

--- a/raid-luks-3.ks.in
+++ b/raid-luks-3.ks.in
@@ -1,0 +1,46 @@
+#version=DEVEL
+#test name: raid-luks-3
+
+url @KSTEST_URL@
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+clearpart --all --initlabel
+
+# Test LUKS 2 with pbkdf2 and the --pbkdf-time option.
+
+part /boot --fstype="ext4" --size=1024
+part swap --fstype="swap" --size=2048
+part raid.1 --fstype="mdmember" --ondisk=sda --size=7167
+part raid.2 --fstype="mdmember" --ondisk=sdb --size=7167
+
+raid / --device=root --fstype="ext4" --level=RAID1 --encrypted --passphrase="passphrase" --luks-version=luks2 --pbkdf=pbkdf2 --pbkdf-time=10 raid.1 raid.2
+
+keyboard us
+lang en_US.UTF-8
+timezone America/New_York --utc
+rootpw testcase
+shutdown
+
+%packages
+%end
+
+%post
+
+# Set the crypted device.
+crypted="/dev/md/root"
+
+# Check the PBKDF of /dev/sda2.
+result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "PBKDF:") print $2; }' )"
+
+if [[ "$result" != "pbkdf2" ]] ; then
+    echo "*** unexpected PBKDF for ${crypted}: ${result}" >> /root/RESULT
+fi
+
+# The test was successful.
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+
+%end

--- a/raid-luks-3.sh
+++ b/raid-luks-3.sh
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+
+TESTTYPE="storage raid luks"
+
+. ${KSTESTDIR}/functions.sh
+
+prepare_disks() {
+    tmpdir=$1
+
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-a.img 10G
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-b.img 10G
+    echo ${tmpdir}/disk-a.img ${tmpdir}/disk-b.img
+}
+
+copy_file() {
+    disks="$1"
+    file="$2"
+    dir="$3"
+
+    echo "passphrase" | \
+    guestfish --keys-from-stdin --ro ${disks} -i copy-out ${file} ${dir}
+}

--- a/raid-luks-4.ks.in
+++ b/raid-luks-4.ks.in
@@ -1,0 +1,60 @@
+#version=DEVEL
+#test name: raid-luks-4
+
+url @KSTEST_URL@
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+clearpart --all --initlabel
+
+# Test LUKS 2 with argon2i and options --pbkdf-iterations and --pbkdf-memory.
+
+part /boot --fstype="ext4" --size=1024
+part swap --fstype="swap" --size=2048
+part raid.1 --fstype="mdmember" --ondisk=sda --size=7167
+part raid.2 --fstype="mdmember" --ondisk=sdb --size=7167
+
+raid / --device=root --fstype="ext4" --level=RAID1 --encrypted --passphrase="passphrase" --luks-version=luks2 --pbkdf=argon2i --pbkdf-iterations=4 --pbkdf-memory=64 raid.1 raid.2
+
+keyboard us
+lang en_US.UTF-8
+timezone America/New_York --utc
+rootpw testcase
+shutdown
+
+%packages
+%end
+
+%post
+
+# Set the crypted device.
+crypted="/dev/md/root"
+
+# Check the PBKDF.
+result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "PBKDF:") print $2; }' )"
+
+if [[ "$result" != "argon2i" ]] ; then
+    echo "*** unexpected PBKDF for ${crypted}: ${result}" >> /root/RESULT
+fi
+
+# Check the iterations.
+result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "Time" && $2 == "cost:") print $3; }' )"
+
+if [[ "$result" != "4" ]] ; then
+    echo "*** unexpected iterations for ${crypted}: ${result}" >> /root/RESULT
+fi
+
+# Check the memory.
+result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "Memory:") print $2; }' )"
+
+if [[ "$result" != "64" ]] ; then
+    echo "*** unexpected memory for ${crypted}: ${result}" >> /root/RESULT
+fi
+
+# The test was successful.
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+
+%end

--- a/raid-luks-4.sh
+++ b/raid-luks-4.sh
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+
+TESTTYPE="storage raid luks"
+
+. ${KSTESTDIR}/functions.sh
+
+prepare_disks() {
+    tmpdir=$1
+
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-a.img 10G
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-b.img 10G
+    echo ${tmpdir}/disk-a.img ${tmpdir}/disk-b.img
+}
+
+copy_file() {
+    disks="$1"
+    file="$2"
+    dir="$3"
+
+    echo "passphrase" | \
+    guestfish --keys-from-stdin --ro ${disks} -i copy-out ${file} ${dir}
+}


### PR DESCRIPTION
Add tests for LUKS2 options in autopart, logvol, part and raid.
Depends on: https://github.com/rhinstaller/anaconda/pull/1525