### PR TITLE
Deduplicate boot option overrides & prevent Dracut emergency shell

### DIFF
--- a/bindtomac-ifname-httpks.sh
+++ b/bindtomac-ifname-httpks.sh
@@ -23,7 +23,7 @@ TESTTYPE="network"
 
 kernel_args() {
     . ${tmpdir}/ks_url
-    echo vnc debug=1 inst.debug ifname=ifname0:52:54:00:12:34:5D ifname=ifname1:52:54:00:12:34:5E ip=ifname0:dhcp inst.ks=${ks_url}
+    echo ${DEFAULT_BOOTOPTS} ifname=ifname0:52:54:00:12:34:5D ifname=ifname1:52:54:00:12:34:5E ip=ifname0:dhcp inst.ks=${ks_url}
 }
 
 # Arguments for virt-install --network options

--- a/bindtomac-network-device-mac-httpks.sh
+++ b/bindtomac-network-device-mac-httpks.sh
@@ -23,7 +23,7 @@ TESTTYPE="network"
 
 kernel_args() {
     . ${tmpdir}/ks_url
-    echo vnc debug=1 inst.debug ip=ens3:dhcp inst.ks=${ks_url}
+    echo ${DEFAULT_BOOTOPTS} ip=ens3:dhcp inst.ks=${ks_url}
 }
 
 # Arguments for virt-install --network options

--- a/bindtomac-network-device-mac-pre.sh
+++ b/bindtomac-network-device-mac-pre.sh
@@ -22,7 +22,7 @@ TESTTYPE="network"
 . ${KSTESTDIR}/functions.sh
 
 kernel_args() {
-    echo vnc debug=1 inst.debug ip=ens3:dhcp
+    echo ${DEFAULT_BOOTOPTS} ip=ens3:dhcp
 }
 
 # Arguments for virt-install --network options

