### PR TITLE
Make sure sane locale is used on remote hosts

### DIFF
--- a/scripts/run_kickstart_tests.sh
+++ b/scripts/run_kickstart_tests.sh
@@ -370,6 +370,14 @@ if [[ "$TEST_REMOTES" != "" ]]; then
     cd ..
 
     echo "starting tests"
+
+    # Parallel aparently tends to import environment shell variables to the
+    # remote shell run environment, which can cause issues if the host that
+    # has initiated a test run has a locale the host running the tests does
+    # not have. So always set a well known locale, which should prevent this
+    # missmatch from happening.
+    export LANG=en_US.UTF-8
+
     parallel --no-notice ${remote_args} --wd kickstart-tests --jobs ${TEST_JOBS:-4} \
              sudo PYTHONPATH=$PYTHONPATH scripts/launcher/run_one_test.py \
                                                                -i ../install_images/${_IMAGE} \


### PR DESCRIPTION
We use GNU Parallel to run the kickstart test jobs both locally
and on remote hosts. When it runs the jobs Parallel apparently
imports shell variables from the local host starting the job batch
to the shell environment on the remote hosts running the jobs.

This can cause issues if there is a locale availability mismatch
between the local and remote hosts, such as local host having
locale cs_CZ.UTF-8 while the remote hosts are lightweight cloud images
that only have a basic set of locales available (C.UTF-8, en_US.UTF-8,
etc.).

This mismatch then apparently causes the shell environment to
fallback to a **non-UTF-8 C locale**, wreaking all sorts of havoc,
especially with with log monitoring in Lorax/LMC, as the logs
*do* contain Unicode and make the log monitor crash due to Unicode
encoding errors.

So to avoid this nasty edge case, always set a well-known locale
to the LANG variable before starting remote jobs with Parallel.