### PR TITLE
Add initial RHEL8 platform configuration

### DIFF
--- a/fragments/platform/rhel8/payload/default_packages.ks
+++ b/fragments/platform/rhel8/payload/default_packages.ks
@@ -1,0 +1,3 @@
+# Default RHEL8 packages section (empty)
+%packages
+%end

--- a/fragments/platform/rhel8/repos/default.ks
+++ b/fragments/platform/rhel8/repos/default.ks
@@ -1,0 +1,3 @@
+# Default RHEL8 repositories - BeseOS + AppStream or unified repo can be used
+url RHEL8_BASE_OS_REPO_URL_GOES_HERE
+repo --name=appstream RHEL8_APPSTREAM_REPO_URL_GOES_HERE


### PR DESCRIPTION
Users are expected to use appropriate BaseOS and AppStream URLs
for RHEL8 in the repos/default.ks fragment.