### PR TITLE
Add support for using %ksappend in kickstart tests & make packaging tests use it

### DIFF
--- a/container.ks.in
+++ b/container.ks.in
@@ -1,19 +1,18 @@
 #version=DEVEL
 #test name: container
-url @KSTEST_URL@
-install
-network --bootproto=dhcp
+
+%ksappend repos/default.ks
 
 bootloader --disabled
-zerombr
-clearpart --all --initlabel
-autopart
-
-keyboard us
-lang en_US.UTF-8
-timezone America/New_York --utc
+# the container testcase requires custom
+# bootloader configuration so we use
+# individual fragments here
+%ksappend common/common.ks
+%ksappend l10n/default.ks
+%ksappend users/default.ks
+%ksappend network/default.ks
+%ksappend storage/default.ks
 rootpw testcase
-shutdown
 
 %packages --nocore
 -kernel
@@ -51,7 +50,6 @@ if [[ $count -gt 200 ]]; then
     exit 1
 fi
 
-if [ ! -e /root/RESULT ]; then
-    echo SUCCESS > /root/RESULT
-fi
+%ksappend validation/success_if_result_empty.ks
+
 %end

--- a/fedora-live-image-build.ks.in
+++ b/fedora-live-image-build.ks.in
@@ -2,7 +2,11 @@
 # - for now just having it run to the end with all of its
 #   complex post scripts should be enough
 
-url @KSTEST_URL@
+# We only use the repository fragment, as the
+# rest of the kickstart is basically 1:1 taken
+# from the Fedora live image creation kickstart
+# so we should keep it as close as possible.
+%ksappend repos/default.ks
 
 #version=DEVEL
 # X Window System configuration information

--- a/fragments/platform/fedora_rawhide/payload/default_packages.ks
+++ b/fragments/platform/fedora_rawhide/payload/default_packages.ks
@@ -1,0 +1,3 @@
+# Default Fedora packages section (empty)
+%packages
+%end

--- a/fragments/platform/fedora_rawhide/repos/default.ks
+++ b/fragments/platform/fedora_rawhide/repos/default.ks
@@ -1,0 +1,3 @@
+# Default Fedora Rawhide repositories
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-rawhide&arch=$basearch
+repo --name=modular --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=rawhide-modular&arch=$basearch

--- a/fragments/shared/bootloader/default.ks
+++ b/fragments/shared/bootloader/default.ks
@@ -1,0 +1,2 @@
+# Default bootloader configuration
+bootloader --timeout=1

--- a/fragments/shared/common/common.ks
+++ b/fragments/shared/common/common.ks
@@ -1,0 +1,3 @@
+# Commands needed by most kickstart tests to run correctly
+install
+shutdown

--- a/fragments/shared/common/common_no_payload.ks
+++ b/fragments/shared/common/common_no_payload.ks
@@ -1,0 +1,17 @@
+## common commands without payload configuration ##
+install
+shutdown
+# network
+network --bootproto=dhcp
+# storage & bootloader
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+# l10n
+keyboard us
+lang en
+timezone America/New_York
+# user confguration
+rootpw testcase
+## common commands without payload configuration - end ##

--- a/fragments/shared/l10n/default.ks
+++ b/fragments/shared/l10n/default.ks
@@ -1,0 +1,4 @@
+# Default l10n configuration
+keyboard us
+lang en_US.UTF-8
+timezone America/New_York --utc

--- a/fragments/shared/network/default.ks
+++ b/fragments/shared/network/default.ks
@@ -1,0 +1,2 @@
+# Default network configuration
+network --bootproto=dhcp

--- a/fragments/shared/payload/default_packages.ks
+++ b/fragments/shared/payload/default_packages.ks
@@ -1,0 +1,3 @@
+# Default package selection
+%packages
+%end

--- a/fragments/shared/storage/default.ks
+++ b/fragments/shared/storage/default.ks
@@ -1,0 +1,5 @@
+# Default storage configuration
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart

--- a/fragments/shared/users/default.ks
+++ b/fragments/shared/users/default.ks
@@ -1,0 +1,2 @@
+# Default user configuration
+rootpw testcase

--- a/fragments/shared/validation/success_if_result_empty.ks
+++ b/fragments/shared/validation/success_if_result_empty.ks
@@ -1,0 +1,9 @@
+# Report success if no errors have been reported to /root/RESULT
+if [ ! -f /root/RESULT ]
+then
+    # no result file (no errors) -> success
+    echo SUCCESS > /root/RESULT
+else
+    # some errors happened
+    exit 1
+fi

--- a/groups-and-envs-1.ks.in
+++ b/groups-and-envs-1.ks.in
@@ -1,18 +1,7 @@
 #test name: groups-and-envs-1
-url @KSTEST_URL@
-install
-network --bootproto=dhcp
 
-bootloader --timeout=1
-zerombr
-clearpart --all
-autopart
-
-keyboard us
-lang en
-timezone America/New_York
-rootpw qweqwe
-shutdown
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 %packages
 @core

