### PR TITLE
ansible: add playbook for scheduling provisioning and test in cloud

### DIFF
--- a/linchpin/remove_scheduled_tests.yml
+++ b/linchpin/remove_scheduled_tests.yml
@@ -1,0 +1,9 @@
+---
+
+- hosts: localhost
+  become: false
+
+  roles:
+   - role: schedule
+     vars:
+       action: remove

--- a/linchpin/roles/schedule/defaults/main.yml
+++ b/linchpin/roles/schedule/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+
+# Each test_id has its own timer, service and script to be run
+# to manage multiple tests from single host.
+test_id: 1
+
+# The path to the git repository from which the tests should be run.
+# If not defined, assumes running the playbook from the git repository root.
+#git_repo_path: "/path/to/kickstart-tests/git/repo"
+
+# Path to linchpin virtualenv
+virtualenv_linchpin_path: "/path/to/bin/activate"
+
+# When the test should be run (systemd OnCalendar value)
+systemd_on_calendar: "daily"
+#systemd_on_calendar: "*-*-* 00:00:00"
+#systemd_on_calendar: "Mon,Tue,Wed,Thu,Fri *-*-* 00:00:00"

--- a/linchpin/roles/schedule/tasks/main.yml
+++ b/linchpin/roles/schedule/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Schedule test {{ test_id }}
+  import_tasks: schedule.yml
+  when: action == "schedule"
+
+- name: Remove scheduled test {{ test_id }}
+  import_tasks: remove.yml
+  when: action == "remove"

--- a/linchpin/roles/schedule/tasks/remove.yml
+++ b/linchpin/roles/schedule/tasks/remove.yml
@@ -1,0 +1,24 @@
+---
+
+- name: Remove the service file {{ service_file_path }}
+  file:
+    state: absent
+    path: "{{ service_file_path }}"
+
+- name: Stop the timer
+  systemd:
+    name: "{{ service_name }}.timer"
+    user: yes
+    state: stopped
+    enabled: no
+    daemon_reload: yes
+
+- name: Remove the timer file {{ timer_file_path }}
+  file:
+    state: absent
+    path: "{{ timer_file_path }}"
+
+- name: Remove the run script {{ run_script_path }}
+  file:
+    state: absent
+    path: "{{ run_script_path }}"

--- a/linchpin/roles/schedule/tasks/schedule.yml
+++ b/linchpin/roles/schedule/tasks/schedule.yml
@@ -1,0 +1,33 @@
+---
+
+- name: Create run script
+  template:
+    src: run_scheduled_tests.sh.j2
+    dest: "{{ run_script_path }}"
+    mode: 0755
+
+- name: Ensure user systemd directory exists
+  file:
+    path: "{{ systemd_dir_path }}"
+    state: directory
+    mode: 0775
+
+- name: Create systemd user service {{ service_file_path }} to run the script
+  template:
+    src: kstests-cloud.service.j2
+    dest: "{{ service_file_path }}"
+    mode: 0664
+
+- name: Create user timer {{ timer_file_path }} to run the service
+  template:
+    src: kstests-cloud.timer.j2
+    dest: "{{ timer_file_path }}"
+    mode: 0664
+
+- name: Restart the timer
+  systemd:
+    name: "{{ service_name }}.timer"
+    user: yes
+    state: restarted
+    enabled: yes
+    daemon_reload: yes

--- a/linchpin/roles/schedule/templates/kstests-cloud.service.j2
+++ b/linchpin/roles/schedule/templates/kstests-cloud.service.j2
@@ -1,0 +1,6 @@
+[Unit]
+Description=Run kickstart tests in cloud
+
+[Service]
+Type=simple
+ExecStart={{ run_script_dir_path }}/{{ run_script_name }}

--- a/linchpin/roles/schedule/templates/kstests-cloud.timer.j2
+++ b/linchpin/roles/schedule/templates/kstests-cloud.timer.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=Runs scheduled kickstart tests in cloud
+
+[Timer]
+OnCalendar={{ systemd_on_calendar }}
+Unit=kstests-cloud-{{ test_id }}.service
+
+[Install]
+WantedBy=default.target

--- a/linchpin/roles/schedule/templates/run_scheduled_tests.sh.j2
+++ b/linchpin/roles/schedule/templates/run_scheduled_tests.sh.j2
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+cd {{ run_script_dir_path }}
+
+# Activate virtualenv for linchpin
+source {{virtualenv_linchpin_path}}/bin/activate
+
+# Separator in the log
+echo "TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT" >> {{ log_file_name }}
+echo $(date) >> {{ log_file_name }}
+
+# Run the test
+./run_tests_in_cloud.sh 2>&1 | tee -a {{ log_file_name }}
+
+# Instead of running the test, to only check if linchpin is installed and set up correctly, you can use:
+#linchpin --version 2>&1 | tee -a {{ log_file_name }}

--- a/linchpin/roles/schedule/vars/main.yml
+++ b/linchpin/roles/schedule/vars/main.yml
@@ -1,0 +1,9 @@
+---
+run_script_name: run_scheduled_tests-{{ test_id }}.sh
+log_file_name: run_scheduled_tests-{{ test_id }}.log
+service_name: kstests-cloud-{{ test_id }}
+systemd_dir_path: "{{ ansible_env['HOME'] }}/.config/systemd/user"
+run_script_dir_path: "{{ git_repo_path | default(playbook_dir.split('/')[0:-1]|join('/')) }}"
+run_script_path: "{{ run_script_dir_path }}/{{ run_script_name }}"
+service_file_path: "{{ systemd_dir_path }}/{{ service_name }}.service"
+timer_file_path: "{{ systemd_dir_path }}/{{ service_name }}.timer"

--- a/linchpin/schedule_tests.yml
+++ b/linchpin/schedule_tests.yml
@@ -1,0 +1,9 @@
+---
+
+- hosts: localhost
+  become: false
+
+  roles:
+   - role: schedule
+     vars:
+       action: schedule


### PR DESCRIPTION
Create runner instances in cloud, run test, sync results, destroy runners.