### PR TITLE
Tweak curl ISO download parameters

### DIFF
--- a/ansible/roles/kstest-master/templates/run_tests.sh.j2
+++ b/ansible/roles/kstest-master/templates/run_tests.sh.j2
@@ -125,7 +125,7 @@ EOF
 ### Download the boot.iso
 
 rm -f ${BOOT_ISO}
-curl "${BOOT_ISO_URL}" -o ${BOOT_ISO}
+curl -Lf "${BOOT_ISO_URL}" -o ${BOOT_ISO}
 
 ISO_MD5_SUM=$(md5sum ${BOOT_ISO})
 


### PR DESCRIPTION
Adding two new parameters to curl boot ISO download.

-f -- do not fail silently when getting 404 or similar error
-L -- redirect if it is required by the site