### PR TITLE
Add rsync as required package for the main task

### DIFF
--- a/ansible/roles/kstest/tasks/main.yml
+++ b/ansible/roles/kstest/tasks/main.yml
@@ -20,6 +20,7 @@
       - python3-libvirt # kstests
       - libguestfs-tools # kstests
       - vim
+      - rsync
     state: latest
 
 - name: Install kernel-modules (reboot if updated)


### PR DESCRIPTION
Rsync is now required to synchronize the images and tests.