### PR TITLE
Raise default hung_task_timeout_secs

### DIFF
--- a/scripts/launcher/lib/configuration.py
+++ b/scripts/launcher/lib/configuration.py
@@ -53,6 +53,7 @@ class RunnerConfiguration(object):
         self._keep_option = KeepLevel.NOTHING
         self._updates_img_path = ""
         self._append_host_id = False
+        self._hung_task_timeout_secs = 1200
 
     def _confiure_parser(self):
         self._parser.add_argument("kickstart_test", metavar="KS test controller",
@@ -110,6 +111,10 @@ class RunnerConfiguration(object):
     @property
     def append_host_id(self):
         return self._append_host_id
+
+    @property
+    def hung_task_timeout_secs(self):
+        return self._hung_task_timeout_secs
 
     def process_argument(self):
         ns = self._parser.parse_args()

--- a/scripts/launcher/run_one_test.py
+++ b/scripts/launcher/run_one_test.py
@@ -105,6 +105,10 @@ class Runner(object):
         if self._conf.updates_img_path:
             kernel_args += " inst.updates={}".format(self._conf.updates_img_path)
 
+        if self._conf.hung_task_timoeout_secs:
+            kernel_args += " inst.kernel.hung_task_timeout_secs={}".format(
+                self._conf.hung_task_timoeut_secs)
+
         disk_args = self._shell.prepare_disks()
         nics_args = self._shell.prepare_network()
         boot_args = self._shell.boot_args()


### PR DESCRIPTION
Use inst.kernel.hung_task_timeout_secs=1200 boot option by default.
So we don't kill tests we should let finish because of resources (IO)
starvation in VM.

Related: https://github.com/rhinstaller/anaconda/pull/1638