### PR TITLE
Add kickstart tests for Initial Setup configuration

### DIFF
--- a/initial-setup-default.ks.in
+++ b/initial-setup-default.ks.in
@@ -1,0 +1,45 @@
+#test name: initial-setup-default
+#
+# Check that Initial Setup is configured correctly if the firstboot command
+# is not present in the installation kickstart.
+#
+# The expected behavior is:
+# - the initial-setup and initial-setup-gui packages are not installed
+# - the initial-setup.service is not present and thus not enabled
+# - /etc/reconfigSys does not exist
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
+
+%packages
+vim
+%end
+
+%post
+# check that initial-setup RPM is installed
+rpm -q initial-setup
+if [[ $? == 0 ]]; then
+    echo '*** the initial-setup package should not be installed' >> /root/RESULT
+fi
+
+# check that initial-setup-gui RPM is not installed
+# (it was not specified in the %packages section
+#  and should not be pulled in automatically)
+rpm -q initial-setup-gui
+if [[ $? == 0 ]]; then
+    echo '*** initial-setup-gui package should not be installed' >> /root/RESULT
+fi
+
+# check that the initial-setup service is enabled
+systemctl is-enabled initial-setup
+if [[ $? == 0 ]]; then
+    echo "*** initial-setup.service should not be enabled" >> /root/RESULT
+fi
+
+# the reconfig file should only be present if the --reconfig option was
+# passed to the firstboot kickstart command
+if [ -f /etc/reconfigSys ]; then
+    echo "*** /etc/reconfigSys should not exist when --reconfig is not used" >> /root/RESULT
+fi
+
+%ksappend validation/success_if_result_empty.ks
+%end

--- a/initial-setup-default.sh
+++ b/initial-setup-default.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="initial-setup"
+
+. ${KSTESTDIR}/functions.sh

--- a/initial-setup-disable.ks.in
+++ b/initial-setup-disable.ks.in
@@ -1,0 +1,45 @@
+#test name: initial-setup-disable
+#
+# Check that Initial Setup is correctly disabled if specified in kickstart.
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
+
+# disable initial setup
+firstboot --disable
+
+# make sure the initial setup package is installed
+%packages
+initial-setup
+%end
+
+%post
+# check that initial-setup RPM is installed
+# - this is specified in the %packages section and is not
+#   conditional on Initial Setup being enabled
+rpm -q initial-setup
+if [[ $? != 0 ]]; then
+    echo '*** the initial-setup package should be installed' >> /root/RESULT
+fi
+
+# check that initial-setup-gui RPM is not installed
+# (it was not specified in the %packages section
+#  and should not be pulled in automatically)
+rpm -q initial-setup-gui
+if [[ $? == 0 ]]; then
+    echo '*** initial-setup-gui package should not be installed' >> /root/RESULT
+fi
+
+# check that the initial-setup service is disabled
+systemctl is-enabled initial-setup
+if [[ $? == 0 ]]; then
+    echo "*** initial-setup.service should be disabled" >> /root/RESULT
+fi
+
+# the reconfig file should only be present if the --reconfig option was
+# passed to the firstboot kickstart command
+if [ -f /etc/reconfigSys ]; then
+    echo "*** /etc/reconfigSys should not exist when --reconfig is not used" >> /root/RESULT
+fi
+
+%ksappend validation/success_if_result_empty.ks
+%end

--- a/initial-setup-disable.sh
+++ b/initial-setup-disable.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="initial-setup"
+
+. ${KSTESTDIR}/functions.sh

--- a/initial-setup-enable.ks.in
+++ b/initial-setup-enable.ks.in
@@ -1,0 +1,43 @@
+#test name: initial-setup-enable
+#
+# Check that Initial Setup is correctly enabled if specified in kickstart.
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
+
+# enable initial setup
+firstboot --enable
+
+# make sure the initial setup package is installed
+%packages
+initial-setup
+%end
+
+%post
+# check that initial-setup RPM is installed
+rpm -q initial-setup
+if [[ $? != 0 ]]; then
+    echo '*** the initial-setup package should be installed' >> /root/RESULT
+fi
+
+# check that initial-setup-gui RPM is not installed
+# (it was not specified in the %packages section
+#  and should not be pulled in automatically)
+rpm -q initial-setup-gui
+if [[ $? == 0 ]]; then
+    echo '*** initial-setup-gui package should not be installed' >> /root/RESULT
+fi
+
+# check that the initial-setup service is enabled
+systemctl is-enabled initial-setup
+if [[ $? != 0 ]]; then
+    echo "*** initial-setup.service is not enabled" >> /root/RESULT
+fi
+
+# the reconfig file should only be present if the --reconfig option was
+# passed to the firstboot kickstart command
+if [ -f /etc/reconfigSys ]; then
+    echo "*** /etc/reconfigSys should not exist when --reconfig is not used" >> /root/RESULT
+fi
+
+%ksappend validation/success_if_result_empty.ks
+%end

