### PR TITLE
Adjust tests to module availability changes

### DIFF
--- a/module-enable-many.ks.in
+++ b/module-enable-many.ks.in
@@ -20,9 +20,9 @@ shutdown
 
 module --name=nodejs --stream=10
 module --name=django --stream=1.6
-module --name=postgresql --stream=9.6
+#module --name=postgresql --stream=9.6
 module --name=mysql --stream=5.7
-module --name=docker --stream=2017.0
+#module --name=docker --stream=2017.0
 module --name=gimp --stream=2.10
 
 %packages
@@ -58,25 +58,25 @@ if [[ $? == 0 ]]; then
     echo '*** python2-django for the only enabled django module installed' >> /root/RESULT
 fi
 
-rpm -q postgresql
-if [[ $? == 0 ]]; then
-    echo '*** postgresql for the only enabled postgresql module installed' >> /root/RESULT
-fi
+#rpm -q postgresql
+#if [[ $? == 0 ]]; then
+#    echo '*** postgresql for the only enabled postgresql module installed' >> /root/RESULT
+#fi
 
 rpm -q community-mysql
 if [[ $? == 0 ]]; then
     echo '*** community-mysql for the only enabled mysql module installed' >> /root/RESULT
 fi
 
-rpm -q docker
-if [[ $? == 0 ]]; then
-    echo '*** docker for the only enabled docker module installed' >> /root/RESULT
-fi
+#rpm -q docker
+#if [[ $? == 0 ]]; then
+#    echo '*** docker for the only enabled docker module installed' >> /root/RESULT
+#fi
 
-rpm -q docker-distribution
-if [[ $? == 0 ]]; then
-    echo '*** docker-community for only enabled the docker module installed' >> /root/RESULT
-fi
+#rpm -q docker-distribution
+#if [[ $? == 0 ]]; then
+#    echo '*** docker-community for only enabled the docker module installed' >> /root/RESULT
+#fi
 
 rpm -q gimp
 if [[ $? == 0 ]]; then
@@ -92,17 +92,17 @@ dnf module list
 # all installed modules should be also enabled
 dnf module list --enabled django | grep django || echo "django module not marked as enabled" >> /root/RESULT
 dnf module list --enabled nodejs | grep nodejs || echo "nodejs module not marked as enabled" >> /root/RESULT
-dnf module list --enabled postgresql | grep postgresql  || echo "postgresql module not marked as enabled" >> /root/RESULT
+#dnf module list --enabled postgresql | grep postgresql  || echo "postgresql module not marked as enabled" >> /root/RESULT
 dnf module list --enabled mysql | grep mysql || echo "mysql module not marked as enabled" >> /root/RESULT
-dnf module list --enabled docker | grep docker || echo "docker module not marked as enabled" >> /root/RESULT
+#dnf module list --enabled docker | grep docker || echo "docker module not marked as enabled" >> /root/RESULT
 dnf module list --enabled gimp | grep gimp || echo "gimp module not marked as enabled" >> /root/RESULT
 
 # check all modules are also marked as installed
 dnf module list --installed django | grep django && echo "django module marked as installed" >> /root/RESULT
 dnf module list --installed nodejs | grep nodejs && echo "nodejs module marked as installed" >> /root/RESULT
-dnf module list --installed postgresql | grep ostgresql && echo "postgresql module marked as installed" >> /root/RESULT
+#dnf module list --installed postgresql | grep ostgresql && echo "postgresql module marked as installed" >> /root/RESULT
 dnf module list --installed mysql | grep mysql && echo "mysql module marked as installed" >> /root/RESULT
-dnf module list --installed docker | grep docker && echo "docker module marked as installed" >> /root/RESULT
+#dnf module list --installed docker | grep docker && echo "docker module marked as installed" >> /root/RESULT
 dnf module list --installed gimp | grep gimp && echo "gimp module marked as installed" >> /root/RESULT
 
 if [ ! -f /root/RESULT ]
@@ -113,7 +113,5 @@ else
     # some errors happened
     exit 1
 fi
-
-
 
 %end

--- a/module-enable-one-module-multiple-streams.ks.in
+++ b/module-enable-one-module-multiple-streams.ks.in
@@ -6,9 +6,6 @@
 # current expected behavior
 # - fails with traceback when the module command is being processed
 #