--- a/groups-and-envs-2.ks.in
+++ b/groups-and-envs-2.ks.in
@@ -5,20 +5,9 @@
 #   (this could be important for multiple ksincluded %packages sections)
 # - that the --optional flag for package groups is working
 # - that the --nodefaults flag for package groups is working
-url @KSTEST_URL@
-install
-network --bootproto=dhcp
 
-bootloader --timeout=1
-zerombr
-clearpart --all
-autopart
-
-keyboard us
-lang en
-timezone America/New_York
-rootpw qweqwe
-shutdown
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 %packages
 # (1) Test that you can remove a group that's part of an environment.
@@ -87,13 +76,6 @@ else
     fi
 fi
 
-if [ ! -f /root/RESULT ]
-then
-    # no result file (no errors) -> success
-    echo SUCCESS > /root/RESULT
-else
-    # some errors happened
-    exit 1
-fi
+%ksappend validation/success_if_result_empty.ks
 
 %end

--- a/groups-and-envs-3.ks.in
+++ b/groups-and-envs-3.ks.in
@@ -1,19 +1,8 @@
 #version=DEVEL
 #test name: groups-and-envs-3
-url @KSTEST_URL@
-install
-network --bootproto=dhcp
 
-bootloader --timeout=1
-zerombr
-clearpart --all --initlabel
-autopart
-
-keyboard us
-lang en_US.UTF-8
-timezone America/New_York --utc
-rootpw testcase
-shutdown
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 %packages
 @container-management

--- a/groups-ignoremissing.ks.in
+++ b/groups-ignoremissing.ks.in
@@ -4,20 +4,9 @@
 # what we are testing there:
 # - that missing groups are ignored if --ignoremissing is used
 # - that such an installation finishes successfully
-url @KSTEST_URL@
-install
-network --bootproto=dhcp
 
-bootloader --timeout=1
-zerombr
-clearpart --all --initlabel
-autopart
-
-keyboard us
-lang en_US.UTF-8
-timezone America/New_York --utc
-rootpw testcase
-shutdown
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 %packages --ignoremissing
 @fake-group-name

--- a/module-enable-many.ks.in
+++ b/module-enable-many.ks.in
@@ -2,21 +2,8 @@
 #
 # test enabling many different modules at once
 
-url @KSTEST_URL@
-repo --name=modular @KSTEST_MODULAR_URL@
-install
-network --bootproto=dhcp
-
-bootloader --timeout=1
-zerombr
-clearpart --all
-autopart
-
-keyboard us
-lang en
-timezone America/New_York
-rootpw qweqwe
-shutdown
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 module --name=nodejs --stream=10
 module --name=django --stream=1.6
@@ -105,13 +92,5 @@ dnf module list --installed mysql | grep mysql && echo "mysql module marked as i
 #dnf module list --installed docker | grep docker && echo "docker module marked as installed" >> /root/RESULT
 dnf module list --installed gimp | grep gimp && echo "gimp module marked as installed" >> /root/RESULT
 
-if [ ! -f /root/RESULT ]
-then
-    # no result file (no errors) -> success
-    echo SUCCESS > /root/RESULT
-else
-    # some errors happened
-    exit 1
-fi
-
+%ksappend validation/success_if_result_empty.ks
 %end

--- a/module-enable-one-module-multiple-streams.ks.in
+++ b/module-enable-one-module-multiple-streams.ks.in
@@ -7,22 +7,8 @@
 # - fails with traceback when the module command is being processed
 #
 
-url @KSTEST_URL@
-repo --name=modular @KSTEST_MODULAR_URL@
-
-install
-network --bootproto=dhcp
-
-bootloader --timeout=1
-zerombr
-clearpart --all
-autopart
-
-keyboard us
-lang en
-timezone America/New_York
-rootpw qweqwe
-shutdown
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 module --name=cri-o --stream=2018.0
 module --name=cri-o --stream=1.11

--- a/module-enable-one-module-multiple-times.ks.in
+++ b/module-enable-one-module-multiple-times.ks.in
@@ -3,22 +3,8 @@
 # try enabling one module multiple times
 # - with same stream spec
 
-url @KSTEST_URL@
-repo --name=modular @KSTEST_MODULAR_URL@
-
-install
-network --bootproto=dhcp
-
-bootloader --timeout=1
-zerombr
-clearpart --all
-autopart
-
-keyboard us
-lang en
-timezone America/New_York
-rootpw qweqwe
-shutdown
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 module --name=nodejs --stream=10
 module --name=nodejs --stream=10

--- a/module-enable-one-stream-install-different-stream.ks.in
+++ b/module-enable-one-stream-install-different-stream.ks.in
@@ -11,22 +11,8 @@
 # This test is basically checking the current behavior holds that we can catch any changes,
 # both intended and unintended.
 
-url @KSTEST_URL@
-repo --name=modular @KSTEST_MODULAR_URL@
-
-install
-network --bootproto=dhcp
-
-bootloader --timeout=1
-zerombr
-clearpart --all
-autopart
-
-keyboard us
-lang en
-timezone America/New_York
-rootpw qweqwe
-shutdown
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 module --name=cri-o --stream=2018.0
 

