### PR TITLE
Split of bash function result also on newlines

### DIFF
--- a/scripts/launcher/lib/shell_launcher.py
+++ b/scripts/launcher/lib/shell_launcher.py
@@ -51,7 +51,7 @@ class ShellOutput(object):
         ret = self.stdout
 
         if ret:
-            return ret.split(" ")
+            return ret.split()
         else:
             return []
 


### PR DESCRIPTION
Some prepare_disk and almost all prepare_network functions return
multi-line result.