### PR TITLE
Disable some of the tests for LUKS

### DIFF
--- a/lvm-luks-1.sh
+++ b/lvm-luks-1.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
-TESTTYPE="storage lvm luks"
+TESTTYPE="knownfailure storage lvm luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/lvm-luks-2.sh
+++ b/lvm-luks-2.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
-TESTTYPE="storage lvm luks"
+TESTTYPE="knownfailure storage lvm luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/lvm-luks-3.sh
+++ b/lvm-luks-3.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
-TESTTYPE="storage lvm luks"
+TESTTYPE="knownfailure storage lvm luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/lvm-luks-4.sh
+++ b/lvm-luks-4.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
-TESTTYPE="storage lvm luks"
+TESTTYPE="knownfailure storage lvm luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/part-luks-1.sh
+++ b/part-luks-1.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
-TESTTYPE="storage partition luks"
+TESTTYPE="knownfailure storage partition luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/part-luks-2.sh
+++ b/part-luks-2.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
-TESTTYPE="storage partition luks"
+TESTTYPE="knownfailure storage partition luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/part-luks-3.sh
+++ b/part-luks-3.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
-TESTTYPE="storage partition luks"
+TESTTYPE="knownfailure storage partition luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/part-luks-4.sh
+++ b/part-luks-4.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
-TESTTYPE="storage partition luks"
+TESTTYPE="knownfailure storage partition luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-luks-1.sh
+++ b/raid-luks-1.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
-TESTTYPE="storage raid luks"
+TESTTYPE="knownfailure storage raid luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-luks-2.sh
+++ b/raid-luks-2.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
-TESTTYPE="storage raid luks"
+TESTTYPE="knownfailure storage raid luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-luks-3.sh
+++ b/raid-luks-3.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
-TESTTYPE="storage raid luks"
+TESTTYPE="knownfailure storage raid luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-luks-4.sh
+++ b/raid-luks-4.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
-TESTTYPE="storage raid luks"
+TESTTYPE="knownfailure storage raid luks"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
It looks like libvirt is not always able to work with encrypted storage
and it fails with "no operating system was found on this disk" when
it tries to copy out files. It means that the results of these tests
have to be checked manualy, so let's disable them for now.