-# dnf.module.exception.NoModuleException: No such module: nodejs:8
-#
-# - it's always nodejs:8 regardless of the order of module command ordering
 
 url @KSTEST_URL@
 repo --name=modular @KSTEST_MODULAR_URL@
@@ -27,8 +24,8 @@ timezone America/New_York
 rootpw qweqwe
 shutdown
 
-module --name=nodejs --stream=10
-module --name=nodejs --stream=8
+module --name=cri-o --stream=2018.0
+module --name=cri-o --stream=1.11
 
 %packages
 @^Fedora Server Edition
@@ -54,21 +51,20 @@ if [[ $? != 0 ]]; then
     echo '*** kernel package not installed' >> /root/RESULT
 fi
 
-# the nodejs module should be just enabled, so the API package should *not*
+# if we got this far the cri-o module should be just enabled, so the API package should *not*
 # be installed
 
-rpm -q nodejs
+rpm -q cri-o
 if [[ $? == 0 ]]; then
-    echo '*** nodejs package for nodejs module installed (module should be only enabled)' >> /root/RESULT
+    echo '*** cri-o package for cri-o module installed (module should be only enabled)' >> /root/RESULT
 fi
 
 # next we will check if the module is seen as enabled/installed from the
 # metadata/DNF point of view
-dnf module list --enabled nodejs | grep nodejs || echo "*** nodejs module not marked as enabled" >> /root/RESULT
-dnf module list --installed nodejs | grep nodejs && echo "*** nodejs module marked as installed (should be just enabled)" >> /root/RESULT
+dnf module list --enabled cri-o | grep cri-o || echo "*** cri-o module not marked as enabled" >> /root/RESULT
+dnf module list --installed cri-o | grep cri-o && echo "*** cri-o module marked as installed (should be just enabled)" >> /root/RESULT
 
-# check the stream
-dnf module list --enabled nodejs | grep "8 \[e\]" || echo "*** nodejs stream id 8 not marked as enabled" >> /root/RESULT
+dnf module list --enabled cri-o | grep "1.11 \[e\]" || echo "*** cri-o stream id 8 not marked as enabled" >> /root/RESULT
 
 if [ ! -f /root/RESULT ]
 then

--- a/module-enable-one-stream-install-different-stream.ks.in
+++ b/module-enable-one-stream-install-different-stream.ks.in
@@ -28,12 +28,11 @@ timezone America/New_York
 rootpw qweqwe
 shutdown
 
-module --name=nodejs --stream=10
+module --name=cri-o --stream=2018.0
 
 %packages
 @^Fedora Server Edition
-# lets use a no-default profile to see if it is correctly set afterwards
-@nodejs:8/development
+@cri-o:1.11/default
 kernel
 vim
 %end
@@ -56,18 +55,18 @@ if [[ $? != 0 ]]; then
 fi
 
 # module should be just enabled due to the miss-match
-rpm -q nodejs
+rpm -q cri-o
 if [[ $? != 0 ]]; then
-    echo '*** nodejs package for nodejs module should be installed' >> /root/RESULT
+    echo '*** cri-o package for cri-o module should be installed' >> /root/RESULT
 fi
 
 # next we will check if the module is seen as enabled/installed from the
 # metadata/DNF point of view
-dnf module list --enabled nodejs | grep nodejs || echo "*** nodejs module not marked as enabled" >> /root/RESULT
-dnf module list --installed nodejs | grep nodejs || echo "*** nodejs module not marked as installed" >> /root/RESULT
+dnf module list --enabled cri-o | grep cri-o || echo "*** cri-o module not marked as enabled" >> /root/RESULT
+dnf module list --installed cri-o | grep cri-o || echo "*** cri-o module not marked as installed" >> /root/RESULT
 
 # check the stream
-dnf module list --enabled nodejs | grep "8 \[e\]" || echo "*** nodejs stream id 8 not marked as enabled (stream id from packages section should win)" >> /root/RESULT
+dnf module list --enabled cri-o | grep "2018.0 \[e\]" || echo "*** cri-o stream id 2018.0 not marked as enabled (stream id from packages section should win)" >> /root/RESULT
 
 if [ ! -f /root/RESULT ]
 then

--- a/module-install-4.ks.in
+++ b/module-install-4.ks.in
@@ -2,7 +2,8 @@
 #
 # generic module install test:
 # - enable one module with a stream
-# - install the same module with a different stream
+# - install the same module with the same stream
+# (enabling one stream and installing a different one is an error)
 
 url @KSTEST_URL@
 repo --name=modular @KSTEST_MODULAR_URL@