--- a/initial-setup-enable.sh
+++ b/initial-setup-enable.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="initial-setup"
+
+. ${KSTESTDIR}/functions.sh

--- a/initial-setup-gui.ks.in
+++ b/initial-setup-gui.ks.in
@@ -1,0 +1,42 @@
+#test name: initial-setup-gui
+#
+# Check that the initial-setup-gui package is correctly installed
+# when specified in the %packages section.
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
+
+# enable initial setup
+firstboot --enable
+
+# make sure the initial setup package is installed
+%packages
+initial-setup-gui
+%end
+
+%post
+# check that initial-setup RPM is installed
+rpm -q initial-setup
+if [[ $? != 0 ]]; then
+    echo '*** the initial-setup package should be installed' >> /root/RESULT
+fi
+
+# check that initial-setup-gui RPM is installed
+rpm -q initial-setup-gui
+if [[ $? != 0 ]]; then
+    echo '*** initial-setup-gui package should be installed' >> /root/RESULT
+fi
+
+# check that the initial-setup service is enabled
+systemctl is-enabled initial-setup
+if [[ $? != 0 ]]; then
+    echo "*** initial-setup.service is not enabled" >> /root/RESULT
+fi
+
+# the reconfig file should only be present if the --reconfig option was
+# passed to the firstboot kickstart command
+if [ -f /etc/reconfigSys ]; then
+    echo "*** /etc/reconfigSys should not exist when --reconfig is not used" >> /root/RESULT
+fi
+
+%ksappend validation/success_if_result_empty.ks
+%end

--- a/initial-setup-gui.sh
+++ b/initial-setup-gui.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="initial-setup"
+
+. ${KSTESTDIR}/functions.sh

--- a/initial-setup-reconfig.ks.in
+++ b/initial-setup-reconfig.ks.in
@@ -1,0 +1,43 @@
+#test name: initial-setup-reconfig
+#
+# Check that Initial Setup is correctly configured in reconfig mode if specified in kickstart.
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
+
+# enable initial setup
+firstboot --enable --reconfig
+
+# make sure the initial setup package is installed
+%packages
+initial-setup
+%end
+
+%post
+# check that initial-setup RPM is installed
+rpm -q initial-setup
+if [[ $? != 0 ]]; then
+    echo '*** the initial-setup package should not be installed' >> /root/RESULT
+fi
+
+# check that initial-setup-gui RPM is not installed
+# (it was not specified in the %packages section
+#  and should not be pulled in automatically)
+rpm -q initial-setup-gui
+if [[ $? == 0 ]]; then
+    echo '*** initial-setup-gui package should not be installed' >> /root/RESULT
+fi
+
+# check that the initial-setup service is enabled
+systemctl is-enabled initial-setup
+if [[ $? != 0 ]]; then
+    echo "*** initial-setup.service is not enabled" >> /root/RESULT
+fi
+
+# the reconfig file should only be present if the --reconfig option was
+# passed to the firstboot kickstart command
+if [ ! -f /etc/reconfigSys ]; then
+    echo "*** /etc/reconfigSys should exist when --reconfig is used" >> /root/RESULT
+fi
+
+%ksappend validation/success_if_result_empty.ks
+%end

--- a/initial-setup-reconfig.sh
+++ b/initial-setup-reconfig.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="initial-setup"
+
+. ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
These tests come with their own test group ("initial-setup") and
test various aspects of Initial Setup configuration:

- initial-setup and initial-setup-gui are installed correctly
- the packages are not installed by default
- the initial-setup.service is correctly enabled/disabled
- the /etc/reconfigSys file is created only in reconfig mode