### PR TITLE
ansible: do not use reserved name for a variable

### DIFF
--- a/ansible/kstest-master-configure-test.yml
+++ b/ansible/kstest-master-configure-test.yml
@@ -9,5 +9,5 @@
   roles:
     - role: kstest-master
       vars:
-        action: configure-test
+        master_action: configure-test
 

--- a/ansible/kstest-master-run-test.yml
+++ b/ansible/kstest-master-run-test.yml
@@ -9,4 +9,4 @@
   roles:
     - role: kstest-master
       vars:
-        action: run-test
+        master_action: run-test

--- a/ansible/kstest-master-schedule-test.yml
+++ b/ansible/kstest-master-schedule-test.yml
@@ -9,4 +9,4 @@
   roles:
     - role: kstest-master
       vars:
-        action: schedule-test
+        master_action: schedule-test

--- a/ansible/roles/kstest-master/tasks/main.yml
+++ b/ansible/roles/kstest-master/tasks/main.yml
@@ -2,12 +2,12 @@
 
 - name: Configure test
   import_tasks: configure-test.yml
-  when: action == "configure-test"
+  when: master_action == "configure-test"
 
 - name: Run test
   import_tasks: run-test.yml
-  when: action == "run-test"
+  when: master_action == "run-test"
 
 - name: Schedule test
   import_tasks: schedule-test.yml
-  when: action == "schedule-test"
+  when: master_action == "schedule-test"


### PR DESCRIPTION
Fix this warning:
[WARNING]: Found variable using reserved name: action