### PR TITLE
Enable compression when transferring results via scp

### DIFF
--- a/scripts/run_kickstart_tests.sh
+++ b/scripts/run_kickstart_tests.sh
@@ -425,7 +425,7 @@ if [[ "$TEST_REMOTES" != "" ]]; then
             ssh kstest@${remote} sudo chmod -R a+r /var/tmp/kstest-\*
             # Fix permissions of log folders gathered via libguestfs
             ssh kstest@${remote} sudo find /var/tmp/kstest-\* -type d -exec chmod 755 {} +
-            scp -r kstest@${remote}:/var/tmp/kstest-\* /var/tmp/
+            scp -C -r kstest@${remote}:/var/tmp/kstest-\* /var/tmp/
         fi
 
         ssh kstest@${remote} sudo rm -rf /var/tmp/kstest-\*


### PR DESCRIPTION
Pass the -C flag to scp when transferring the results from
remote kickstart test workers, which should enabled compression
on the SSH channel used by scp.

This should not make anything slower but might speed up things a bit
as many of the artifacts are plain text log files which should
compress quite well.