@@ -21,12 +22,11 @@ timezone America/New_York
 rootpw qweqwe
 shutdown
 
-module --name=nodejs --stream=10
+module --name=cri-o --stream=1.11
 
 %packages
 @^Fedora Server Edition
-# lets use a no-default profile to see if it is correctly set afterwards
-@nodejs:8/development
+@cri-o:1.11/default
 kernel
 vim
 %end
@@ -48,21 +48,25 @@ if [[ $? != 0 ]]; then
     echo '*** kernel package not installed' >> /root/RESULT
 fi
 
-# the nodejs module should be just enabled, so the API package should *not*
-# be installed
-
-rpm -q nodejs
+rpm -q cri-o
 if [[ $? != 0 ]]; then
-    echo '*** nodejs package for nodejs module not installed' >> /root/RESULT
+    echo '*** cri-o package for cri-o module not installed' >> /root/RESULT
+fi
+
+rpm -q cri-tools
+if [[ $? != 0 ]]; then
+    echo '*** cri-tools package for cri-o module not installed' >> /root/RESULT
 fi
 
 # next we will check if the module is seen as enabled/installed from the
 # metadata/DNF point of view
-dnf module list --enabled nodejs | grep nodejs || echo "*** nodejs module not marked as enabled" >> /root/RESULT
-dnf module list --installed nodejs | grep nodejs || echo "*** nodejs module not marked as installed" >> /root/RESULT
+dnf module list --enabled cri-o | grep cri-o || echo "*** cri-o module not marked as enabled" >> /root/RESULT
+dnf module list --installed cri-o | grep cri-o || echo "*** cri-o module not marked as installed" >> /root/RESULT
 
 # check the stream and profile as well
-dnf module list --installed nodejs | grep "development \[i\]" || echo "*** nodejs module development profile not marked as installed" >> /root/RESULT
+# - commented out due to DNF output breakage, see:
+#   https://bugzilla.redhat.com/show_bug.cgi?id=1602028#c1
+#dnf module list --installed cri-o | grep "default \[i\]" || echo "*** cri-o module default profile not marked as installed" >> /root/RESULT
 
 if [ ! -f /root/RESULT ]
 then

--- a/module-install-4.sh
+++ b/module-install-4.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
-TESTTYPE="packaging modularity fedora-only
+TESTTYPE="packaging modularity fedora-only"
 
 . ${KSTESTDIR}/functions.sh

--- a/module-install-many.ks.in
+++ b/module-install-many.ks.in
@@ -22,7 +22,8 @@ shutdown
 @^Fedora Server Edition
 @nodejs:10/default
 @django:1.6/default
-@postgresql:9.6/default
+#@postgresql:9.6/default
+#@mariadb:10.1/default
 @mysql:5.7/default
 @scala:2.10/default
 @gimp:2.10/default
@@ -57,10 +58,20 @@ if [[ $? != 0 ]]; then
     echo '*** python2-django for the django module not installed' >> /root/RESULT
 fi
 
-rpm -q postgresql
-if [[ $? != 0 ]]; then
-    echo '*** postgresql for the postgresql module not installed' >> /root/RESULT
-fi
+#rpm -q postgresql
+#if [[ $? != 0 ]]; then
+#    echo '*** postgresql for the postgresql module not installed' >> /root/RESULT
+#fi
+
+#rpm -q mariadb
+#if [[ $? != 0 ]]; then
+#    echo '*** mariadb for the mariadb module not installed' >> /root/RESULT
+#fi
+
+#rpm -q mariadb-server
+#if [[ $? != 0 ]]; then
+#    echo '*** mariadb-server for the mariadb module not installed' >> /root/RESULT
+#fi
 
 rpm -q community-mysql
 if [[ $? != 0 ]]; then
@@ -86,7 +97,8 @@ dnf module list
 # all installed modules should be also enabled
 dnf module list --enabled django | grep django || echo "*** django module not marked as enabled" >> /root/RESULT
 dnf module list --enabled nodejs | grep nodejs || echo "*** nodejs module not marked as enabled" >> /root/RESULT
