### PR TITLE
hostname tests: do not check static hostname via hostnamectl in chroot

### DIFF
--- a/post-lib-network.sh
+++ b/post-lib-network.sh
@@ -178,10 +178,4 @@ function check_hostname() {
     if [[ $? -ne 0 ]]; then
         echo "*** Failed check: ${hostname} is set in /etc/hostname" >> /root/RESULT
     fi
-
-    hostnamectl --static | grep -q "^${hostname}$"
-    if [[ $? -ne 0 ]]; then
-        echo "*** Failed check: hostnamectl --static returns ${hostname}" >> /root/RESULT
-    fi
-
 }


### PR DESCRIPTION
Just check that the configuration is passed via /etc/hostname.
hostnamectl run in chroot checks static hostname of installer environment
and there is no need to set static hostname in installer environment

We used to do set installer environment hostname at the end of installation
by calling "hostnamectl set-hostname" (which sets also static hostname)
while now we call SetHostname method of hostnamed service.