### PR TITLE
Reuse existing .sh file in bindtomac version of a network test

### DIFF
--- a/network-static-to-dhcp-pre-single.sh
+++ b/network-static-to-dhcp-pre-single.sh
@@ -24,7 +24,7 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
-TESTTYPE="network"
+TESTTYPE=${TESTTYPE:-"network"}
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Same as for other bindtomac tests.