--- a/module-ignoremissing.ks.in
+++ b/module-ignoremissing.ks.in
@@ -4,20 +4,9 @@
 # what we are testing there:
 # - that missing modules are ignored if --ignoremissing is used
 # - that such an installation finishes successfully
-url @KSTEST_URL@
-install
-network --bootproto=dhcp
 
-bootloader --timeout=1
-zerombr
-clearpart --all --initlabel
-autopart
-
-keyboard us
-lang en_US.UTF-8
-timezone America/New_York --utc
-rootpw testcase
-shutdown
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 %packages --ignoremissing
 @fake-module:fakestream/fakeprofile

--- a/module-install-1.ks.in
+++ b/module-install-1.ks.in
@@ -4,22 +4,8 @@
 # - enable one module
 # - install a second module
 
-url @KSTEST_URL@
-repo --name=modular @KSTEST_MODULAR_URL@
-
-install
-network --bootproto=dhcp
-
-bootloader --timeout=1
-zerombr
-clearpart --all
-autopart
-
-keyboard us
-lang en
-timezone America/New_York
-rootpw qweqwe
-shutdown
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 module --name=nodejs --stream=10
 
@@ -68,15 +54,6 @@ dnf module list --enabled nodejs | grep nodejs || echo "*** nodejs module not ma
 dnf module list --enabled django | grep django || echo "*** django module not marked as enabled" >> /root/RESULT
 dnf module list --installed django | grep django || echo "*** django module not marked as installed" >> /root/RESULT
 
-if [ ! -f /root/RESULT ]
-then
-    # no result file (no errors) -> success
-    echo SUCCESS > /root/RESULT
-else
-    # some errors happened
-    exit 1
-fi
-
-
+%ksappend validation/success_if_result_empty.ks
 
 %end

--- a/module-install-2.ks.in
+++ b/module-install-2.ks.in
@@ -4,8 +4,8 @@
 # - enable one module (different one this time)
 # - install a second module (different one this time)
 
-url @KSTEST_URL@
-repo --name=modular @KSTEST_MODULAR_URL@
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 install
 network --bootproto=dhcp
@@ -68,15 +68,6 @@ dnf module list --enabled django | grep django || echo "*** django module not ma
 dnf module list --enabled nodejs | grep nodejs || echo "*** nodejs module not marked as enabled" >> /root/RESULT
 dnf module list --installed nodejs | grep nodejs || echo "*** nodejs module not marked as installed" >> /root/RESULT
 
-if [ ! -f /root/RESULT ]
-then
-    # no result file (no errors) -> success
-    echo SUCCESS > /root/RESULT
-else
-    # some errors happened
-    exit 1
-fi
-
-
+%ksappend validation/success_if_result_empty.ks
 
 %end

--- a/module-install-3.ks.in
+++ b/module-install-3.ks.in
@@ -4,22 +4,8 @@
 # - enable one module with a stream
 # - install the same module with same stream
 
-url @KSTEST_URL@
-repo --name=modular @KSTEST_MODULAR_URL@
-
-install
-network --bootproto=dhcp
-
-bootloader --timeout=1
-zerombr
-clearpart --all
-autopart
-
-keyboard us
-lang en
-timezone America/New_York
-rootpw qweqwe
-shutdown
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 module --name=nodejs --stream=10
 
@@ -64,13 +50,6 @@ dnf module list --installed nodejs | grep nodejs || echo "*** nodejs module not 
 # check the stream and profile as well
 dnf module list --installed nodejs | grep "development \[i\]" || echo "*** nodejs module development profile not marked as installed" >> /root/RESULT
 
-if [ ! -f /root/RESULT ]
-then
-    # no result file (no errors) -> success
-    echo SUCCESS > /root/RESULT
-else
-    # some errors happened
-    exit 1
-fi
+%ksappend validation/success_if_result_empty.ks
 
 %end

--- a/module-install-4.ks.in
+++ b/module-install-4.ks.in
@@ -5,22 +5,8 @@
 # - install the same module with the same stream
 # (enabling one stream and installing a different one is an error)
 
-url @KSTEST_URL@
-repo --name=modular @KSTEST_MODULAR_URL@
-
-install
-network --bootproto=dhcp
-
-bootloader --timeout=1
-zerombr
-clearpart --all
-autopart
-
-keyboard us
-lang en
-timezone America/New_York
-rootpw qweqwe
-shutdown
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 module --name=cri-o --stream=1.11
 
@@ -68,13 +54,6 @@ dnf module list --installed cri-o | grep cri-o || echo "*** cri-o module not mar
 #   https://bugzilla.redhat.com/show_bug.cgi?id=1602028#c1
 #dnf module list --installed cri-o | grep "default \[i\]" || echo "*** cri-o module default profile not marked as installed" >> /root/RESULT
 
-if [ ! -f /root/RESULT ]
-then
-    # no result file (no errors) -> success
-    echo SUCCESS > /root/RESULT
-else
-    # some errors happened
-    exit 1
-fi
+%ksappend validation/success_if_result_empty.ks
 
 %end

--- a/module-install-many.ks.in
+++ b/module-install-many.ks.in
@@ -2,21 +2,8 @@
 #
 # test installing many different modules at once
 
