### PR TITLE
Do not set inst.ks in non-httpks test (vlan-pre)

### DIFF
--- a/vlan-pre.sh
+++ b/vlan-pre.sh
@@ -23,8 +23,7 @@ TESTTYPE=${TESTTYPE:-"network"}
 
 
 kernel_args() {
-    . ${tmpdir}/ks_url
-    echo ${DEFAULT_BOOTOPTS} ip=${KSTEST_NETDEV1}:dhcp ip=${KSTEST_NETDEV2}:dhcp inst.ks=${ks_url}
+    echo ${DEFAULT_BOOTOPTS} ip=${KSTEST_NETDEV1}:dhcp ip=${KSTEST_NETDEV2}:dhcp
 }
 
 # Arguments for virt-install --network options


### PR DESCRIPTION
Current kernel_args would just leave "inst.ks=" empty and ignored, but let's make
the boot options correct.