### PR TITLE
Use Fedora master repos by default

### DIFF
--- a/fragments/platform/fedora_rawhide/repos/default.ks
+++ b/fragments/platform/fedora_rawhide/repos/default.ks
@@ -1,3 +1,3 @@
 # Default Fedora Rawhide repositories
-url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-rawhide&arch=$basearch
-repo --name=modular --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=rawhide-modular&arch=$basearch
+url --url=https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/$basearch/os/
+repo --name=modular --baseurl https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Modular/$basearch/os/

--- a/scripts/defaults.sh
+++ b/scripts/defaults.sh
@@ -7,6 +7,6 @@
 # CAUTION: the sed expression we currently use does not like white-space in the strings
 
 source network-device-names.cfg
-export KSTEST_URL='--mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-rawhide\\&arch=$basearch'
-export KSTEST_MODULAR_URL='--mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=rawhide-modular\\&arch=$basearch'
+export KSTEST_URL='--url=https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/$basearch/os/'
+export KSTEST_MODULAR_URL='https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Modular/$basearch/os/'
 export KSTEST_FTP_URL='ftp://mirror.utexas.edu/pub/fedora/linux/development/rawhide/Everything/$basearch/os/'


### PR DESCRIPTION
Due to frequent cases where individual kickstart test got corrupted
mirrors from the Fedora mirror list lets just switch to the master
mirror instead.

This way if even the master mirror is not consistent
then all tests should fail consistently rather then at
random due to getting a bad mirror.