-dnf module list --enabled postgresql | grep postgresql  || echo "*** postgresql module not marked as enabled" >> /root/RESULT
+#dnf module list --enabled postgresql | grep postgresql  || echo "*** postgresql module not marked as enabled" >> /root/RESULT
+#dnf module list --enabled mariadb | grep mariadb || echo "*** mariadb module not marked as enabled" >> /root/RESULT
 dnf module list --enabled mysql | grep mysql || echo "*** mysql module not marked as enabled" >> /root/RESULT
 dnf module list --enabled scala | grep scala  || echo "*** scala module not marked as enabled" >> /root/RESULT
 dnf module list --enabled gimp | grep gimp  || echo "*** gimp module not marked as enabled" >> /root/RESULT
@@ -94,11 +106,20 @@ dnf module list --enabled gimp | grep gimp  || echo "*** gimp module not marked 
 # check all modules are also marked as installed
 dnf module list --installed django | grep django || echo "*** django module not marked as installed" >> /root/RESULT
 dnf module list --installed nodejs | grep nodejs || echo "*** nodejs module not marked as installed" >> /root/RESULT
-dnf module list --installed postgresql | grep postgresql  || echo "*** postgresql module not marked as installed" >> /root/RESULT
+#dnf module list --installed postgresql | grep postgresql  || echo "*** postgresql module not marked as installed" >> /root/RESULT
+#dnf module list --installed mariadb | grep mariadb || echo "*** mariadb module not marked as installed" >> /root/RESULT
 dnf module list --installed mysql | grep mysql || echo "*** mysql module not marked as installed" >> /root/RESULT
 dnf module list --installed scala | grep scala  || echo "*** scala module not marked as installed" >> /root/RESULT
 dnf module list --installed gimp | grep gimp  || echo "*** gimp module not marked as installed" >> /root/RESULT
 
+# check the stream and profile as well
+dnf module list --installed django | grep "default \[i\]" || echo "*** django module default profile not marked as installed" >> /root/RESULT
+dnf module list --installed nodejs | grep "default \[i\]" || echo "*** nodejs module default profile not marked as installed" >> /root/RESULT
+#dnf module list --installed postgresq | grep "default \[i\]" || echo "*** postgresql module default profile not marked as installed" >> /root/RESULT
+#dnf module list --installed mariadb | grep "default \[i\]" || echo "*** mariadb module default profile not marked as installed" >> /root/RESULT
+dnf module list --installed mysql | grep "default \[i\]" || echo "*** mysql module default profile not marked as installed" >> /root/RESULT
+dnf module list --installed scala grep "default \[i\]" || echo "*** scala module default profile not marked as installed" >> /root/RESULT
+dnf module list --installed gimp | grep "default \[i\]" || echo "*** gimp module default profile not marked as installed" >> /root/RESULT
 
 if [ ! -f /root/RESULT ]
 then

--- a/module-install-no-stream-no-profile.ks.in
+++ b/module-install-no-stream-no-profile.ks.in
@@ -25,7 +25,7 @@ shutdown
 kernel
 vim
 @nodejs
-@postgresql
+#@postgresql
 @mongodb
 @mysql
 @gimp
@@ -58,15 +58,15 @@ if [[ $? == 0 ]]; then
     echo '*** nodejs-devel for module nodejs default profile installed' >> /root/RESULT
 fi
 
-rpm -q postgresql-server
-if [[ $? != 0 ]]; then
-    echo '*** postgresql-server for the postgresql module default profile not installed' >> /root/RESULT
-fi
+#rpm -q postgresql-server
+#if [[ $? != 0 ]]; then
+#    echo '*** postgresql-server for the postgresql module default profile not installed' >> /root/RESULT
+#fi
 
-rpm -q postgresql
-if [[ $? == 0 ]]; then
-    echo '*** postgresql for the postgresql module default profile installed' >> /root/RESULT
-fi
+#rpm -q postgresql
+#if [[ $? == 0 ]]; then
+#    echo '*** postgresql for the postgresql module default profile installed' >> /root/RESULT
+#fi
 
 rpm -q mongodb-server
 if [[ $? != 0 ]]; then
@@ -106,14 +106,14 @@ dnf module list
 
 # all installed modules should be also enabled
 dnf module list --enabled nodejs | grep nodejs || echo "nodejs module not marked as enabled" >> /root/RESULT