-url @KSTEST_URL@
-repo --name=modular @KSTEST_MODULAR_URL@
-install
-network --bootproto=dhcp
-
-bootloader --timeout=1
-zerombr
-clearpart --all
-autopart
-
-keyboard us
-lang en
-timezone America/New_York
-rootpw qweqwe
-shutdown
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 %packages
 @^Fedora Server Edition
@@ -121,15 +108,6 @@ dnf module list --installed mysql | grep "default \[i\]" || echo "*** mysql modu
 dnf module list --installed scala grep "default \[i\]" || echo "*** scala module default profile not marked as installed" >> /root/RESULT
 dnf module list --installed gimp | grep "default \[i\]" || echo "*** gimp module default profile not marked as installed" >> /root/RESULT
 
-if [ ! -f /root/RESULT ]
-then
-    # no result file (no errors) -> success
-    echo SUCCESS > /root/RESULT
-else
-    # some errors happened
-    exit 1
-fi
-
-
+%ksappend validation/success_if_result_empty.ks
 
 %end

--- a/module-install-no-stream-no-profile.ks.in
+++ b/module-install-no-stream-no-profile.ks.in
@@ -4,21 +4,8 @@
 # NOTE: this is not really testable on Rawhide right now as there are
 #       no modules with a default stream
 
-url @KSTEST_URL@
-repo --name=modular @KSTEST_MODULAR_URL@
-install
-network --bootproto=dhcp
-
-bootloader --timeout=1
-zerombr
-clearpart --all
-autopart
-
-keyboard us
-lang en
-timezone America/New_York
-rootpw qweqwe
-shutdown
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 %packages
 @^Fedora Server Edition
@@ -120,13 +107,6 @@ dnf module list --installed gimp | grep "default \[i\]"&& echo "gimp module prof
 
 #TODO: test default profile is correctly used
 
-if [ ! -f /root/RESULT ]
-then
-    # no result file (no errors) -> success
-    echo SUCCESS > /root/RESULT
-else
-    # some errors happened
-    exit 1
-fi
+%ksappend validation/success_if_result_empty.ks
 
 %end

--- a/module-install-one-module-multiple-profiles.ks.in
+++ b/module-install-one-module-multiple-profiles.ks.in
@@ -5,22 +5,8 @@
 # expected result
 # - ?
 
-url @KSTEST_URL@
-repo --name=modular @KSTEST_MODULAR_URL@
-
-install
-network --bootproto=dhcp
-
-bootloader --timeout=1
-zerombr
-clearpart --all
-autopart
-
-keyboard us
-lang en
-timezone America/New_York
-rootpw qweqwe
-shutdown
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 %packages
 @^Fedora Server Edition
@@ -67,13 +53,6 @@ dnf module list --installed nodejs | grep "default \[i\]" || echo "*** nodejs mo
 # check the stream
 dnf module list --enabled nodejs | grep "10 \[e\]" || echo "*** nodejs stream id 10 not marked as enabled" >> /root/RESULT
 
-if [ ! -f /root/RESULT ]
-then
-    # no result file (no errors) -> success
-    echo SUCCESS > /root/RESULT
-else
-    # some errors happened
-    exit 1
-fi
+%ksappend validation/success_if_result_empty.ks
 
 %end

--- a/module-install-one-module-multiple-streams-and-profiles.ks.in
+++ b/module-install-one-module-multiple-streams-and-profiles.ks.in
@@ -5,22 +5,8 @@
 # expected result
 # - ?
 
-url @KSTEST_URL@
-repo --name=modular @KSTEST_MODULAR_URL@
-
-install
-network --bootproto=dhcp
-
-bootloader --timeout=1
-zerombr
-clearpart --all
-autopart
-
-keyboard us
-lang en
-timezone America/New_York
-rootpw qweqwe
-shutdown
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 %packages
 @^Fedora Server Edition
@@ -67,13 +53,6 @@ dnf module list --installed cri-o | grep "default \[i\]" || echo "*** cri-o modu
 # check the stream
 dnf module list --installed cri-o | grep "1.11 \[e\]" || echo "*** cri-o stream id 1.11 not marked as enabled" >> /root/RESULT
 
-if [ ! -f /root/RESULT ]
-then
-    # no result file (no errors) -> success
-    echo SUCCESS > /root/RESULT
-else
-    # some errors happened
-    exit 1
-fi
+%ksappend validation/success_if_result_empty.ks
 
 %end

--- a/module-install-one-module-multiple-streams.ks.in
+++ b/module-install-one-module-multiple-streams.ks.in
@@ -8,22 +8,8 @@
 #   (we forward the specs to DNF in order), anything else
 #   would be black magic
 
-url @KSTEST_URL@
-repo --name=modular @KSTEST_MODULAR_URL@
-
-install
-network --bootproto=dhcp
-
-bootloader --timeout=1
-zerombr
-clearpart --all
-autopart
-
-keyboard us
-lang en
-timezone America/New_York
-rootpw qweqwe
-shutdown
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 %packages
 @^Fedora Server Edition
