### PR TITLE
Fix a typo in log_handler

### DIFF
--- a/scripts/launcher/lib/log_handler.py
+++ b/scripts/launcher/lib/log_handler.py
@@ -34,8 +34,8 @@ class VirtualLogRequestHandler(LogRequestHandler):
         "Out of memory:",
     ]
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         # add any additional error lines
         self.simple_tests.extend(self.added_simple_tests)
 


### PR DESCRIPTION
A recent patch for log handler started to call the __init__() method,
but incorrectly (without passing args & kwargs). So lets fix that.