### PR TITLE
Fix testing of the swap entry in /etc/fstab

### DIFF
--- a/encrypt-swap.ks.in
+++ b/encrypt-swap.ks.in
@@ -41,8 +41,8 @@ if ! grep -q "$swap_part_dm" /proc/swaps ; then
 fi
 
 # verify that the swap entry in /etc/fstab is correct
-swap_part_regular_entry="^${swap_part_luks}\\s\\+swap\\s"
-swap_part_uuid_entry="^UUID=$(blkid -o value -s UUID $swap_part_luks)\\s\\+swap\\s"
+swap_part_regular_entry="^${swap_part_luks}\\s\\+none\\s\\+swap\\s"
+swap_part_uuid_entry="^UUID=$(blkid -o value -s UUID $swap_part_luks)\\s\\+none\\s\\+swap\\s"
 if ! ( grep -q "$swap_part_regular_entry" /etc/fstab || grep -q "$swap_part_uuid_entry" /etc/fstab ) ; then
     echo "*** encrypted swap partition not found in /etc/fstab" >> /root/RESULT
 fi
@@ -63,8 +63,8 @@ if ! grep -q "$swap_lv_dm" /proc/swaps ; then
 fi
 
 # verify that the swap entry in /etc/fstab is correct
-swap_lv_regular_entry="^${swap_lv_luks}\\s\\+swap\\s"
-swap_lv_uuid_entry="^UUID=$(blkid -o value -s UUID $swap_lv_luks)\\s\\+swap\\s"
+swap_lv_regular_entry="^${swap_lv_luks}\\s\\+none\\s\\+swap\\s"
+swap_lv_uuid_entry="^UUID=$(blkid -o value -s UUID $swap_lv_luks)\\s\\+none\\s\\+swap\\s"
 if ! ( grep -q "$swap_lv_regular_entry" /etc/fstab || grep -q "$swap_lv_uuid_entry" /etc/fstab ) ; then
     echo "*** encrypted swap LV is not in /etc/fstab" >> /root/RESULT
 fi
@@ -81,8 +81,8 @@ if ! grep -q "$swap_md_dm" /proc/swaps ; then
     echo "*** encrypted swap MD is not active" >> /root/RESULT
 fi
 
-swap_md_regular_entry="^${swap_md_luks}\\s\\+swap\\s"
-swap_md_uuid_entry="^UUID=$(blkid -o value -s UUID $swap_md_luks)\\s\\+swap\\s"
+swap_md_regular_entry="^${swap_md_luks}\\s\\+none\\s\\+swap\\s"
+swap_md_uuid_entry="^UUID=$(blkid -o value -s UUID $swap_md_luks)\\s\\+none\\s\\+swap\\s"
 if ! ( grep -q "$swap_md_regular_entry" /etc/fstab || grep -q "$swap_md_uuid_entry" /etc/fstab ) ; then
     echo "*** encrypted swap MD is not in /etc/fstab" >> /root/RESULT
 fi

--- a/lvm-1.ks.in
+++ b/lvm-1.ks.in
@@ -63,8 +63,8 @@ if ! grep -q $swap_dm /proc/swaps ; then
 fi
 
 # verify swap entry in /etc/fstab is correct
-swap_lv_entry="$(grep ^$swap_lv\\s\\+swap\\s /etc/fstab)"
-swap_uuid_entry="$(grep ^$swap_uuid\\s\\+swap\\s /etc/fstab)"
+swap_lv_entry="$(grep ^$swap_lv\\s\\+none\\s\\+swap\\s /etc/fstab)"
+swap_uuid_entry="$(grep ^$swap_uuid\\s\\+none\\s\\+swap\\s /etc/fstab)"
 if [ -z "$swap_lv_entry" -a -z "$swap_uuid_entry" ] ; then
     echo "*** swap lv is not in /etc/fstab" >> /root/RESULT
 fi

--- a/lvm-cache-1.ks.in
+++ b/lvm-cache-1.ks.in
@@ -77,8 +77,8 @@ if ! grep -q "$swap_dm" /proc/swaps ; then
 fi
 
 # verify swap entry in /etc/fstab is correct
-swap_lv_entry=$(grep ^$swap_lv\\s\\+swap\\s /etc/fstab)
-swap_uuid_entry=$(grep ^$swap_uuid\\s\\+swap\\s /etc/fstab)
+swap_lv_entry=$(grep ^$swap_lv\\s\\+none\\s\\+swap\\s /etc/fstab)
+swap_uuid_entry=$(grep ^$swap_uuid\\s\\+none\\s\\+swap\\s /etc/fstab)
 if [ -z "$swap_lv_entry" -a -z "$swap_uuid_entry" ] ; then
     echo "*** swap lv is not in /etc/fstab" >> /root/RESULT
 fi

