### PR TITLE
Fixes for various kickstart tests

### DIFF
--- a/container.ks.in
+++ b/container.ks.in
@@ -36,7 +36,7 @@ if [[ $count -gt 0 ]]; then
 fi
 
 # (3) No authconfig or firewall packages should be installed.
-count=$(rpm -qa authconfig\* firewall\* | wc -l)
+count=$(rpm -qa authselect\* authconfig\* firewall\* | wc -l)
 if [[ $count -gt 0 ]]; then
     echo '*** No authconfig or firewall packages should have been installed' > /root/RESULT
     exit 1

--- a/fedora-live-image-build.ks.in
+++ b/fedora-live-image-build.ks.in
@@ -39,8 +39,7 @@ zerombr
 # Partition clearing information
 clearpart --all
 # Disk partitioning information
-part / --fstype="ext4" --size=5120
-part / --size=6656
+part / --fstype="ext4" --grow
 
 %post
 # FIXME: it'd be better to get this installed from a package
@@ -410,6 +409,18 @@ restorecon -R /home/liveuser/
 EOF
 
 %end
+
+
+%post
+
+# if we got this far the live image build itself did not fail
+#
+# TODO: some basic checks that the image looks fine
+
+echo SUCCESS > /root/RESULT
+
+%end
+
 
 %packages
 @anaconda-tools

--- a/scripts/launcher/lib/log_handler.py
+++ b/scripts/launcher/lib/log_handler.py
@@ -32,10 +32,12 @@ class VirtualLogRequestHandler(LogRequestHandler):
     simple_tests = LogRequestHandler.simple_tests + [
         "Payload setup error:",
         "Out of memory:",
-        "The following group or module is missing:",
+        "Would you like to ignore this and continue with installation?",
+        "Some packages, groups or modules are broken, the installation will be aborted.",
         "Stream was not specified for a module",
         "The following problem occurred on line",  # kickstart parsing error
         "storage configuration failed:",
+        "Not enough space in file systems for the current software selection.",
     ]
 
     def iserror(self, line):


### PR DESCRIPTION
- fix the Fedora live image test (bigger storage & write SUCCESS to result file)
- make the container test authselect aware
- catch some additional & new log messages in monitor