### PR TITLE
Use repo fragment in storage related kickstart tests

### DIFF
--- a/autopart-encrypted-1.ks.in
+++ b/autopart-encrypted-1.ks.in
@@ -1,6 +1,6 @@
 #test name: autopart-encrypted-1
 
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/autopart-encrypted-2.ks.in
+++ b/autopart-encrypted-2.ks.in
@@ -1,6 +1,6 @@
 #test name: autopart-encrypted-2
 
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/autopart-encrypted-3.ks.in
+++ b/autopart-encrypted-3.ks.in
@@ -1,6 +1,6 @@
 #test name: autopart-encrypted-3
 
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/autopart-fstype.ks.in
+++ b/autopart-fstype.ks.in
@@ -1,5 +1,5 @@
 #test name: autopart-fstype
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/autopart-luks-1.ks.in
+++ b/autopart-luks-1.ks.in
@@ -1,6 +1,6 @@
 #test name: autopart-luks-1
 
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/autopart-luks-2.ks.in
+++ b/autopart-luks-2.ks.in
@@ -1,6 +1,6 @@
 #test name: autopart-luks-2
 
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/autopart-luks-3.ks.in
+++ b/autopart-luks-3.ks.in
@@ -1,6 +1,6 @@
 #test name: autopart-luks-3
 
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/autopart-luks-4.ks.in
+++ b/autopart-luks-4.ks.in
@@ -1,6 +1,6 @@
 #test name: autopart-luks-4
 
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/autopart-luks-5.ks.in
+++ b/autopart-luks-5.ks.in
@@ -1,6 +1,6 @@
 #test name: autopart-luks-5
 
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/autopart-nohome.ks.in
+++ b/autopart-nohome.ks.in
@@ -1,5 +1,5 @@
 #test name: autopart-nohome
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/bootloader-1.ks.in
+++ b/bootloader-1.ks.in
@@ -1,4 +1,4 @@
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/bootloader-2.ks.in
+++ b/bootloader-2.ks.in
@@ -1,4 +1,4 @@
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/bootloader-3.ks.in
+++ b/bootloader-3.ks.in
@@ -1,4 +1,4 @@
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/bootloader-4.ks.in
+++ b/bootloader-4.ks.in
@@ -1,4 +1,4 @@
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/bootloader-5.ks.in
+++ b/bootloader-5.ks.in
@@ -1,4 +1,4 @@
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/btrfs-1.ks.in
+++ b/btrfs-1.ks.in
@@ -1,5 +1,5 @@
 #test name: btrfs-1
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/btrfs-2.ks.in
+++ b/btrfs-2.ks.in
@@ -1,5 +1,5 @@
 #test name: btrfs-2
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/clearpart-2.ks.in
+++ b/clearpart-2.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: ignoredisk
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/clearpart-3.ks.in
+++ b/clearpart-3.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: ignoredisk
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/clearpart-4.ks.in
+++ b/clearpart-4.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: ignoredisk
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/default-fstype.ks.in
+++ b/default-fstype.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: default-fstype
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/encrypt-device.ks.in
+++ b/encrypt-device.ks.in
@@ -1,5 +1,5 @@
 #test name: encrypt-device
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/encrypt-swap.ks.in
+++ b/encrypt-swap.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: encrypt-swap
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/ignoredisk-1.ks.in
+++ b/ignoredisk-1.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: ignoredisk
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/ignoredisk-2.ks.in
+++ b/ignoredisk-2.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: ignoredisk
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/iscsi-bind.ks.in
+++ b/iscsi-bind.ks.in
@@ -1,6 +1,6 @@
 #test name: iscsi-bind
 
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 iscsiname @KSTEST_ISCSINAME@

--- a/iscsi.ks.in
+++ b/iscsi.ks.in
@@ -1,6 +1,6 @@
 #test name: iscsi-root
 
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 iscsiname @KSTEST_ISCSINAME@

