### PR TITLE
Add host id for kickstart test result line

### DIFF
--- a/scripts/launcher/lib/configuration.py
+++ b/scripts/launcher/lib/configuration.py
@@ -52,6 +52,7 @@ class RunnerConfiguration(object):
         self._image_path = ""
         self._keep_option = KeepLevel.NOTHING
         self._updates_img_path = ""
+        self._append_host_id = False
 
     def _confiure_parser(self):
         self._parser.add_argument("kickstart_test", metavar="KS test controller",
@@ -70,6 +71,9 @@ class RunnerConfiguration(object):
         self._parser.add_argument("--updates", '-u', metavar="Path",
                                   type=str, dest="updates_path",
                                   help="Updates image path used in the test")
+        self._parser.add_argument("--append-host-id", default=False, action="store_true",
+                                  dest="append_host_id",
+                                  help="append an id of the host running the test to the result")
 
     @property
     def shell_test_path(self):
@@ -103,6 +107,10 @@ class RunnerConfiguration(object):
     def script_path(self):
         return os.path.dirname(os.path.realpath(__file__))
 
+    @property
+    def append_host_id(self):
+        return self._append_host_id
+
     def process_argument(self):
         ns = self._parser.parse_args()
 
@@ -121,6 +129,9 @@ class RunnerConfiguration(object):
 
         if ns.updates_path:
             self._updates_img_path = ns.updates_path
+
+        if ns.append_host_id:
+            self._append_host_id = ns.append_host_id
 
         self._check_arguments()
 

--- a/scripts/launcher/lib/validator.py
+++ b/scripts/launcher/lib/validator.py
@@ -34,16 +34,18 @@ def replace_new_lines(line):
 
 class ResultFormatter(object):
 
-    def __init__(self, test_name):
+    def __init__(self, test_name, host_id=""):
         super().__init__()
 
         self._test_name = test_name
+        self._host_id = host_id
 
     def format_result(self, result, msg):
         text_result = "SUCCESS" if result else "FAILED"
-        msg = "RESULT:{name}:{result}:{message}".format(name=self._test_name,
-                                                        result=text_result,
-                                                        message=msg)
+        msg = "RESULT:{name}:{host_id}:{result}:{message}".format(name=self._test_name,
+                                                            host_id=self._host_id,
+                                                            result=text_result,
+                                                            message=msg)
         return msg
 
     def report_result(self, result, msg):

--- a/scripts/launcher/run_one_test.py
+++ b/scripts/launcher/run_one_test.py
@@ -35,6 +35,7 @@
 import os
 import shutil
 import subprocess
+import socket
 
 from lib.temp_manager import TempManager
 from lib.configuration import RunnerConfiguration, VirtualConfiguration
@@ -55,10 +56,21 @@ class Runner(object):
         self._ks_file = None
 
         self._shell = ShellLauncher(configuration, tmp_dir)
-        self._result_formatter = ResultFormatter(self._conf.ks_test_name)
+        self._result_formatter = ResultFormatter(self._conf.ks_test_name, host_id=self.host_id)
         # test prepare function can change place of the kickstart test
         # so the validator will be set later
         self._validator = None
+
+    @property
+    def host_id(self):
+        """Return a show string identifying the host where the test is running.
+
+        This is currently simply the hostname.
+
+        :return: a test runner describing string
+        :rtype: str
+        """
+        return socket.gethostname()
 
     def _prepare_test(self):
         log.debug("Preparing test")

--- a/scripts/run_kickstart_tests.sh
+++ b/scripts/run_kickstart_tests.sh
@@ -361,6 +361,7 @@ if [[ "$TEST_REMOTES" != "" ]]; then
              sudo PYTHONPATH=$PYTHONPATH scripts/launcher/run_one_test.py \
                                                                -i ../install_images/${_IMAGE} \
                                                                -k ${KEEPIT} \
+                                                               --append-host-id \
                                                                ${UPDATES_ARG} ${BOOT_ARG} {} ::: ${tests}
     rc=$?
     cd -
@@ -390,6 +391,7 @@ else
         sudo PYTHONPATH=$PYTHONPATH scripts/launcher/run_one_test.py \
                                                       -i ${IMAGE} \
                                                       -k ${KEEPIT} \
+                                                      --append-host-id \
                                                       ${UPDATES_ARG} ${BOOT_ARG} {} ::: ${tests}
     rc=$?
 fi

--- a/scripts/run_report.sh
+++ b/scripts/run_report.sh
@@ -1,20 +1,20 @@
 #!/bin/gawk -f
 
 BEGIN {
-    printf("\n\n\n%-55s | %-10s | %s\n", "TEST", "RESULT", "EXPLANATION");
-    printf("-------------------------------+------------+--------------------------------------------------------\n");
+    printf("\n\n\n%-55s | %-15s | %-10s | %s\n", "TEST", "HOST", "RESULT", "EXPLANATION");
+    printf("--------------------------------------------------------+-----------------+------------+-------------------------------------------\n");
     FS=":";
     count=0;
     failed=0;
     timed_out=0;
 }
-/: RESULT:/ { if ($7 == "Test timed out") {
+/: RESULT:/ { if ($8 == "Test timed out") {
                  result = "TIMED OUT";
                  explanation = "";
                  timed_out++;
              } else if (match($0, "Traceback")) {
                  result = "FAILED";
-                 explanation = "Traceback: " $10;
+                 explanation = "Traceback: " $11;
                  failed++;
              } else if (match($0, "traceback")) {
                  result = "FAILED";
@@ -22,29 +22,29 @@ BEGIN {
                  failed++;
              } else if (match($0, "failed on line")) {
                  result = "FAILED";
-                 explanation = "error in log: "$11 $12 $13
+                 explanation = "error in log: "$12 ":" $13 ":" $14
                  failed++;
              } else if (match($0, "SUCCESS")) {
-                 result = $6;
+                 result = $7;
                  explanation = "";
              } else {
-                 result = $6;
-                 explanation = $7
+                 result = $7;
+                 explanation = $8
                  failed++;
              }
 
-             printf("%-55s | %-10s | %s\n", $5, result, explanation);
+             printf("%-55s | %-15s | %-10s | %s\n", $5, $6, result, explanation);
              count++
            }
 END {
     printf("\n");
-    printf("=====================================================================================================\n");
+    printf("===================================================================================================================================\n");
     printf("Test suite for kickstart tests summary:\n");
-    printf("=====================================================================================================\n");
+    printf("===================================================================================================================================\n");
     printf("# TOTAL:      %s\n", count);
     printf("# PASS:       %s\n", count - failed - timed_out);
     printf("# FAILED:     %s\n", failed);
     printf("# TIMED OUT:  %s\n", timed_out);
-    printf("=====================================================================================================\n");
+    printf("===================================================================================================================================\n");
     printf("\n\n");
 }


### PR DESCRIPTION
When many kickstart tests are running in parallel on different
machines/VM hosts it can be very useful to know on which host
a given test was run.

This information can be used for example to debug host specific issues
that break tests (machine is too slow or unstable, has broken
networking, etc.) or to directly access test logs on machines during a
long run.

So add a host id (at the moment simply the machine hostname) to
the RESULT line, so we can easily see on which machine did the test run.

Also adjust the run_report.sh script to be compatible with the new RESULT format.