### PR TITLE
Use repo fragment in network related kickstart tests

### DIFF
--- a/bindtomac-bond-vlan-httpks.ks.in
+++ b/bindtomac-bond-vlan-httpks.ks.in
@@ -1,5 +1,5 @@
 #test name: bindtomac-bond-vlan
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 network --device bond0 --bootproto static --ip @KSTEST_STATIC_IP@ --netmask @KSTEST_STATIC_NETMASK@ --gateway @KSTEST_STATIC_GATEWAY@ --bondslaves=@KSTEST_NETDEV2@,@KSTEST_NETDEV3@ --bondopts=mode=active-backup,miimon-100,primary=@KSTEST_NETDEV2@ --activate --vlanid=222 --activate --onboot=no --bindto=mac

--- a/bindtomac-bond2-httpks.ks.in
+++ b/bindtomac-bond2-httpks.ks.in
@@ -1,5 +1,5 @@
 #test name: bindtomac-bond2
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 network --device bond0 --bootproto dhcp --bondslaves=@KSTEST_NETDEV2@,@KSTEST_NETDEV3@ --bondopts=mode=active-backup,primary=@KSTEST_NETDEV2@ --activate --onboot=no --bindto=mac

--- a/bindtomac-bond2-pre.ks.in
+++ b/bindtomac-bond2-pre.ks.in
@@ -1,6 +1,6 @@
 #test name: bindtomac-bond2-pre
 #NOTE: this test is a variant of bond2 test, it is sharing its .sh file (setup of NICs and network boot configuration) so beware of changing it independently of bond2 test
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 %include /tmp/ksinclude

--- a/bindtomac-bridge-2devs-httpks.ks.in
+++ b/bindtomac-bridge-2devs-httpks.ks.in
@@ -1,7 +1,7 @@
 #test name bindtomac-bridge-2devs
 # One bridge with slave activated in dracut,
 # the other one with slave activated only with the bridge
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 # --onboot=no doesn't make much sense as a use case but we want to test that it works in this test

--- a/bindtomac-bridge-2devs-pre.ks.in
+++ b/bindtomac-bridge-2devs-pre.ks.in
@@ -1,7 +1,7 @@
 #test name bindtomac-bridge-2devs-pre
 # One bridge with slave activated in dracut,
 # the other one with slave activated only with the bridge
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 %include /tmp/ksinclude

--- a/bindtomac-bridge-httpks.ks.in
+++ b/bindtomac-bridge-httpks.ks.in
@@ -1,5 +1,5 @@
 #test name bindtomac-bridge
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 # --onboot=no doesn't make much sense as a use case but we want to test that it works in this test

--- a/bindtomac-bridge-no-bootopts-net.ks.in
+++ b/bindtomac-bridge-no-bootopts-net.ks.in
@@ -2,7 +2,7 @@
 # Test activating bridge from kickstart in dracut (requires no active network
 # when parsing kickstart, ie ks=hd: or ks=file:)
 # https://bugzilla.redhat.com/show_bug.cgi?id=1373360
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 # --onboot=no doesn't make much sense as a use case but we want to test that it works in this test

--- a/bindtomac-bridged-bond-httpks.ks.in
+++ b/bindtomac-bridged-bond-httpks.ks.in
@@ -1,5 +1,5 @@
 #test name bindtomac-bridged-bond
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 network --device=@KSTEST_NETDEV1@ --bootproto=dhcp --onboot=yes --activate

--- a/bindtomac-ifname-httpks.ks.in
+++ b/bindtomac-ifname-httpks.ks.in
@@ -1,5 +1,5 @@
 #test name: bindtomac-ifname-httpks
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 network --bootproto=dhcp --device=ifname0 --ipv6=2001:cafe:cafe::2/64 --bindto=mac

--- a/bindtomac-network-device-default-httpks.ks.in
+++ b/bindtomac-network-device-default-httpks.ks.in
@@ -3,7 +3,7 @@
 #      in initrafs (ifcfg files created by parse-kickstart). The parse-kickstart
 #      code actually ignores the command without --device specified
 #      (and no ksdevice set), so it will be applied in anaconda.
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 network --bootproto=dhcp --ipv6=2001:cafe:cafe::1/64 --bindto=mac