--- a/lvm-1.ks.in
+++ b/lvm-1.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: lvm-1
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/lvm-2.ks.in
+++ b/lvm-2.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: lvm-2
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/lvm-cache-1.ks.in
+++ b/lvm-cache-1.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: lvm-cache-1
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/lvm-cache-2.ks.in
+++ b/lvm-cache-2.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: lvm-cache-2
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/lvm-luks-1.ks.in
+++ b/lvm-luks-1.ks.in
@@ -1,6 +1,6 @@
 #test name: lvm-luks-1
 
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/lvm-luks-2.ks.in
+++ b/lvm-luks-2.ks.in
@@ -1,6 +1,6 @@
 #test name: lvm-luks-2
 
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/lvm-luks-3.ks.in
+++ b/lvm-luks-3.ks.in
@@ -1,6 +1,6 @@
 #test name: lvm-luks-3
 
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/lvm-luks-4.ks.in
+++ b/lvm-luks-4.ks.in
@@ -1,6 +1,6 @@
 #test name: lvm-luks-4
 
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/lvm-raid-1.ks.in
+++ b/lvm-raid-1.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: lvm-raid-1
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/lvm-thinp-1.ks.in
+++ b/lvm-thinp-1.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: lvm-thinp-1
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/lvm-thinp-2.ks.in
+++ b/lvm-thinp-2.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: lvm-thinp-2
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/mountpoint-assignment-1.ks.in
+++ b/mountpoint-assignment-1.ks.in
@@ -1,7 +1,7 @@
 #version=DEVEL
 #test name: mountpoint-assignment-1
 
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 bootloader --timeout=1

--- a/mountpoint-assignment-2.ks.in
+++ b/mountpoint-assignment-2.ks.in
@@ -1,7 +1,7 @@
 #version=DEVEL
 #test name: mountpoint-assignment-2
 
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 bootloader --timeout=1

--- a/network-bootopts-static-legacy-httpks.ks.in
+++ b/network-bootopts-static-legacy-httpks.ks.in
@@ -1,6 +1,6 @@
 #test name: network-static-to-dhcp-pre
 # Testing legacy boot options (rhel6). Works on RHEL 7, doesn't work on Fedora 26
-url @KSTEST_URL@
+%ksappend repos/default.ks
 
 # We need a device with dns configured for repo
 network --device=@KSTEST_NETDEV2@ --bootproto dhcp

--- a/part-luks-1.ks.in
+++ b/part-luks-1.ks.in
@@ -1,6 +1,6 @@
 #test name: part-luks-1
 
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/part-luks-2.ks.in
+++ b/part-luks-2.ks.in
@@ -1,6 +1,6 @@
 #test name: part-luks-2
 
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/part-luks-3.ks.in
+++ b/part-luks-3.ks.in
@@ -1,6 +1,6 @@
 #test name: part-luks-3
 
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/part-luks-4.ks.in
+++ b/part-luks-4.ks.in
@@ -1,6 +1,6 @@
 #test name: part-luks-4
 
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/raid-1.ks.in
+++ b/raid-1.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: raid-1
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/raid-luks-1.ks.in
+++ b/raid-luks-1.ks.in
@@ -1,7 +1,7 @@
 #version=DEVEL
 #test name: raid-luks-1
 
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/raid-luks-2.ks.in
+++ b/raid-luks-2.ks.in
@@ -1,7 +1,7 @@
 #version=DEVEL
 #test name: raid-luks-2
 
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/raid-luks-3.ks.in
+++ b/raid-luks-3.ks.in
@@ -1,7 +1,7 @@
 #version=DEVEL
 #test name: raid-luks-3
 
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/raid-luks-4.ks.in
+++ b/raid-luks-4.ks.in
@@ -1,7 +1,7 @@
 #version=DEVEL
 #test name: raid-luks-4
 
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/reqpart.ks.in
+++ b/reqpart.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: reqpart
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/snapshot-post.ks.in
+++ b/snapshot-post.ks.in
@@ -1,5 +1,5 @@
 #test name: snapshot-post
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/snapshot-pre.ks.in
+++ b/snapshot-pre.ks.in
@@ -1,5 +1,5 @@
 #test name: snapshot-pre
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 


### PR DESCRIPTION
Use the repos/default.ks fragment in storage related kickstart
tests.

By default this will make sure a corresponding modular repo
is available as well as making it easily possible to inject
arbitrary other repositories for all tests when needed.