### PR TITLE
Bump default test timeout to 120 minutes

### DIFF
--- a/scripts/launcher/run_one_test.py
+++ b/scripts/launcher/run_one_test.py
@@ -126,7 +126,7 @@ class Runner(object):
         v_conf.log_path = os.path.join(self._tmp_dir, "livemedia.log")
         v_conf.vnc = "vnc"
         v_conf.boot_image = boot_args
-        v_conf.timeout = 60
+        v_conf.timeout = 120
         v_conf.disk_paths = disk_args
         v_conf.networks = nics_args
 


### PR DESCRIPTION
Turns out that some tests will take more than an hour to finish
on slower open stack worker with nested virtualisation.