--- a/bindtomac-network-device-mac-httpks.ks.in
+++ b/bindtomac-network-device-mac-httpks.ks.in
@@ -1,5 +1,5 @@
 #test name: bindtomac-network-device-mac
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 network --bootproto=dhcp --device=52:54:00:12:34:51 --bindto=mac

--- a/bindtomac-network-device-mac-pre.ks.in
+++ b/bindtomac-network-device-mac-pre.ks.in
@@ -1,5 +1,5 @@
 #test name: bindtomac-network-device-mac-pre
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 %include /tmp/ksinclude

--- a/bindtomac-network-device-mac.ks.in
+++ b/bindtomac-network-device-mac.ks.in
@@ -1,5 +1,5 @@
 #test name: bindtomac-network-device-mac
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 network --bootproto=dhcp --device=52:54:00:12:34:50 --bindto=mac

--- a/bindtomac-network-static-2-httpks.ks.in
+++ b/bindtomac-network-static-2-httpks.ks.in
@@ -1,6 +1,6 @@
 #test name: bindtomac-network-static-2
 #various combinations of activation in initramfs and stage 2
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 # activated in initramfs with dhcp, reactivated in stage 2
 network --device=@KSTEST_NETDEV2@ --bootproto static --ip @KSTEST_STATIC_IP1@ --netmask @KSTEST_STATIC_NETMASK@ --gateway @KSTEST_STATIC_GATEWAY@ --bindto mac

--- a/bindtomac-network-static-to-dhcp-pre-single.ks.in
+++ b/bindtomac-network-static-to-dhcp-pre-single.ks.in
@@ -1,6 +1,6 @@
 #test name: bindtomac-network-static-to-dhcp-pre-single
 # rhbz#1432886
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 %include /tmp/ksinclude
 %pre

--- a/bindtomac-onboot-activate-httpks.ks.in
+++ b/bindtomac-onboot-activate-httpks.ks.in
@@ -1,5 +1,5 @@
 #test name: bindtomac-onboot-activate-httpks
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --device=@KSTEST_NETDEV2@ --bootproto=dhcp --no-activate --onboot=yes --bindto=mac
 network --device=@KSTEST_NETDEV1@ --bootproto=dhcp --onboot=no --bindto=mac

--- a/bindtomac-onboot-bootopts-pre.ks.in
+++ b/bindtomac-onboot-bootopts-pre.ks.in
@@ -1,5 +1,5 @@
 #test name: bindtomac-onboot-bootopts-pre
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 %include /tmp/ksinclude

--- a/bindtomac-team-httpks.ks.in
+++ b/bindtomac-team-httpks.ks.in
@@ -1,5 +1,5 @@
 #test name: bindtomac-team
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 network --device team0 --bootproto dhcp --teamslaves="@KSTEST_NETDEV2@'{\"prio\": -10, \"sticky\": true}',@KSTEST_NETDEV3@'{\"prio\": 100}'" --teamconfig="{\"runner\": {\"name\": \"activebackup\"}}" --activate --onboot=no --bindto=mac

--- a/bindtomac-team-pre.ks.in
+++ b/bindtomac-team-pre.ks.in
@@ -1,6 +1,6 @@
 #test name: bindtomac-team-pre
 #NOTE: this test is a variant of team test, it is sharing its .sh file (setup of NICs and network boot configuration) so beware of changing it independently of team test
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 %include /tmp/ksinclude

--- a/bond-vlan-httpks.ks.in
+++ b/bond-vlan-httpks.ks.in
@@ -1,5 +1,5 @@
 #test name: bond-vlan
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 network --device bond0 --bootproto static --ip @KSTEST_STATIC_IP@ --netmask @KSTEST_STATIC_NETMASK@ --gateway @KSTEST_STATIC_GATEWAY@ --bondslaves=@KSTEST_NETDEV2@,@KSTEST_NETDEV3@ --bondopts=mode=active-backup,miimon-100,primary=@KSTEST_NETDEV2@ --activate --vlanid=222 --activate --onboot=no

--- a/bond.ks.in
+++ b/bond.ks.in
@@ -1,5 +1,5 @@
 #test name: bond
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --device=link --bootproto=dhcp
 