--- a/lvm-cache-2.ks.in
+++ b/lvm-cache-2.ks.in
@@ -70,8 +70,8 @@ if ! grep -q "$swap_dm" /proc/swaps ; then
 fi
 
 # verify swap entry in /etc/fstab is correct
-swap_lv_entry=$(grep ^$swap_lv\\s\\+swap\\s /etc/fstab)
-swap_uuid_entry=$(grep ^$swap_uuid\\s\\+swap\\s /etc/fstab)
+swap_lv_entry=$(grep ^$swap_lv\\s\\+none\\s\\+swap\\s /etc/fstab)
+swap_uuid_entry=$(grep ^$swap_uuid\\s\\+none\\s\\+swap\\s /etc/fstab)
 if [ -z "$swap_lv_entry" -a -z "$swap_uuid_entry" ] ; then
     echo "*** swap lv is not in /etc/fstab" >> /root/RESULT
 fi

--- a/lvm-raid-1.ks.in
+++ b/lvm-raid-1.ks.in
@@ -68,8 +68,8 @@ if ! grep -q $swap_dm /proc/swaps ; then
 fi
 
 # verify swap entry in /etc/fstab is correct
-swap_lv_entry="$(grep ^$swap_lv\\s\\+swap\\s /etc/fstab)"
-swap_uuid_entry="$(grep ^$swap_uuid\\s\\+swap\\s /etc/fstab)"
+swap_lv_entry="$(grep ^$swap_lv\\s\\+none\\s\\+swap\\s /etc/fstab)"
+swap_uuid_entry="$(grep ^$swap_uuid\\s\\+none\\s\\+swap\\s /etc/fstab)"
 if [ -z "$swap_lv_entry" -a -z "$swap_uuid_entry" ] ; then
     echo "*** swap lv is not in /etc/fstab" >> /root/RESULT
 fi

--- a/lvm-thinp-1.ks.in
+++ b/lvm-thinp-1.ks.in
@@ -88,8 +88,8 @@ if ! grep -q $swap_dm /proc/swaps ; then
 fi
 
 # verify swap entry in /etc/fstab is correct
-swap_lv_entry="$(grep ^$swap_lv\\s\\+swap\\s /etc/fstab)"
-swap_uuid_entry="$(grep ^$swap_uuid\\s\\+swap\\s /etc/fstab)"
+swap_lv_entry="$(grep ^$swap_lv\\s\\+none\\s\\+swap\\s /etc/fstab)"
+swap_uuid_entry="$(grep ^$swap_uuid\\s\\+none\\s\\+swap\\s /etc/fstab)"
 if [ -z "$swap_lv_entry" -a -z "$swap_uuid_entry" ] ; then
     echo "*** swap lv is not in /etc/fstab" >> /root/RESULT
 fi

--- a/lvm-thinp-2.ks.in
+++ b/lvm-thinp-2.ks.in
@@ -88,8 +88,8 @@ if ! grep -q $swap_dm /proc/swaps ; then
 fi
 
 # verify swap entry in /etc/fstab is correct
-swap_lv_entry="$(grep ^$swap_lv\\s\\+swap\\s /etc/fstab)"
-swap_uuid_entry="$(grep ^$swap_uuid\\s\\+swap\\s /etc/fstab)"
+swap_lv_entry="$(grep ^$swap_lv\\s\\+none\\s\\+swap\\s /etc/fstab)"
+swap_uuid_entry="$(grep ^$swap_uuid\\s\\+none\\s\\+swap\\s /etc/fstab)"
 if [ -z "$swap_lv_entry" -a -z "$swap_uuid_entry" ] ; then
     echo "*** swap lv is not in /etc/fstab" >> /root/RESULT
 fi

--- a/raid-1.ks.in
+++ b/raid-1.ks.in
@@ -80,8 +80,8 @@ if ! grep -q $swap_md /proc/swaps ; then
 fi
 
 # verify swap entry in /etc/fstab is correct
-swap_md_entry="$(grep ^$swap_md\\sswap\\s /etc/fstab)"
-swap_uuid_entry="$(grep ^$swap_uuid\\sswap\\s /etc/fstab)"
+swap_md_entry="$(grep ^$swap_md\\s\\+none\\s\\+swap\\s /etc/fstab)"
+swap_uuid_entry="$(grep ^$swap_uuid\\s\\+none\\s\\+swap\\s /etc/fstab)"
 if [ -z "$swap_md_entry" -a -z "$swap_uuid_entry" ] ; then
     echo "*** swap md is not in /etc/fstab" >> /root/RESULT
 fi


### PR DESCRIPTION
In /etc/fstab, the field, that describes the mount point for the
filesystem, should be specified as 'none' for swap partitions.

Related: rhbz#1258322