### PR TITLE
Fix ks repo permissions

### DIFF
--- a/ansible/roles/kstest-master/tasks/configure-test.yml
+++ b/ansible/roles/kstest-master/tasks/configure-test.yml
@@ -5,6 +5,14 @@
     file: "{{ test_configuration }}"
   when: test_configuration is defined
 
+# This will prevent problems during checkout (__pycache__ folders will be owned by root)
+- name: Fix permissions on kickstart tests repo
+  file:
+    path: "{{ kstest_git_repo }}"
+    owner: "{{ kstest_remote_user }}"
+    group: "{{ kstest_remote_user }}"
+    recurse: yes
+
 - name: Checkout kickstart tests repo
   become_user: "{{ kstest_remote_user }}"
   git:

--- a/scripts/run_kickstart_tests.sh
+++ b/scripts/run_kickstart_tests.sh
@@ -365,7 +365,7 @@ if [[ "$TEST_REMOTES" != "" ]]; then
         ssh kstest@${remote} mkdir -p kickstart-tests
         ssh kstest@${remote} mkdir -p install_images
         echo "synchronizing tests"
-        rsync -az --delete . kstest@${remote}:kickstart-tests/
+        rsync -az --delete-after --exclude "__pycache__" --exclude ".git/" . kstest@${remote}:kickstart-tests/
         echo "synchronizing installation image"
         rsync -az ${IMAGE} kstest@${remote}:install_images/
     done


### PR DESCRIPTION
This is a fix when sync of the repositories fails thanks to the change in the python code. The `__pycache__` directories will have root permission which will block rsync and checkout.

This is not an ideal fix because directories containing `__pycache__` stays on slaves but it works. See second commit message for a detail explanation.

Fix permissions on master repository before sync.

Tweak rsync from master to slaves. 