-dnf module list --enabled postgresql | grep postgresql  || echo "postgresql module not marked as enabled" >> /root/RESULT
+#dnf module list --enabled postgresql | grep postgresql  || echo "postgresql module not marked as enabled" >> /root/RESULT
 dnf module list --enabled mongodb | grep mongodb  || echo "mongodb module not marked as enabled" >> /root/RESULT
 dnf module list --enabled mysql | grep mysql || echo "mysql module not marked as enabled" >> /root/RESULT
 dnf module list --enabled gimp | grep gimp || echo "gimp module not marked as enabled" >> /root/RESULT
 
 # check all modules are also marked as installed with the correct profile
 dnf module list --installed nodejs | grep "default \[i\]" && echo "nodejs module profile not marked as installed" >> /root/RESULT
-dnf module list --installed postgresql | grep "default \[i\]" && echo "postgresql module profile not marked as installed" >> /root/RESULT
+#dnf module list --installed postgresql | grep "default \[i\]" && echo "postgresql module profile not marked as installed" >> /root/RESULT
 dnf module list --installed mongodb | grep "default \[i\]" && echo "mongodb profile not marked as installed" >> /root/RESULT
 dnf module list --installed mysql | grep "default \[i\]" && echo "mysql module profile not marked as installed" >> /root/RESULT
 dnf module list --installed gimp | grep "default \[i\]"&& echo "gimp module profile not marked as installed" >> /root/RESULT

--- a/module-install-one-module-multiple-streams-and-profiles.ks.in
+++ b/module-install-one-module-multiple-streams-and-profiles.ks.in
@@ -25,8 +25,8 @@ shutdown
 %packages
 @^Fedora Server Edition
 # lets use a no-default profile to see if it is correctly set afterwards
-@nodejs:10/default
-@nodejs:8/development
+@cri-o:2018.0/default
+@cri-o:1.11/default
 kernel
 vim
 %end
@@ -48,24 +48,24 @@ if [[ $? != 0 ]]; then
     echo '*** kernel package not installed' >> /root/RESULT
 fi
 
-# the nodejs module should be just enabled, so the API package should *not*
+# the cri-o module should be just enabled, so the API package should *not*
 # be installed
 
-rpm -q nodejs
+rpm -q cri-o
 if [[ $? != 0 ]]; then
-    echo '*** nodejs package for nodejs module not installed' >> /root/RESULT
+    echo '*** cri-o package for cri-o module not installed' >> /root/RESULT
 fi
 
 # next we will check if the module is seen as enabled/installed from the
 # metadata/DNF point of view
-dnf module list --enabled nodejs | grep nodejs || echo "*** nodejs module not marked as enabled" >> /root/RESULT
-dnf module list --installed nodejs | grep nodejs || echo "*** nodejs module not marked as installed" >> /root/RESULT
+dnf module list --enabled cri-o | grep cri-o || echo "*** cri-o module not marked as enabled" >> /root/RESULT
+dnf module list --installed cri-o | grep cri-o || echo "*** cri-o module not marked as installed" >> /root/RESULT
 
 # check the stream
-dnf module list --installed nodejs | grep "default \[i\]" || echo "*** nodejs module default profile not marked as installed" >> /root/RESULT
+dnf module list --installed cri-o | grep "default \[i\]" || echo "*** cri-o module default profile not marked as installed" >> /root/RESULT
 
 # check the stream
-dnf module list --installed nodejs | grep "10 \[e\]" || echo "*** nodejs stream id 10 not marked as enabled" >> /root/RESULT
+dnf module list --installed cri-o | grep "1.11 \[e\]" || echo "*** cri-o stream id 1.11 not marked as enabled" >> /root/RESULT
 
 if [ ! -f /root/RESULT ]
 then

--- a/module-install-one-module-multiple-streams.ks.in
+++ b/module-install-one-module-multiple-streams.ks.in
@@ -3,9 +3,10 @@
 # specify one module in packages section twice with different streams
 #
 # expected result
-# - apparently no crash
-# - highest stream id apparently takes prefference
-#   (which is weird as stream ids should not be comparable for higher/lower)
+# - crash ?
+# - if no crash the I guess the last seen module spec
+#   (we forward the specs to DNF in order), anything else
+#   would be black magic
 
 url @KSTEST_URL@
 repo --name=modular @KSTEST_MODULAR_URL@
@@ -27,8 +28,8 @@ shutdown
 %packages
 @^Fedora Server Edition
 # lets use a no-default profile to see if it is correctly set afterwards
-@nodejs:8/default
-@nodejs:10/default
+@avocado:latest/default
+@avocado:stable/default
 kernel
 vim
 %end
