### PR TITLE
Don't remove old images on remotes

### DIFF
--- a/scripts/run_kickstart_tests.sh
+++ b/scripts/run_kickstart_tests.sh
@@ -331,8 +331,6 @@ if [[ "$TEST_REMOTES" != "" ]]; then
         rsync -az --delete . kstest@${remote}:kickstart-tests/
         echo "synchronizing installation image"
         rsync -az ${IMAGE} kstest@${remote}:install_images/
-        # remove any old images
-        ssh kstest@${remote} find install_images -type f ! -name ${_IMAGE} -delete
     done
 
     # (1a) We also need to copy the provided image to under kickstart_tests/ on


### PR DESCRIPTION
Turns out it's better to handle by other means rather then in the
runner script. Images can be cleaned up via Ansible or the remote
can be re-created for each test run.

This way we can also easily run tests on different Fedora & RHEL
versions without having to first download the respective images
before each run.