### PR TITLE
Show the unexpected .mo files in error messages

### DIFF
--- a/packages-instlangs-1.ks.in
+++ b/packages-instlangs-1.ks.in
@@ -12,7 +12,7 @@
 # Make sure no non-english .mo files were installed
 molist="$(find /usr/share/locale \( -name 'en' -type d -prune \) -o \( -name 'en[@_]*' -type d -prune \) -o \( -name '*.mo' -print \) )"
 if [ -n "$molist" ]; then
-    echo "*** non-en .mo files were installed" >> /root/RESULT
+    echo "*** non-en .mo files were installed: $molist" >> /root/RESULT
 fi
 
 # Check that the en_US locale was installed

--- a/packages-instlangs-2.ks.in
+++ b/packages-instlangs-2.ks.in
@@ -12,7 +12,7 @@
 # Make sure no .mo files were installed
 molist="$(find /usr/share/locale -name '*.mo')"
 if [ -n "$molist" ]; then
-    echo "*** .mo files were installed" >> /root/RESULT
+    echo "*** .mo files were installed: $molist" >> /root/RESULT
 fi
 
 %ksappend validation/success_if_result_empty.ks


### PR DESCRIPTION
Show the unexpected .mo files in error messages of the instlangs tests,
so we can open bugs for packages that install these files.