@@ -50,24 +51,21 @@ if [[ $? != 0 ]]; then
     echo '*** kernel package not installed' >> /root/RESULT
 fi
 
-# the nodejs module should be just enabled, so the API package should *not*
-# be installed
-
-rpm -q nodejs
+rpm -q python2-avocado
 if [[ $? != 0 ]]; then
-    echo '*** nodejs package for nodejs module not installed' >> /root/RESULT
+    echo '*** python2-avocado package for avocado module not installed' >> /root/RESULT
 fi
 
 # next we will check if the module is seen as enabled/installed from the
 # metadata/DNF point of view
-dnf module list --enabled nodejs | grep nodejs || echo "*** nodejs module not marked as enabled" >> /root/RESULT
-dnf module list --installed nodejs | grep nodejs || echo "*** nodejs module not marked as installed" >> /root/RESULT
+dnf module list --enabled avocado | grep avocado || echo "*** avocado module not marked as enabled" >> /root/RESULT
+dnf module list --installed avocado | grep avocado || echo "*** avocado module not marked as installed" >> /root/RESULT
 
 # check the stream
-dnf module list --installed nodejs | grep "default \[i\]" || echo "*** nodejs module default profile not marked as installed" >> /root/RESULT
+dnf module list --installed avocado | grep "default \[i\]" || echo "*** avocado module default profile not marked as installed" >> /root/RESULT
 
 # check the stream
-dnf module list --installed nodejs | grep "10 \[e\]" || echo "*** nodejs stream id 10 not marked as enabled" >> /root/RESULT
+dnf module list --installed avocado | grep "stable \[e\]" || echo "*** avocado stream stable not marked as enabled" >> /root/RESULT
 
 if [ ! -f /root/RESULT ]
 then

--- a/module-install-without-profile.ks.in
+++ b/module-install-without-profile.ks.in
@@ -25,8 +25,8 @@ shutdown
 kernel
 vim
 @nodejs:10
-@postgresql:9.6
-@mongodb:3.4
+#@postgresql:9.6
+@mongodb:3.6
 @mysql:5.7
 @gimp:2.10
 %end
@@ -58,10 +58,10 @@ if [[ $? == 0 ]]; then
     echo '*** nodejs-devel for module nodejs default profile installed' >> /root/RESULT
 fi
 
-rpm -q postgresql-server
-if [[ $? != 0 ]]; then
-    echo '*** postgresql-server for the postgresql module default profile not installed' >> /root/RESULT
-fi
+#rpm -q postgresql-server
+#if [[ $? != 0 ]]; then
+#    echo '*** postgresql-server for the postgresql module default profile not installed' >> /root/RESULT
+#fi
 
 rpm -q mongodb-server
 if [[ $? != 0 ]]; then
@@ -101,14 +101,14 @@ dnf module list
 
 # all installed modules should be also enabled
 dnf module list --enabled nodejs | grep nodejs || echo "*** nodejs module not marked as enabled" >> /root/RESULT
-dnf module list --enabled postgresql | grep postgresql  || echo "*** postgresql module not marked as enabled" >> /root/RESULT
+#dnf module list --enabled postgresql | grep postgresql  || echo "*** postgresql module not marked as enabled" >> /root/RESULT
 dnf module list --enabled mongodb | grep mongodb  || echo "*** mongodb module not marked as enabled" >> /root/RESULT
 dnf module list --enabled mysql | grep mysql || echo "*** mysql module not marked as enabled" >> /root/RESULT
 dnf module list --enabled gimp | grep gimp || echo "*** gimp module not marked as enabled" >> /root/RESULT
 
 # check all modules are also marked as installed with the correct profile
 dnf module list --installed nodejs | grep "default \[i\]" || echo "*** nodejs module profile not marked as installed" >> /root/RESULT
-dnf module list --installed postgresql | grep "default \[i\]" || echo "*** postgresql module profile not marked as installed" >> /root/RESULT
+#dnf module list --installed postgresql | grep "default \[i\]" || echo "*** postgresql module profile not marked as installed" >> /root/RESULT
 dnf module list --installed mongodb | grep "default \[i\]" || echo "*** mongodb profile not marked as installed" >> /root/RESULT
 dnf module list --installed mysql | grep "default \[i\]" || echo "*** mysql module profile not marked as installed" >> /root/RESULT
 dnf module list --installed gimp | grep "default \[i\]" || echo "*** gimp module profile not marked as installed" >> /root/RESULT