--- a/bond2-httpks.ks.in
+++ b/bond2-httpks.ks.in
@@ -1,5 +1,5 @@
 #test name: bond2
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 network --device bond0 --bootproto dhcp --bondslaves=@KSTEST_NETDEV2@,@KSTEST_NETDEV3@ --bondopts=mode=active-backup,primary=@KSTEST_NETDEV2@ --activate --onboot=no

--- a/bond2-pre.ks.in
+++ b/bond2-pre.ks.in
@@ -1,6 +1,6 @@
 #test name: bond2-pre
 #NOTE: this test is a variant of bond2 test, it is sharing its .sh file (setup of NICs and network boot configuration) so beware of changing it independently of bond2 test
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 %include /tmp/ksinclude

--- a/bridge-2devs-httpks.ks.in
+++ b/bridge-2devs-httpks.ks.in
@@ -1,7 +1,7 @@
 #test name bridge-2devs
 # One bridge with slave activated in dracut,
 # the other one with slave activated only with the bridge
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 # --onboot=no doesn't make much sense as a use case but we want to test that it works in this test

--- a/bridge-2devs-pre.ks.in
+++ b/bridge-2devs-pre.ks.in
@@ -1,7 +1,7 @@
 #test name bridge-2devs-pre
 # One bridge with slave activated in dracut,
 # the other one with slave activated only with the bridge
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 %include /tmp/ksinclude

--- a/bridge-2devs.ks.in
+++ b/bridge-2devs.ks.in
@@ -1,7 +1,7 @@
 #test name bridge-2devs
 # One bridge with slave activated in dracut,
 # the other one with slave activated only with the bridge
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 # --onboot=no doesn't make much sense as a use case but we want to test that it works in this test

--- a/bridge-httpks.ks.in
+++ b/bridge-httpks.ks.in
@@ -1,5 +1,5 @@
 #test name bridge
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 # --onboot=no doesn't make much sense as a use case but we want to test that it works in this test

--- a/bridge-no-bootopts-net.ks.in
+++ b/bridge-no-bootopts-net.ks.in
@@ -2,7 +2,7 @@
 # Test activating bridge from kickstart in dracut (requires no active network
 # when parsing kickstart, ie ks=hd: or ks=file:)
 # https://bugzilla.redhat.com/show_bug.cgi?id=1373360
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 # --onboot=no doesn't make much sense as a use case but we want to test that it works in this test

--- a/bridged-bond-httpks.ks.in
+++ b/bridged-bond-httpks.ks.in
@@ -1,5 +1,5 @@
 #test name bridged-bond
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 network --device=@KSTEST_NETDEV1@ --bootproto=dhcp --onboot=yes --activate

--- a/bridged-bond-pre.ks.in
+++ b/bridged-bond-pre.ks.in
@@ -1,5 +1,5 @@
 # test name bridged-bond-pre
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 %include /tmp/ksinclude

--- a/hostname-bootopts.ks.in
+++ b/hostname-bootopts.ks.in
@@ -1,6 +1,6 @@
 #test name: hostname-bootopts
 # rhbz#1441337
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 bootloader --timeout=1

--- a/hostname.ks.in
+++ b/hostname.ks.in
@@ -1,5 +1,5 @@
 #test name: hostname
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 # Set hostname for testing

--- a/ibft.ks.in
+++ b/ibft.ks.in
@@ -1,6 +1,6 @@
 #test name: ibft
 
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 bootloader --timeout=1

--- a/ifname-httpks.ks.in
+++ b/ifname-httpks.ks.in
@@ -1,5 +1,5 @@
 #test name: ifname
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 network --bootproto=dhcp --device=ifname0 --ipv6=2001:cafe:cafe::2/64

--- a/network-device-bootif-httpks.ks.in
+++ b/network-device-bootif-httpks.ks.in
@@ -1,5 +1,5 @@
 #test name: network-device-bootif
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 network --device=bootif --bootproto=dhcp --ipv6=2001:cafe:cafe::1/64

--- a/network-device-default-ksdevice-httpks.ks.in
+++ b/network-device-default-ksdevice-httpks.ks.in
@@ -3,7 +3,7 @@
 #      in initrafs (ifcfg files created by parse-kickstart). The code actually
 #      ignores the command without --device specified (and no ksdevice set),
 #      but it will be applied in anaconda.
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 network --bootproto=dhcp --ipv6=2001:cafe:cafe::1/64

