### PR TITLE
Add utility playbooks

### DIFF
--- a/ansible/utility/cleanup.yml
+++ b/ansible/utility/cleanup.yml
@@ -1,0 +1,19 @@
+---
+- hosts:
+    kstest
+  become: true
+  become_user: root
+
+  tasks:
+  - name: Find kickstart test results
+    find:
+      paths: /var/tmp
+      patterns: "kstest-*"
+      file_type: any
+    register: wildcard_items_to_delete
+
+  - name: Femove kickstart test results
+    file:
+      path: "{{ item.path }}"
+      state: absent
+    with_items: "{{ wildcard_items_to_delete.files }}"

--- a/ansible/utility/download-image.yml
+++ b/ansible/utility/download-image.yml
@@ -1,0 +1,21 @@
+---
+# run with --extra-vars "image_url=<boot iso URL>"
+- hosts:
+    kstest
+  become: true
+  become_user: root
+
+  tasks:
+
+  - name: Create directory for install images
+    file:
+      path: /home/kstest/install_images/
+      state: directory
+      owner: kstest
+      group: kstest
+
+  - name: Download new boot iso
+    get_url:
+      url: "{{ image_url }}"
+      dest: /home/kstest/install_images/
+

--- a/ansible/utility/list-images.yml
+++ b/ansible/utility/list-images.yml
@@ -1,0 +1,14 @@
+---
+- hosts:
+    kstest
+  become: true
+  become_user: root
+
+  tasks:
+  - name: List available images
+    shell: ls -lh install_images
+    args:
+      chdir: /home/kstest
+    register: available_images
+  - debug:
+      var: available_images.stdout_lines

--- a/ansible/utility/reboot.yml
+++ b/ansible/utility/reboot.yml
@@ -1,0 +1,18 @@
+---
+- hosts:
+    kstest
+  become: true
+  become_user: root
+
+  tasks:
+  - name: Reboot all machines
+    shell: "sleep 5 && reboot"
+    async: 1
+    poll: 0
+
+  - name: Wait for the reboot to complete
+    wait_for_connection:
+      connect_timeout: 20
+      sleep: 5
+      delay: 5
+      timeout: 300

--- a/ansible/utility/update-system.yml
+++ b/ansible/utility/update-system.yml
@@ -1,0 +1,11 @@
+---
+- hosts:
+    kstest
+  become: true
+  become_user: root
+
+  tasks:
+  - name: Update all packages
+    dnf:
+      name: "*"
+      state: latest


### PR DESCRIPTION
Add playbooks for easy test runner management.

cleanup - clean stale tests results
download-image - download a new boot iso
list-images - list available test images
reboot - perform a reboot of the runners
update - update the system to latest package version via DNF

This playbook basically target the usecase where kickstart test
are used to validate development and ad-hoc component changes
where the test runners are not created on demand, but created
once and then used for multiple test runs as needed.