@@ -67,13 +53,6 @@ dnf module list --installed avocado | grep "default \[i\]" || echo "*** avocado 
 # check the stream
 dnf module list --installed avocado | grep "stable \[e\]" || echo "*** avocado stream stable not marked as enabled" >> /root/RESULT
 
-if [ ! -f /root/RESULT ]
-then
-    # no result file (no errors) -> success
-    echo SUCCESS > /root/RESULT
-else
-    # some errors happened
-    exit 1
-fi
+%ksappend validation/success_if_result_empty.ks
 
 %end

--- a/module-install-without-profile.ks.in
+++ b/module-install-without-profile.ks.in
@@ -4,21 +4,8 @@
 # - a default profile should be selected automatically based on module
 #   metadata
 
-url @KSTEST_URL@
-repo --name=modular @KSTEST_MODULAR_URL@
-install
-network --bootproto=dhcp
-
-bootloader --timeout=1
-zerombr
-clearpart --all
-autopart
-
-keyboard us
-lang en
-timezone America/New_York
-rootpw qweqwe
-shutdown
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 %packages
 @^Fedora Server Edition
@@ -113,13 +100,6 @@ dnf module list --installed mongodb | grep "default \[i\]" || echo "*** mongodb 
 dnf module list --installed mysql | grep "default \[i\]" || echo "*** mysql module profile not marked as installed" >> /root/RESULT
 dnf module list --installed gimp | grep "default \[i\]" || echo "*** gimp module profile not marked as installed" >> /root/RESULT
 
-if [ ! -f /root/RESULT ]
-then
-    # no result file (no errors) -> success
-    echo SUCCESS > /root/RESULT
-else
-    # some errors happened
-    exit 1
-fi
+%ksappend validation/success_if_result_empty.ks
 
 %end

--- a/module-non-default-profiles.ks.in
+++ b/module-non-default-profiles.ks.in
@@ -2,21 +2,8 @@
 #
 # test installing many modules with non-default profiles
 
-url @KSTEST_URL@
-repo --name=modular @KSTEST_MODULAR_URL@
-install
-network --bootproto=dhcp
-
-bootloader --timeout=1
-zerombr
-clearpart --all
-autopart
-
-keyboard us
-lang en
-timezone America/New_York
-rootpw qweqwe
-shutdown
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 %packages
 @^Fedora Server Edition
@@ -101,13 +88,6 @@ dnf module list --installed mysql | grep "server \[i\]" || echo "*** mysql modul
 #dnf module list --installed postgresql | grep "server \[i\]" || echo "*** postgresql module profile server not marked as installed" >> /root/RESULT
 dnf module list --installed gimp | grep "devel \[i\]" || echo "*** gimp module profile devel not marked as installed" >> /root/RESULT
 
-if [ ! -f /root/RESULT ]
-then
-    # no result file (no errors) -> success
-    echo SUCCESS > /root/RESULT
-else
-    # some errors happened
-    exit 1
-fi
+%ksappend validation/success_if_result_empty.ks
 
 %end

--- a/packages-and-groups-1.ks.in
+++ b/packages-and-groups-1.ks.in
@@ -1,18 +1,7 @@
 #test name: packages-and-groups-1
-url @KSTEST_URL@
-install
-network --bootproto=dhcp
 
-bootloader --timeout=1
-zerombr
-clearpart --all
-autopart
-
-keyboard us
-lang en
-timezone America/New_York
-rootpw qweqwe
-shutdown
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 %packages
 @^xfce-desktop-environment
@@ -65,13 +54,6 @@ if [[ $count -gt 0 ]]; then
     echo '*** ibus glob should not have been installed' >> /root/RESULT
 fi
 
-if [ ! -f /root/RESULT ]
-then
-    # no result file (no errors) -> success
-    echo SUCCESS > /root/RESULT
-else
-    # some errors happened
-    exit 1
-fi
+%ksappend validation/success_if_result_empty.ks
 
 %end

--- a/packages-and-groups-ignoremissing.ks.in
+++ b/packages-and-groups-ignoremissing.ks.in
@@ -7,20 +7,9 @@
 # - that regular packages and groups requested at the same time
 #   are installed correctly
 # - that such an installation finishes successfully
-url @KSTEST_URL@
-install
-network --bootproto=dhcp
 
-bootloader --timeout=1
-zerombr
-clearpart --all --initlabel
-autopart
-
-keyboard us
-lang en_US.UTF-8
-timezone America/New_York --utc
-rootpw testcase
-shutdown
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 %packages --ignoremissing
 fake-package-name-1
@@ -42,12 +31,6 @@ if [[ $? != 0 ]]; then
     echo '*** gcc should have been installed via the c-development package group' >> /root/RESULT
 fi
 
-if [ ! -f /root/RESULT ]
-then
-    # no result file (no errors) -> success
-    echo SUCCESS > /root/RESULT
-else
-    # some errors happened
-    exit 1
-fi
+%ksappend validation/success_if_result_empty.ks
+
 %end

--- a/packages-default.ks.in
+++ b/packages-default.ks.in
@@ -1,19 +1,8 @@
 #version=DEVEL
 #test name: packages-default
