### PR TITLE
Remove debugging option from network legacy bootopts test

### DIFF
--- a/network-bootopts-static-legacy-httpks.sh
+++ b/network-bootopts-static-legacy-httpks.sh
@@ -36,7 +36,7 @@ ip_static_boot_config=""
 kernel_args() {
     . ${tmpdir}/ip_static_boot_config
     . ${tmpdir}/ks_url
-    echo ${DEFAULT_BASIC_BOOTOPTS} rd.break=cmdline ${ip_static_boot_config} ks=${ks_url}
+    echo ${DEFAULT_BOOTOPTS} ${ip_static_boot_config} ks=${ks_url}
 }
 
 prepare() {


### PR DESCRIPTION
Perhaps debug version of the test has been pushed by accident.