### PR TITLE
Change default boot options

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -31,7 +31,7 @@ inject_ks_to_initrd() {
     echo "true"
 }
 
-DEFAULT_BASIC_BOOTOPTS="vnc debug=1 inst.debug"
+DEFAULT_BASIC_BOOTOPTS="inst.noninteractive debug=1 inst.debug"
 
 DEFAULT_DRACUT_BOOTOPTS="rd.shell=0 rd.emergency=poweroff"
 


### PR DESCRIPTION
Drop the default option forcing the "vnc" UI mode.
This was overriding the NTP tests that try to
run in text mode and also is pretty much useless
with tests running on remote workers.

Also add inst.noninteractive option so that we don't
wait hours for tests that get stuck blocking on of the
"channels" for some reason, quite likely unrelated to
what's being tested.