### PR TITLE
ansible: allow using python 3 on ansible managed machines

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -36,10 +36,11 @@ Before running the playbooks the inventory file has to be populated with hosts. 
 
 [kstest-master]
 
-[kstest:all]
+[all:vars]
+#ansible_python_interpreter=/usr/bin/python3
 #ansible_ssh_private_key_file=
 #ansible_ssh_user=fedora
-#ansible_ssh_common_args='-o StrictHostKeyChecking=no'[kstest-master]
+#ansible_ssh_common_args='-o StrictHostKeyChecking=no'
 ```
 
 Depending on the provisioning, access to the hosts may need to be additionally configured:
@@ -57,6 +58,7 @@ Depending on the provisioning, access to the hosts may need to be additionally c
 
 * *Master* is using a *master key* for accessing the *runners* when distributing the *test run*. By default a new keypair is generated when deploying the *master* with `kstest-master-deploy.yml` playbook. It is possible to use custom keypair by setting the playbook variables `master_private_ssh_key` and `master_public_ssh_key` to the paths to the keys. This can be useful if automatic [syncing](#syncing) of results from master to a remote *resutlts host* is used.
 
+To use python 3 for running the playbooks on deployed hosts set the `ansible_python_interpreter` variable. By default python 2 will be installed to the *runners* during deployment.
 
 NOTE: It is also possible to specify the inventory and configure access to *runners* in `ansible.cfg` file by updating `inventory`, `remote_user` and `ssh_private_key` variables. In this case the inventory does not have to be passed to the playbooks with `-i` option. The file should be placed in current working directory.
 ```

--- a/ansible/inventory/hosts
+++ b/ansible/inventory/hosts
@@ -3,6 +3,7 @@
 [kstest-master]
 
 [all:vars]
+#ansible_python_interpreter=/usr/bin/python3
 #ansible_ssh_private_key_file=
 #ansible_ssh_user=fedora
 #ansible_ssh_common_args='-o StrictHostKeyChecking=no'

--- a/ansible/kstest-runners-deploy.yml
+++ b/ansible/kstest-runners-deploy.yml
@@ -7,10 +7,11 @@
 
   gather_facts: False
   pre_tasks:
-    - name: Install python for Ansible
+    - name: Install python2 for Ansible
       raw: rpm -q python2 > /dev/null || dnf -y install python2
       register: output
       changed_when: output.stdout != ""
+      when: ansible_python_interpreter is not defined
     - name: Gathering facts
       setup:
 

--- a/kstests-in-cloud.sh
+++ b/kstests-in-cloud.sh
@@ -30,6 +30,7 @@ VIRTUALENV_PATH=""
 # Defined by linchpin layout configuration.
 INVENTORY_DIR="linchpin/inventories"
 
+ANSIBLE_PYTHON_INTERPRETER=""
 
 usage () {
     cat <<HELP_USAGE
@@ -101,10 +102,17 @@ Options:
     --virtualenv PATH        path to virtualenv location that may be required for linchpin
                              run by scheduler
 
+  Ansible options:
+
+    --ansible-python-interpreter PATH
+                             use alternative python interpreter on deployed hosts;
+                             (for example /usr/bin/python3, /usr/libexec/platform-python)
+
+
 HELP_USAGE
 }
 
-options=$(getopt -o k:r:c:p: --long cloud:,results:,key-name:,key-use-existing,key-upload:,ansible-private-key:,key-use-for-master,test-configuration:,pinfile:,when:,remove,logfile:,scheduled,remote-user:,virtualenv: -- "$@")
+options=$(getopt -o k:r:c:p: --long cloud:,results:,key-name:,key-use-existing,key-upload:,ansible-private-key:,key-use-for-master,test-configuration:,pinfile:,when:,remove,logfile:,scheduled,remote-user:,virtualenv:,ansible-python-interpreter: -- "$@")
 [ $? -eq 0 ] || {
     echo "Usage:"
     usage
@@ -181,6 +189,10 @@ while true; do
     --virtualenv)
         shift;
         VIRTUALENV_PATH=$1
+        ;;
+    --ansible-python-interpreter)
+        shift;
+        ANSIBLE_PYTHON_INTERPRETER=$1
         ;;
     --)
         shift;
@@ -335,6 +347,11 @@ EOF
     if [[ -n ${PRIVATE_KEY_PATH} ]]; then
         cat <<EOF >> ${INVENTORY}
 ansible_ssh_private_key_file=${PRIVATE_KEY_PATH}
+EOF
+    fi
+    if [[ -n ${ANSIBLE_PYTHON_INTERPRETER} ]]; then
+        cat <<EOF >> ${INVENTORY}
+ansible_python_interpreter=${ANSIBLE_PYTHON_INTERPRETER}
 EOF
     fi
 

--- a/linchpin/README.md
+++ b/linchpin/README.md
@@ -67,6 +67,8 @@ Some of them may require using a *script* parameter:
 
 * `image` - Cloud image to be used as the base for *runners* deployment. This may require setting the default remote user for deployment by `--remote-user` option. (For example Fedora cloud images have `fedora` user, RHEL cloud images have `cloud-user`.)
 
+Depending on the OS image used it may be possible to use python 3 for ansible playbooks on deployed hosts by setting the `--ansible-python-interpreter` to the python 3 interpreter path.
+
 Ssh keys
 --------
 


### PR DESCRIPTION
By default python 2 is used and installed as a deployment pre-task.
We should allow to skip the pre-task by defining python interpreter
to be used on managed machines.

Also cleans up typos in ansible README.md doc.