### PR TITLE
Fix running kstests from boot.iso with virt-install 2.1.0

### DIFF
--- a/scripts/launcher/lib/virtual_controller.py
+++ b/scripts/launcher/lib/virtual_controller.py
@@ -157,7 +157,7 @@ class VirtualInstall(object):
             args.append(extra_args)
 
             args.append("--location")
-            args.append(self._iso.mount_dir)
+            args.append(self._iso.iso_path + ",kernel=isolinux/vmlinuz,initrd=isolinux/initrd.img")
 
         channel_args = "tcp,host={0}:{1},mode=connect,target_type=virtio" \
                        ",name=org.fedoraproject.anaconda.log.0".format(


### PR DESCRIPTION
Note, this *requires* virt-install 2.1.0, older versions of virt-install available in F28 and earlier will not work with it.