-url @KSTEST_URL@
-install
-network --bootproto=dhcp
 
-bootloader --timeout=1
-zerombr
-clearpart --all --initlabel
-autopart
-
-keyboard us
-lang en_US.UTF-8
-timezone America/New_York --utc
-rootpw testcase
-shutdown
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 %packages --default
 %end

--- a/packages-excludedocs.ks.in
+++ b/packages-excludedocs.ks.in
@@ -1,19 +1,8 @@
 #version=DEVEL
 #test name: packages-excludedocs
-url @KSTEST_URL@
-install
-network --bootproto=dhcp
 
-bootloader --timeout=1
-zerombr
-clearpart --all --initlabel
-autopart
-
-keyboard us
-lang en_US.UTF-8
-timezone America/New_York --utc
-rootpw testcase
-shutdown
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 %packages --excludedocs
 @container-management

--- a/packages-ignoremissing.ks.in
+++ b/packages-ignoremissing.ks.in
@@ -4,20 +4,9 @@
 # what we are testing there:
 # - that missing packages are ignored if --ignoremissing is used
 # - that such an installation finishes
-url @KSTEST_URL@
-install
-network --bootproto=dhcp
 
-bootloader --timeout=1
-zerombr
-clearpart --all --initlabel
-autopart
-
-keyboard us
-lang en_US.UTF-8
-timezone America/New_York --utc
-rootpw testcase
-shutdown
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 %packages --ignoremissing
 fake-package-name

--- a/packages-instlangs-1.ks.in
+++ b/packages-instlangs-1.ks.in
@@ -1,19 +1,8 @@
 #version=DEVEL
 #test name: packages-instlangs-1
-url @KSTEST_URL@
-install
-network --bootproto=dhcp
 
-bootloader --timeout=1
-zerombr
-clearpart --all --initlabel
-autopart
-
-keyboard us
-lang en_US.UTF-8
-timezone America/New_York --utc
-rootpw testcase
-shutdown
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 # Only install the en_US locale
 %packages --instLangs=en_US
@@ -41,7 +30,6 @@ if [ -n "$other_locales" ]; then
     echo "*** non-en locales were installed" >> /root/RESULT
 fi
 
-if [ ! -f /root/RESULT ]; then
-    echo SUCCESS > /root/RESULT
-fi
+%ksappend validation/success_if_result_empty.ks
+
 %end

--- a/packages-instlangs-2.ks.in
+++ b/packages-instlangs-2.ks.in
@@ -1,19 +1,8 @@
 #version=DEVEL
 #test name: packages-instlangs-2
-url @KSTEST_URL@
-install
-network --bootproto=dhcp
 
-bootloader --timeout=1
-zerombr
-clearpart --all --initlabel
-autopart
-
-keyboard us
-lang en_US.UTF-8
-timezone America/New_York --utc
-rootpw testcase
-shutdown
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 # Install no locales
 %packages --instLangs=
@@ -26,7 +15,6 @@ if [ -n "$molist" ]; then
     echo "*** .mo files were installed" >> /root/RESULT
 fi
 
-if [ ! -f /root/RESULT ]; then
-    echo SUCCESS > /root/RESULT
-fi
+%ksappend validation/success_if_result_empty.ks
+
 %end

--- a/packages-instlangs-3.ks.in
+++ b/packages-instlangs-3.ks.in
@@ -1,23 +1,22 @@
 #version=DEVEL
 #test name: packages-instlangs-3
-url @KSTEST_URL@
-install
-network --bootproto=dhcp
+%ksappend repos/default.ks
 
-bootloader --timeout=1
-zerombr
-clearpart --all --initlabel
-autopart
+# Due to the custom language configuration we
+# use individual fragments instead of the
+# bigger custom_no_packaging.ks fragment.
+%ksappend common/common.ks
+%ksappend network/default.ks
+%ksappend bootloader/default.ks
+%ksappend storage/default.ks
+%ksappend users/default.ks
 
 keyboard us
+timezone America/New_York --utc
 
 # Use a language that overlaps with the --instLangs list below so that
 # additional langpacks packages don't confuse the locale test
 lang fr_FR.UTF-8
-
-timezone America/New_York --utc
-rootpw testcase
-shutdown
 
 # Install a short list of languages
 # Use ones with translations in blivet to make them easy to find.

--- a/packages-multilib.ks.in
+++ b/packages-multilib.ks.in
@@ -1,19 +1,8 @@
 #version=DEVEL
 #test name: packages-multilib
-url @KSTEST_URL@
-install
-network --bootproto=dhcp
 
-bootloader --timeout=1
-zerombr
-clearpart --all --initlabel
-autopart
-
-keyboard us
-lang en_US.UTF-8
-timezone America/New_York --utc
-rootpw testcase
-shutdown
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 %packages --multilib
 @container-management

--- a/packages-weakdeps.ks.in
+++ b/packages-weakdeps.ks.in
@@ -1,19 +1,8 @@
 #version=DEVEL
 #test name: packages-weakdeps
-url @KSTEST_URL@
-install
-network --bootproto=dhcp
 