--- a/network-device-default-ksdevice-pre.ks.in
+++ b/network-device-default-ksdevice-pre.ks.in
@@ -3,7 +3,7 @@
 #      in initrafs (ifcfg files created by parse-kickstart). The code actually
 #      ignores the command without --device specified (and no ksdevice set),
 #      but it will be applied in anaconda.
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 %include /tmp/ksinclude

--- a/network-device-default-pre-hostname.ks.in
+++ b/network-device-default-pre-hostname.ks.in
@@ -1,6 +1,6 @@
 #test name: network-device-default-pre-hostname
 # rhbz#1272274
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 %include /tmp/ksinclude

--- a/network-device-default.ks.in
+++ b/network-device-default.ks.in
@@ -1,5 +1,5 @@
 #test name: network-device-default
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 network --bootproto=dhcp --ipv6=2001:cafe:cafe::1/64

--- a/network-device-mac-httpks.ks.in
+++ b/network-device-mac-httpks.ks.in
@@ -1,5 +1,5 @@
 #test name: network-device-mac
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 network --bootproto=dhcp --device=52:54:00:12:34:57

--- a/network-device-mac-pre.ks.in
+++ b/network-device-mac-pre.ks.in
@@ -1,5 +1,5 @@
 #test name: network-device-mac-pre
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 %include /tmp/ksinclude

--- a/network-device-mac.ks.in
+++ b/network-device-mac.ks.in
@@ -1,5 +1,5 @@
 #test name: network-device-mac
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 network --bootproto=dhcp --device=52:54:00:12:34:56

--- a/network-missing-ifcfg-httpks.ks.in
+++ b/network-missing-ifcfg-httpks.ks.in
@@ -1,6 +1,6 @@
 #test name: network-missing-ifcfg
 #creating missing ifcfg files (devices not activated in initramfs and not configured in kickstart)
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 bootloader --timeout=1

--- a/network-noipv4-httpks.ks.in
+++ b/network-noipv4-httpks.ks.in
@@ -1,5 +1,5 @@
 #test name: network-noipv4-httpks
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 network --device=@KSTEST_NETDEV2@ --noipv4 --no-activate --onboot=yes

--- a/network-noipv4-pre.ks.in
+++ b/network-noipv4-pre.ks.in
@@ -1,5 +1,5 @@
 #test name: network-noipv4-pre
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 %include /tmp/ksinclude

--- a/network-prefixdevname.ks.in
+++ b/network-prefixdevname.ks.in
@@ -1,5 +1,5 @@
 #test name: network-prefixdevname
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 %include /tmp/ksinclude

--- a/network-static-2-httpks.ks.in
+++ b/network-static-2-httpks.ks.in
@@ -1,6 +1,6 @@
 #test name: network-static-2
 #various combinations of activation in initramfs and stage 2
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 # activated in initramfs with dhcp, reactivated in stage 2
 network --device=@KSTEST_NETDEV2@ --bootproto static --ip @KSTEST_STATIC_IP1@ --netmask @KSTEST_STATIC_NETMASK@ --gateway @KSTEST_STATIC_GATEWAY@

--- a/network-static-2-pre.ks.in
+++ b/network-static-2-pre.ks.in
@@ -1,6 +1,6 @@
 #test name: network-static-2-pre
 #various combinations of activation in initramfs and stage 2
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 %include /tmp/ksinclude

--- a/network-static-httpks.ks.in
+++ b/network-static-httpks.ks.in
@@ -1,5 +1,5 @@
 #test name: network-static
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --device=@KSTEST_NETDEV2@ --bootproto static --ip @KSTEST_STATIC_IP@ --netmask @KSTEST_STATIC_NETMASK@ --gateway @KSTEST_STATIC_GATEWAY@ --onboot=no
 

--- a/network-static-to-dhcp-pre-single.ks.in
+++ b/network-static-to-dhcp-pre-single.ks.in
@@ -1,6 +1,6 @@
 #test name: network-static-to-dhcp-pre-single
 # rhbz#1432886
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 %include /tmp/ksinclude
 %pre

--- a/network-static-to-dhcp-pre.ks.in
+++ b/network-static-to-dhcp-pre.ks.in
@@ -1,7 +1,7 @@
 #test name: network-static-to-dhcp-pre
 # rhbz#1433891
 # rhbz#1432886
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 %include /tmp/ksinclude
 %pre

