### PR TITLE
Enforce the cleared boot drive

### DIFF
--- a/clearpart-2.ks.in
+++ b/clearpart-2.ks.in
@@ -4,7 +4,7 @@ url @KSTEST_URL@
 install
 network --bootproto=dhcp
 
-bootloader --timeout=1
+bootloader --timeout=1 --boot-drive=sda
 clearpart --all --drives=sda --initlabel
 autopart
 


### PR DESCRIPTION
Enforce to use the cleared and initialized sda as the boot drive.
Otherwise, the installation could fail to continue with the sdb
boot drive.