--- a/module-non-default-profiles.ks.in
+++ b/module-non-default-profiles.ks.in
@@ -23,8 +23,8 @@ shutdown
 kernel
 vim
 @nodejs:10/development
-@postgresql:9.6/server
-@mongodb:3.4/server
+#@postgresql:9.6/server
+@mongodb:3.6/server
 @mysql:5.7/server
 @gimp:2.10/devel
 %end
@@ -56,10 +56,10 @@ if [[ $? != 0 ]]; then
     echo '*** nodejs-devel for module nodejs profile development not installed' >> /root/RESULT
 fi
 
-rpm -q postgresql-server
-if [[ $? != 0 ]]; then
-    echo '*** postgresql-server for the postgresql module profile server not installed' >> /root/RESULT
-fi
+#rpm -q postgresql-server
+#if [[ $? != 0 ]]; then
+#    echo '*** postgresql-server for the postgresql module profile server not installed' >> /root/RESULT
+#fi
 
 rpm -q mongodb-server
 if [[ $? != 0 ]]; then
@@ -89,19 +89,17 @@ dnf module list
 
 # all installed modules should be also enabled
 dnf module list --enabled nodejs | grep nodejs || echo "*** nodejs module not marked as enabled" >> /root/RESULT
-dnf module list --enabled postgresql | grep postgresql  || echo "*** postgresql module not marked as enabled" >> /root/RESULT
+#dnf module list --enabled postgresql | grep postgresql  || echo "*** postgresql module not marked as enabled" >> /root/RESULT
 dnf module list --enabled mongodb | grep mongodb  || echo "*** mongodb module not marked as enabled" >> /root/RESULT
 dnf module list --enabled mysql | grep mysql || echo "*** mysql module not marked as enabled" >> /root/RESULT
 dnf module list --enabled gimp | grep gimp || echo "*** gimp module not marked as enabled" >> /root/RESULT
 
 # check all modules are also marked as installed with the correct profile
 dnf module list --installed nodejs | grep "development \[i\]" || echo "*** nodejs module profile development not marked as installed" >> /root/RESULT
-# the following profiles can't be checked due to an elide bug in DNF output
-# https://bugzilla.redhat.com/show_bug.cgi?id=1602017
-#dnf module list --installed mongodb | grep "server \[i\]" || echo "*** mongodb profile server not marked as installed" >> /root/RESULT
-#dnf module list --installed mysql | grep "server \[i\]" || echo "*** mysql module profile server not marked as installed" >> /root/RESULT
+dnf module list --installed mongodb | grep "server \[i\]" || echo "*** mongodb profile server not marked as installed" >> /root/RESULT
+dnf module list --installed mysql | grep "server \[i\]" || echo "*** mysql module profile server not marked as installed" >> /root/RESULT
 #dnf module list --installed postgresql | grep "server \[i\]" || echo "*** postgresql module profile server not marked as installed" >> /root/RESULT
-#dnf module list --installed gimp | grep "devel \[i\]" || echo "*** gimp module profile devel not marked as installed" >> /root/RESULT
+dnf module list --installed gimp | grep "devel \[i\]" || echo "*** gimp module profile devel not marked as installed" >> /root/RESULT
 
 if [ ! -f /root/RESULT ]
 then

--- a/scripts/launcher/lib/log_handler.py
+++ b/scripts/launcher/lib/log_handler.py
@@ -35,6 +35,7 @@ class VirtualLogRequestHandler(LogRequestHandler):
         "Would you like to ignore this and continue with installation?",
         "Some packages, groups or modules are broken, the installation will be aborted.",
         "Stream was not specified for a module",
+        "Modular dependency problem:",  # broken module
         "The following problem occurred on line",  # kickstart parsing error
         "storage configuration failed:",
         "Not enough space in file systems for the current software selection.",


### PR DESCRIPTION
The 8 stream for the nodejs module was apparently dropped and the
nodejs no longer has two streams, which is something we need for
testing.

So switch to the avocado modules in such cases, which (as only module
in Rawhide at the moment) has two streams (stable & latest) available.

Some other modules & streams have changed or been dropped since the tests have
been initially created so adjust them accordingly.

There are also few modules that are apparently broken at the moment
in Rawhide and had to be disabled in the tests for now:

- postgres
- mariadb
- docker

Also we can't currently verify of profiles are correctly installed
for the cri-o module due to a bug in how DNF formats its output.