-bootloader --timeout=1
-zerombr
-clearpart --all --initlabel
-autopart
-
-keyboard us
-lang en_US.UTF-8
-timezone America/New_York --utc
-rootpw testcase
-shutdown
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
 
 # Install gnupg2 and make sure the packages it recommends are skipped
 %packages --excludeWeakdeps
@@ -36,7 +25,6 @@ if ! ( rpm -q --recommends gnupg2 | grep -q gnupg2-smime ) || \
     echo "gnupg2 --recommends has changed, test needs to be updated" >> /root/RESULT
 fi
 
-if [ ! -f /root/RESULT ]; then
-    echo SUCCESS > /root/RESULT
-fi
+%ksappend validation/success_if_result_empty.ks
+
 %end

--- a/scripts/apply-ksappend.py
+++ b/scripts/apply-ksappend.py
@@ -1,0 +1,239 @@
+#!/usr/bin/python3
+
+import sys
+import os
+import argparse
+import shutil
+import glob
+from pykickstart import parser as kickstart_parser
+
+FRAGMENTS_FOLDER = "fragments"
+SHARED_FRAGMENTS_FOLDER = os.path.join(FRAGMENTS_FOLDER, "shared")
+RUNTIME_FOLDER = os.path.join(FRAGMENTS_FOLDER, "runtime")
+TOPLEVEL_PLATFORM_FOLDER = os.path.join(FRAGMENTS_FOLDER, "platform")
+
+class ArgumentParser(object):
+
+    def __init__(self):
+        super().__init__()
+        self._parser = argparse.ArgumentParser(description="""
+        Include fragments linked by %ksappend in tests.
+        """)
+
+        self._test_file_paths = ""
+        self._platform_name = ""
+
+        self._configure_parser()
+
+    @property
+    def test_file_paths(self):
+        return self._test_file_paths
+
+    @property
+    def platform_name(self):
+        return self._platform_name
+
+    @property
+    def override_folders(self):
+        return self._override_folders
+
+    @property
+    def platform_dir_path(self):
+        return os.path.join(TOPLEVEL_PLATFORM_FOLDER, self._platform_name)
+
+    def _configure_parser(self):
+        self._parser.add_argument("--test-file-paths", "-t", required=True, type=str, nargs="+",
+                                  metavar="TEST_FILE_PATHS",
+                                  help="Space delimited kickstart test files to process.")
+        self._parser.add_argument("--platform-name", "-p", type=str, required=True,
+                                  metavar="PLATFORM_NAME",
+                                  help="Name of the platform folder for platform specific ksappend fragments.")
+        self._parser.add_argument("--override-folders", "-o", type=str, metavar='OVERRIDE_FOLDERS', default=[], nargs="*",
+                                  help='Add contents of one or more override folders on top of shared and platform specific fragments.')
+
+    def parse(self):
+        print("ARGV")
+        print(sys.argv)
+        ns = self._parser.parse_args()
+
+        self._test_file_paths = ns.test_file_paths
+        self._platform_name = ns.platform_name
+        self._override_folders = ns.override_folders
+
+def merge_directories(source_dir, dest_dir):
+    """Copy content of source directory to target directory.
+
+    Merge folders and overwrite any existing files.
+
+    One would kinda expect that Python has something like this
+    available in it's standard library, but apparently not.
+    """
+    # list content of the source directory
+    for item_name in os.listdir(source_dir):
+        item_path = os.path.join(source_dir, item_name)
+        # copy any top level files
+        if os.path.isfile(item_path):
+            shutil.copyfile(item_path, os.path.join(dest_dir, item_name))
+        # walk top level directories
+        elif os.path.isdir(item_path):
+            # copy all directories recursively, merge with existing folders and
+            # overwrite existing files
+            for root, dirs, files in os.walk(item_path):
+                # we only need the full source path to copy files to the destination,
+                # to create all necessary folders we also need the path suffix for
+                # the directory being walked and the target path based on the suffix
+                root_suffix = os.path.relpath(root, source_dir)
+                root_in_dest_dir = os.path.join(dest_dir, root_suffix)
+                # create directories
+                if not os.path.isdir(root_in_dest_dir):
+                    os.makedirs(root_in_dest_dir)
+                # copy files
+                for file in files:
+                   shutil.copyfile(os.path.join(root, file), os.path.join(root_in_dest_dir, file))
+
+def apply_overrides(override_folders, runtime_folder):
+    """ Apply ksappend overrides on a runtime folder.
+
+    This takes a list of folders holding the overrides and copies the *content* of the override
+    folders on top of what's currently in the given runtime folder.
+
+    If a path to an override_folder is not valid the folder is skipped and a warning is printed
+    to stdout.
+
+    :param override_folders: a list of paths to override folders
+    :type override_folders: list of str
+    :param str runtime_folder: path to the ksappend runtime folder
+    """
+    for override_folder in parser.override_folders:
+        if os.path.exists(override_folder):
+            print("adding ksappend override folder {}".format(override_folder))
+            merge_directories(override_folder, runtime_folder)
+        else:
+            print("requested ksappend override folder {} not found".format(override_folder))
+
+def get_available_kickstart_tests(kstests):
+    """Check which kickstart test files from a list are available.
+
+    Return a list of test files that actually exist and print any files we can't
+    find to stdout.
+
+    :param kstests: a list of kickstart test file paths
+    :type kstests: list of str
+    :returns: a list of kickstart test file paths that exist
+    :rtype: list of str
+    """
+    available_test_files = []
+    for test_path in kstests:
+        if os.path.exists(test_path) and os.path.isfile(test_path):
+            available_test_files.append(test_path)
+        else:
+            print("test file requested for ksappend substitution is missing: %s", test_path)
+    return available_test_files
+
+def do_ksappend_substitution(runtime_folder):
+    """Do the ksappend substitution.
+
+    This is done by changing PWD to the runtime folder,
+    (required by how Pykickstart currently does the substitution)
+    running Pykickstart to do the substitution and then
+    reverting PWD back.
+
+    Individual substitution runs are printed to stdout as are
+    failed substitution attempts.
+
+    We keep all the input files and rename them to <name>.ks.input
+    and rename all files that failed the substitution to <name>.ks.input.FAILED.
+
+    :param str runtime_folder: path to the ksappend runtime folder
+    :returns: list of successfully processed kickstart test files
+    :rtype: list of str
+    """
+
+    # save current PWD
+    pwd = os.path.abspath(".")
+
+    # change working directory to the runtime folder or else
+    # Pykickstart will not find the fragments
+    os.chdir(runtime_folder)
+
+    # do the substitution
+    resolved_ks_files = []
+    for test_file in glob.glob("*.ks"):
+        test_base_name = os.path.split(test_file)[1].rsplit(".ks")[0]
+        print("running ksappend substitution on: {}".format(test_file))
+        # the result should be a temp file
+        result_path = kickstart_parser.preprocessKickstart(test_file)
+        if result_path:
+            # rename the input file and keep it for reference
+            input_file = "{}.ks.input".format(test_base_name)
+            shutil.move(test_file, input_file)
+            # move the result file in place of the original ks file
+            shutil.move(result_path, test_file)
+            # register the successfully resolved file
+            resolved_ks_files.append(test_file)
+        else:
+            print("ksappend substitution failed for: {}".format(test_file))
+            # rename the input file to mark it as failed
+            failed_input_file = "{}.ks.input.FAILED".format(test_base_name)
+            shutil.move(test_file, failed_input_file)
+
+    # restore working directory back
+    os.chdir(pwd)
+
+    # return a list of all successfully processed file names & paths in runtime folder
+    # in the [(<file name>, <path to file in runtime folder>),] format
+    return resolved_ks_files
+
+def move_results_in_place(resolved_test_files, runtime_folder):
+    """Move resolved kickstart test files from the ksappend runtime folder.
+
+    :param resolved_ks_files: list of names of all successfully resolved kickstart test files
+    :type: resolved_ks_files: list of str
+    :param str runtime_folder: path to the ksappend runtime folder
+    """
+    for file_name in resolved_test_files:
+        shutil.copyfile(os.path.join(runtime_folder, file_name), file_name)
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.parse()
+
+    # check the requested platform folder exists:
+    if not os.path.exists(parser.platform_dir_path):
+        print("platform folder path not found: {}".format(parser.platform_dir_path))
+        exit(1)
+
+    # make sure the runtime folder exists and is empty
+    if os.path.exists(RUNTIME_FOLDER):
+        # cleanup the existing runtime folder
+        shutil.rmtree(RUNTIME_FOLDER)
+
+    # create new one
+    os.makedirs(RUNTIME_FOLDER)
+
+    # copy all shared fragments to the runtime folder
+    merge_directories(SHARED_FRAGMENTS_FOLDER, RUNTIME_FOLDER)
+
+    # copy contents of the current platform folder into it as well
+    merge_directories(parser.platform_dir_path, RUNTIME_FOLDER)
+
+    # copy any overrides
+    apply_overrides(parser.override_folders, RUNTIME_FOLDER)
+
+    # copy all the test files that actually exist to runtime folder
+    available_test_files = get_available_kickstart_tests(parser.test_file_paths)
+
+    for test_path in available_test_files:
+        shutil.copy(test_path, RUNTIME_FOLDER)
+
+    # do the actual ksappend substitution
+    resolved_test_files = do_ksappend_substitution(RUNTIME_FOLDER)
+
+    # move the results in place
+    move_results_in_place(resolved_test_files, RUNTIME_FOLDER)
+
+    print("ksappend with platform name {} resolved {}/{} test files".format(parser.platform_name,
+                                                                            len(parser.test_file_paths),
+                                                                            len(resolved_test_files)))
+    # and we are done
+    exit(0)


### PR DESCRIPTION
The first few commits add support for using %ksappend in kickstart tests so that we can replace a lot of boilerplate with shared kickstart fragments and also handle per-platform dynamic behavior.

The last commit converts the packaging related kickstart tests to use %ksappend and the fragments as they are a nice largely self-contained test group & dynamic repository configuration is more important than elsewhere due to the need for two repos (base + modular) being available.