### PR TITLE
Do not tag team-pre as knownfailure

### DIFF
--- a/team-pre.sh
+++ b/team-pre.sh
@@ -24,7 +24,7 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
-TESTTYPE=${TESTTYPE:-"knownfailure network"}
+TESTTYPE=${TESTTYPE:-"network"}
 
 . ${KSTESTDIR}/team.sh
 


### PR DESCRIPTION
It has been fixed in the past and bindtomac-team-pre is currently working.