### PR TITLE
Use the SATA bus

### DIFF
--- a/scripts/launcher/lib/virtual_controller.py
+++ b/scripts/launcher/lib/virtual_controller.py
@@ -126,7 +126,7 @@ class VirtualInstall(object):
 
         for disk in self._disk_paths:
             args.append("--disk")
-            args.append("path={0}".format(disk))
+            args.append("path={0},bus=sata".format(disk))
 
         for nic in self._nics or []:
             args.append("--network")


### PR DESCRIPTION
The default bus is hypervisor dependent since not all hypervisors
support all bus types. With SATA or SCSI, the disk will show up as
sda. Otherwise it might show up as vda and some kickstart tests
might fail because of that.