### PR TITLE
linchpin: there is only one type of resource: kstest

### DIFF
--- a/linchpin/topologies/kstests.yml
+++ b/linchpin/topologies/kstests.yml
@@ -8,16 +8,7 @@ resource_groups:
           role: os_server
           flavor: m1.xlarge
           image: Fedora-Cloud-Base-28-1.1
-          count: 1
-          keypair: kstests
-          fip_pool: 10.8.240.0
-          networks:
-            - installer-jenkins-priv-network
-        - name: "kstest-master"
-          role: os_server
-          flavor: m1.xlarge
-          image: Fedora-Cloud-Base-28-1.1
-          count: 1
+          count: 2
           keypair: kstests
           fip_pool: 10.8.240.0
           networks:


### PR DESCRIPTION
The tests are run also on master so it has the same resource
requirements and having special kstest-master does not make sense.

In layouts/kstest.yml one of the kstest resources can be (or not,
depending on use case) assigned to kstest-master group and deployed
as master with ansible.