--- a/network-static.ks.in
+++ b/network-static.ks.in
@@ -1,5 +1,5 @@
 #test name: network-static
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --device=@KSTEST_NETDEV2@ --bootproto static --ip @KSTEST_STATIC_IP@ --netmask @KSTEST_STATIC_NETMASK@ --gateway @KSTEST_STATIC_GATEWAY@ --onboot=no
 

--- a/ntp-nontp-without-chrony-gui.ks.in
+++ b/ntp-nontp-without-chrony-gui.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: ntp-nontp-without-chrony-gui
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/ntp-nontp-without-chrony.ks.in
+++ b/ntp-nontp-without-chrony.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: ntp-nontp-without-chrony
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/ntp-pools.ks.in
+++ b/ntp-pools.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: ntp-pools
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/ntp-with-nontp-gui.ks.in
+++ b/ntp-with-nontp-gui.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: ntp-with-nontp-gui
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/ntp-with-nontp.ks.in
+++ b/ntp-with-nontp.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: ntp-with-nontp
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/ntp-without-chrony-gui.ks.in
+++ b/ntp-without-chrony-gui.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: ntp-without-chrony-gui
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/ntp-without-chrony.ks.in
+++ b/ntp-without-chrony.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: ntp-without-chrony
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/onboot-activate-httpks.ks.in
+++ b/onboot-activate-httpks.ks.in
@@ -1,5 +1,5 @@
 #test name: onboot-activate-httpks
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --device=@KSTEST_NETDEV2@ --bootproto=dhcp --no-activate --onboot=yes
 network --device=@KSTEST_NETDEV1@ --bootproto=dhcp --onboot=no

--- a/onboot-activate.ks.in
+++ b/onboot-activate.ks.in
@@ -1,5 +1,5 @@
 #test name: onboot-activate
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --device=@KSTEST_NETDEV2@ --bootproto=dhcp --no-activate --onboot=yes
 network --device=@KSTEST_NETDEV1@ --bootproto=dhcp --onboot=no

--- a/onboot-bootopts-pre.ks.in
+++ b/onboot-bootopts-pre.ks.in
@@ -1,5 +1,5 @@
 #test name: onboot-bootopts-pre
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 %include /tmp/ksinclude

--- a/proxy-cmdline.ks.in
+++ b/proxy-cmdline.ks.in
@@ -1,5 +1,5 @@
 #test name: proxy-cmdline
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/team-httpks.ks.in
+++ b/team-httpks.ks.in
@@ -1,5 +1,5 @@
 #test name: team
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 network --device team0 --bootproto dhcp --teamslaves="@KSTEST_NETDEV2@'{\"prio\": -10, \"sticky\": true}',@KSTEST_NETDEV3@'{\"prio\": 100}'" --teamconfig="{\"runner\": {\"name\": \"activebackup\"}}" --activate --onboot=no

--- a/team-pre.ks.in
+++ b/team-pre.ks.in
@@ -1,6 +1,6 @@
 #test name: team-pre
 #NOTE: this test is a variant of team test, it is sharing its .sh file (setup of NICs and network boot configuration) so beware of changing it independently of team test
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 %include /tmp/ksinclude

--- a/team.ks.in
+++ b/team.ks.in
@@ -1,5 +1,5 @@
 #test name: team
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 network --device team0 --bootproto dhcp --teamslaves="@KSTEST_NETDEV2@'{\"prio\": -10, \"sticky\": true}',@KSTEST_NETDEV3@'{\"prio\": 100}'" --teamconfig="{\"runner\": {\"name\": \"activebackup\"}}" --activate --onboot=no

--- a/vlan-httpks.ks.in
+++ b/vlan-httpks.ks.in
@@ -1,5 +1,5 @@
 #test name: vlan-httpks
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 # Parent configured and activated in initramfs

--- a/vlan-pre.ks.in
+++ b/vlan-pre.ks.in
@@ -1,6 +1,6 @@
 #test name: vlan-pre
 # variant with commands run in %pre section
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 
 %include /tmp/ksinclude


### PR DESCRIPTION
Use the repos/default.ks fragment in network related kickstart
tests.

By default this will make sure a corresponding modular repo
is available as well as making it easily possible to inject
arbitrary other repositories for all tests when needed.