--- a/bindtomac-network-static-to-dhcp-pre-single.sh
+++ b/bindtomac-network-static-to-dhcp-pre-single.sh
@@ -33,7 +33,7 @@ ip_static_boot_config=""
 
 kernel_args() {
     . ${tmpdir}/ip_static_boot_config
-    echo vnc debug=1 inst.debug ${ip_static_boot_config}
+    echo ${DEFAULT_BOOTOPTS} ${ip_static_boot_config}
 }
 
 prepare() {

--- a/bond-vlan-httpks.sh
+++ b/bond-vlan-httpks.sh
@@ -24,7 +24,7 @@ TESTTYPE=${TESTTYPE:-"network"}
 
 kernel_args() {
     . ${tmpdir}/ks_url
-    echo vnc debug=1 inst.debug ip=ens3:dhcp inst.ks=${ks_url}
+    echo ${DEFAULT_BOOTOPTS} ip=ens3:dhcp inst.ks=${ks_url}
 }
 
 # Arguments for virt-install --network options

--- a/bond2-httpks.sh
+++ b/bond2-httpks.sh
@@ -24,7 +24,7 @@ TESTTYPE=${TESTTYPE:-"network"}
 
 kernel_args() {
     . ${tmpdir}/ks_url
-    echo vnc debug=1 inst.debug ip=ens3:dhcp inst.ks=${ks_url}
+    echo ${DEFAULT_BOOTOPTS} ip=ens3:dhcp inst.ks=${ks_url}
 }
 
 # Arguments for virt-install --network options

--- a/bond2-pre.sh
+++ b/bond2-pre.sh
@@ -23,7 +23,7 @@ TESTTYPE=${TESTTYPE:-"network"}
 
 
 kernel_args() {
-    echo vnc debug=1 inst.debug ip=ens3:dhcp
+    echo ${DEFAULT_BOOTOPTS} ip=ens3:dhcp
 }
 
 # Arguments for virt-install --network options

--- a/bridge-2devs-httpks.sh
+++ b/bridge-2devs-httpks.sh
@@ -24,7 +24,7 @@ TESTTYPE=${TESTTYPE:-"network"}
 
 kernel_args() {
     . ${tmpdir}/ks_url
-    echo vnc debug=1 inst.debug ip=ens3:dhcp inst.ks=${ks_url}
+    echo ${DEFAULT_BOOTOPTS} ip=ens3:dhcp inst.ks=${ks_url}
 }
 
 # Arguments for virt-install --network options

--- a/bridge-2devs.sh
+++ b/bridge-2devs.sh
@@ -23,7 +23,7 @@ TESTTYPE=${TESTTYPE:-"network"}
 
 
 kernel_args() {
-    echo vnc debug=1 inst.debug ip=ens3:dhcp
+    echo ${DEFAULT_BOOTOPTS} ip=ens3:dhcp
 }
 
 # Arguments for virt-install --network options

--- a/bridge-httpks.sh
+++ b/bridge-httpks.sh
@@ -24,7 +24,7 @@ TESTTYPE=${TESTTYPE:-"network"}
 
 kernel_args() {
     . ${tmpdir}/ks_url
-    echo vnc debug=1 inst.debug ip=dhcp inst.ks=${ks_url}
+    echo ${DEFAULT_BOOTOPTS} ip=dhcp inst.ks=${ks_url}
 }
 
 # Arguments for virt-install --network options

--- a/bridge-no-bootopts-net.sh
+++ b/bridge-no-bootopts-net.sh
@@ -23,7 +23,7 @@ TESTTYPE=${TESTTYPE:-"network"}
 
 
 kernel_args() {
-    echo vnc debug=1 inst.debug
+    echo ${DEFAULT_BOOTOPTS}
 }
 
 # Arguments for virt-install --network options

--- a/bridged-bond-httpks.sh
+++ b/bridged-bond-httpks.sh
@@ -24,7 +24,7 @@ TESTTYPE=${TESTTYPE:-"network"}
 
 kernel_args() {
     . ${tmpdir}/ks_url
-    echo vnc debug=1 inst.debug ip=ens3:dhcp inst.ks=${ks_url}
+    echo ${DEFAULT_BOOTOPTS} ip=ens3:dhcp inst.ks=${ks_url}
 }
 
 # Arguments for virt-install --network options

--- a/bridged-bond-pre.sh
+++ b/bridged-bond-pre.sh
@@ -24,7 +24,7 @@ TESTTYPE="knownfailure network"
 
 
 kernel_args() {
-    echo vnc debug=1 inst.debug ip=ens3:dhcp
+    echo ${DEFAULT_BOOTOPTS} ip=ens3:dhcp
 }
 
 # Arguments for virt-install --network options

--- a/functions.sh
+++ b/functions.sh
@@ -29,8 +29,14 @@ inject_ks_to_initrd() {
     echo "true"
 }
 
+DEFAULT_BASIC_BOOTOPTS="vnc debug=1 inst.debug"
+
+DEFAULT_DRACUT_BOOTOPTS="rd.shell=0 rd.emergency=poweroff"
+
+DEFAULT_BOOTOPTS="${DEFAULT_BASIC_BOOTOPTS} ${DEFAULT_DRACUT_BOOTOPTS}"
+
 kernel_args() {
-    echo vnc debug=1 inst.debug
+    echo $DEFAULT_BOOTOPTS
 }
 
 prepare() {

--- a/hostname-bootopts.sh
+++ b/hostname-bootopts.sh
@@ -31,7 +31,7 @@ TESTTYPE="network"
 
 kernel_args() {
     . ${tmpdir}/ip_static_boot_config
-    echo vnc debug=1 inst.debug ip=ens3:dhcp ${ip_static_boot_config}
+    echo ${DEFAULT_BOOTOPTS} ip=ens3:dhcp ${ip_static_boot_config}
 }
 
 prepare() {

--- a/ibft.sh
+++ b/ibft.sh
@@ -46,7 +46,7 @@ real_kernel_args() {
     iso=${tmpdir}/$(basename ${IMAGE})
     local label_line="$(isoinfo -d -i ${iso} | egrep "Volume id:")"
     local iso_label=$(udev_escape "${label_line:11}")
-    echo vnc debug=1 inst.debug ip=ibft inst.ks=${httpd_url}ks.cfg stage2=hd:CDLABEL=${iso_label}
+    echo ${DEFAULT_BOOTOPTS} ip=ibft inst.ks=${httpd_url}ks.cfg stage2=hd:CDLABEL=${iso_label}
 }
 
 # arguments for virt-install --network options

--- a/ifname-httpks.sh
+++ b/ifname-httpks.sh
@@ -23,7 +23,7 @@ TESTTYPE="network"
 
 kernel_args() {
     . ${tmpdir}/ks_url
-    echo vnc debug=1 inst.debug ifname=ifname0:52:54:00:12:34:5B ifname=ifname1:52:54:00:12:34:5C ip=ifname0:dhcp inst.ks=${ks_url}
+    echo ${DEFAULT_BOOTOPTS} ifname=ifname0:52:54:00:12:34:5B ifname=ifname1:52:54:00:12:34:5C ip=ifname0:dhcp inst.ks=${ks_url}
 }
 
 # Arguments for virt-install --network options

--- a/iscsi.sh
+++ b/iscsi.sh
@@ -24,7 +24,7 @@ TESTTYPE="knownfailure iscsi"
 iscsi_disk_img=iscsi-disk.img
 
 kernel_args() {
-    echo vnc debug=1 inst.debug ip=dhcp
+    echo ${DEFAULT_BOOTOPTS} ip=dhcp
 }
 
 # Arguments for virt-install --network options

--- a/network-bootopts-static-legacy-httpks.sh
+++ b/network-bootopts-static-legacy-httpks.sh
@@ -36,7 +36,7 @@ ip_static_boot_config=""
 kernel_args() {
     . ${tmpdir}/ip_static_boot_config
     . ${tmpdir}/ks_url
-    echo vnc debug=1 inst.debug rd.break=cmdline ${ip_static_boot_config} ks=${ks_url}
+    echo ${DEFAULT_BASIC_BOOTOPTS} rd.break=cmdline ${ip_static_boot_config} ks=${ks_url}
 }
 
 prepare() {

--- a/network-device-bootif-httpks.sh
+++ b/network-device-bootif-httpks.sh
@@ -23,7 +23,7 @@ TESTTYPE="network"
 
 kernel_args() {
     . ${tmpdir}/ks_url
-    echo vnc debug=1 inst.debug ip=ens3:dhcp BOOTIF=01-52-54-00-12-34-55 inst.ks=${ks_url}
+    echo ${DEFAULT_BOOTOPTS} ip=ens3:dhcp BOOTIF=01-52-54-00-12-34-55 inst.ks=${ks_url}
 }
 
 # Arguments for virt-install --network options

--- a/network-device-default-httpks.sh
+++ b/network-device-default-httpks.sh
@@ -29,7 +29,7 @@ KICKSTART_NAME=network-device-default
 
 kernel_args() {
     . ${tmpdir}/ks_url
-    echo vnc debug=1 inst.debug ip=ens3:dhcp inst.ks=${ks_url}
+    echo ${DEFAULT_BOOTOPTS} ip=ens3:dhcp inst.ks=${ks_url}
 }
 
 prepare() {

--- a/network-device-default-ksdevice-httpks.sh
+++ b/network-device-default-ksdevice-httpks.sh
@@ -23,7 +23,7 @@ TESTTYPE="network"
 
 kernel_args() {
     . ${tmpdir}/ks_url
-    echo vnc debug=1 inst.debug inst.ks=${ks_url} ksdevice=ens4
+    echo ${DEFAULT_BOOTOPTS} inst.ks=${ks_url} ksdevice=ens4
 }
 
 # Arguments for virt-install --network options

--- a/network-device-default-ksdevice-pre.sh
+++ b/network-device-default-ksdevice-pre.sh
@@ -23,7 +23,7 @@ TESTTYPE="network"
 
 kernel_args() {
     . ${tmpdir}/ks_url
-    echo vnc debug=1 inst.debug ksdevice=ens4
+    echo ${DEFAULT_BOOTOPTS} ksdevice=ens4
 }
 
 # Arguments for virt-install --network options

--- a/network-device-mac-httpks.sh
+++ b/network-device-mac-httpks.sh
@@ -23,7 +23,7 @@ TESTTYPE="network"
 
 kernel_args() {
     . ${tmpdir}/ks_url
-    echo vnc debug=1 inst.debug ip=ens3:dhcp inst.ks=${ks_url}
+    echo ${DEFAULT_BOOTOPTS} ip=ens3:dhcp inst.ks=${ks_url}
 }
 
 # Arguments for virt-install --network options

--- a/network-device-mac-pre.sh
+++ b/network-device-mac-pre.sh
@@ -22,7 +22,7 @@ TESTTYPE="network"
 . ${KSTESTDIR}/functions.sh
 
 kernel_args() {
-    echo vnc debug=1 inst.debug ip=ens3:dhcp
+    echo ${DEFAULT_BOOTOPTS} ip=ens3:dhcp
 }
 
 # Arguments for virt-install --network options

--- a/network-missing-ifcfg-httpks.sh
+++ b/network-missing-ifcfg-httpks.sh
@@ -30,7 +30,7 @@ TESTTYPE="network"
 
 kernel_args() {
     . ${tmpdir}/ks_url
-    echo vnc debug=1 inst.debug ip=ens3:dhcp inst.ks=${ks_url}
+    echo ${DEFAULT_BOOTOPTS} ip=ens3:dhcp inst.ks=${ks_url}
 }
 
 prepare() {

--- a/network-noipv4-httpks.sh
+++ b/network-noipv4-httpks.sh
@@ -24,7 +24,7 @@ TESTTYPE="network"
 
 kernel_args() {
     . ${tmpdir}/ks_url
-    echo vnc debug=1 inst.debug ip=ens3:dhcp ip=ens4:dhcp inst.ks=${ks_url}
+    echo ${DEFAULT_BOOTOPTS} ip=ens3:dhcp ip=ens4:dhcp inst.ks=${ks_url}
 }
 
 # Arguments for virt-install --network options

--- a/network-noipv4-pre.sh
+++ b/network-noipv4-pre.sh
@@ -23,7 +23,7 @@ TESTTYPE="network"
 
 
 kernel_args() {
-    echo vnc debug=1 inst.debug ip=ens3:dhcp ip=ens4:dhcp
+    echo ${DEFAULT_BOOTOPTS} ip=ens3:dhcp ip=ens4:dhcp
 }
 
 # Arguments for virt-install --network options

--- a/network-static-2-httpks.sh
+++ b/network-static-2-httpks.sh
@@ -30,7 +30,7 @@ TESTTYPE=${TESTTYPE:-"network"}
 
 kernel_args() {
     . ${tmpdir}/ks_url
-    echo vnc debug=1 inst.debug ip=ens3:dhcp ip=ens4:dhcp ip=ens5:dhcp inst.ks=${ks_url}
+    echo ${DEFAULT_BOOTOPTS} ip=ens3:dhcp ip=ens4:dhcp ip=ens5:dhcp inst.ks=${ks_url}
 }
 
 prepare() {

--- a/network-static-2-pre.sh
+++ b/network-static-2-pre.sh
@@ -22,7 +22,7 @@ TESTTYPE="network"
 . ${KSTESTDIR}/functions.sh
 
 kernel_args() {
-    echo vnc debug=1 inst.debug ip=ens3:dhcp ip=ens4:dhcp ip=ens5:dhcp
+    echo ${DEFAULT_BOOTOPTS} ip=ens3:dhcp ip=ens4:dhcp ip=ens5:dhcp
 }
 
 prepare() {

--- a/network-static-httpks.sh
+++ b/network-static-httpks.sh
@@ -29,7 +29,7 @@ TESTTYPE="network"
 
 kernel_args() {
     . ${tmpdir}/ks_url
-    echo vnc debug=1 inst.debug ip=dhcp inst.ks=${ks_url}
+    echo ${DEFAULT_BOOTOPTS} ip=dhcp inst.ks=${ks_url}
 }
 
 prepare() {

--- a/network-static-to-dhcp-pre-single.sh
+++ b/network-static-to-dhcp-pre-single.sh
@@ -33,7 +33,7 @@ ip_static_boot_config=""
 
 kernel_args() {
     . ${tmpdir}/ip_static_boot_config
-    echo vnc debug=1 inst.debug ${ip_static_boot_config}
+    echo ${DEFAULT_BOOTOPTS} ${ip_static_boot_config}
 }
 
 prepare() {

--- a/network-static-to-dhcp-pre.sh
+++ b/network-static-to-dhcp-pre.sh
@@ -33,7 +33,7 @@ ip_static_boot_config=""
 
 kernel_args() {
     . ${tmpdir}/ip_static_boot_config
-    echo vnc debug=1 inst.debug ip=ens3:dhcp ${ip_static_boot_config}
+    echo ${DEFAULT_BOOTOPTS} ip=ens3:dhcp ${ip_static_boot_config}
 }
 
 prepare() {

--- a/network-static.sh
+++ b/network-static.sh
@@ -30,7 +30,7 @@ TESTTYPE="network"
 
 
 kernel_args() {
-    echo vnc debug=1 inst.debug ip=dhcp
+    echo ${DEFAULT_BOOTOPTS} ip=dhcp
 }
 
 prepare() {

--- a/nosave-1.sh
+++ b/nosave-1.sh
@@ -22,7 +22,7 @@ TESTTYPE="logs"
 . ${KSTESTDIR}/functions.sh
 
 kernel_args() {
-    echo vnc debug=1 inst.debug inst.nosave=input_ks
+    echo ${DEFAULT_BOOTOPTS} inst.nosave=input_ks
 }
 
 validate_logs() {

--- a/nosave-2.sh
+++ b/nosave-2.sh
@@ -22,7 +22,7 @@ TESTTYPE="logs"
 . ${KSTESTDIR}/functions.sh
 
 kernel_args() {
-    echo vnc debug=1 inst.debug inst.nosave=output_ks
+    echo ${DEFAULT_BOOTOPTS} inst.nosave=output_ks
 }
 
 validate_logs() {

--- a/nosave-3.sh
+++ b/nosave-3.sh
@@ -22,7 +22,7 @@ TESTTYPE="logs"
 . ${KSTESTDIR}/functions.sh
 
 kernel_args() {
-    echo vnc debug=1 inst.debug inst.nosave=logs
+    echo ${DEFAULT_BOOTOPTS} inst.nosave=logs
 }
 
 validate_logs() {

--- a/onboot-activate-httpks.sh
+++ b/onboot-activate-httpks.sh
@@ -29,7 +29,7 @@ TESTTYPE=${TESTTYPE:-"network"}
 
 kernel_args() {
     . ${tmpdir}/ks_url
-    echo vnc debug=1 inst.debug ip=ens3:dhcp inst.ks=${ks_url}
+    echo ${DEFAULT_BOOTOPTS} ip=ens3:dhcp inst.ks=${ks_url}
 }
 
 # Arguments for virt-install --network options

--- a/onboot-activate.sh
+++ b/onboot-activate.sh
@@ -30,7 +30,7 @@ TESTTYPE="network"
 
 
 kernel_args() {
-    echo vnc debug=1 inst.debug ip=ens3:dhcp
+    echo ${DEFAULT_BOOTOPTS} ip=ens3:dhcp
 }
 
 # Arguments for virt-install --network options

--- a/onboot-bootopts-pre.sh
+++ b/onboot-bootopts-pre.sh
@@ -30,7 +30,7 @@ TESTTYPE=${TESTTYPE:-"network"}
 
 
 kernel_args() {
-    echo vnc debug=1 inst.debug ip=dhcp
+    echo ${DEFAULT_BOOTOPTS} ip=dhcp
 }
 
 # Arguments for virt-install --network options

--- a/proxy-cmdline.sh
+++ b/proxy-cmdline.sh
@@ -24,7 +24,7 @@ TESTTYPE="method proxy"
 . ${KSTESTDIR}/functions-proxy.sh
 
 kernel_args() {
-    echo vnc inst.proxy=${proxy_url%%/*} inst.debug
+    echo ${DEFAULT_BOOTOPTS} inst.proxy=${proxy_url%%/*}
 }
 
 prepare() {

--- a/scripts/run_kickstart_tests.sh
+++ b/scripts/run_kickstart_tests.sh
@@ -62,6 +62,8 @@ KEEPIT=${KEEPIT:-0}
 # responsibility, this can break tests.
 UPDATES_IMG=""
 
+PYTHONPATH="lorax/src"
+
 TESTTYPE=""
 SKIP_TESTTYPES=""
 

--- a/team-httpks.sh
+++ b/team-httpks.sh
@@ -31,7 +31,7 @@ TESTTYPE=${TESTTYPE:-"network"}
 
 kernel_args() {
     . ${tmpdir}/ks_url
-    echo vnc debug=1 inst.debug ip=ens3:dhcp inst.ks=${ks_url}
+    echo ${DEFAULT_BOOTOPTS} ip=ens3:dhcp inst.ks=${ks_url}
 }
 
 # Arguments for virt-install --network options

--- a/team.sh
+++ b/team.sh
@@ -30,7 +30,7 @@ TESTTYPE=${TESTTYPE:-"network"}
 
 
 kernel_args() {
-    echo vnc debug=1 inst.debug ip=ens3:dhcp
+    echo ${DEFAULT_BOOTOPTS} ip=ens3:dhcp
 }
 
 # Arguments for virt-install --network options


### PR DESCRIPTION
If dracut fails to reach successful switchroot it will by default start
its emergency shell and wait for user input.

This is a problem for kickstart tests as all our error monitoring mechanisms
rely on log forwarding from the test VM, which only starts in stage2 after
a successful switchroot.

So add rd.shell=0 rd.emergency=poweroff to default command boot options to
prevent Dracut from entering the emergency shell and to shutdown
instead.