### PR TITLE
Use repo fragment in remaining kickstart tests

### DIFF
--- a/clearpart-1.ks.in
+++ b/clearpart-1.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: ignoredisk
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/driverdisk-disk.ks.in
+++ b/driverdisk-disk.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: driverdisk-disk
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/escrow-cert.ks.in
+++ b/escrow-cert.ks.in
@@ -1,5 +1,5 @@
 #test name: escrow-cert
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/firewall.ks.in
+++ b/firewall.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: firewall
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/geolocation-off-by-default-with-ks.ks.in
+++ b/geolocation-off-by-default-with-ks.ks.in
@@ -1,5 +1,5 @@
 #test name: geolocation-off-by-default-with-ks
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/keyboard-addtnl.ks.in
+++ b/keyboard-addtnl.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: keyboard-addtnl
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/keyboard.ks.in
+++ b/keyboard.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: keyboard
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/ks-include.ks.in
+++ b/ks-include.ks.in
@@ -1,5 +1,5 @@
 #test name: ks-include
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/lang.ks.in
+++ b/lang.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: lang
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/nosave-1.ks.in
+++ b/nosave-1.ks.in
@@ -1,5 +1,5 @@
 #test name: nosave-1
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/nosave-2.ks.in
+++ b/nosave-2.ks.in
@@ -1,5 +1,5 @@
 #test name: nosave-2
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/nosave-3.ks.in
+++ b/nosave-3.ks.in
@@ -1,5 +1,5 @@
 #test name: nosave-3
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/pre-install.ks.in
+++ b/pre-install.ks.in
@@ -1,5 +1,5 @@
 #test name: pre-install
-url @KSTEST_URL@
+%ksappend repos/default.ks
 
 install
 

--- a/screen-access-advanced.ks.in
+++ b/screen-access-advanced.ks.in
@@ -1,5 +1,5 @@
 #test name: screen-access-advanced
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/screen-access.ks.in
+++ b/screen-access.ks.in
@@ -1,5 +1,5 @@
 #test name: screen-access
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/selinux-disabled.ks.in
+++ b/selinux-disabled.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: selinux-disabled
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/selinux-enforcing.ks.in
+++ b/selinux-enforcing.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: selinux-enforcing
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/selinux-permissive.ks.in
+++ b/selinux-permissive.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: selinux-permissive
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/services.ks.in
+++ b/services.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: services
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/timezoneLOCAL.ks.in
+++ b/timezoneLOCAL.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: timezoneLOCAL
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/timezoneUTC.ks.in
+++ b/timezoneUTC.ks.in
@@ -1,6 +1,6 @@
 #version=DEVEL
 #test name: timezoneUTC
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 

--- a/tmpfs-fixed_size.ks.in
+++ b/tmpfs-fixed_size.ks.in
@@ -1,5 +1,5 @@
 #test name: tmpfs-fixed_size
-url @KSTEST_URL@
+%ksappend repos/default.ks
 install
 network --bootproto=dhcp
 


### PR DESCRIPTION
Use the repos/default.ks fragment in remaining tests that were
not added to the storage and network related batches.

By default this will make sure a corresponding modular repo
is available as well as making it easily possible to inject
arbitrary other repositories for all tests when needed.