### PR TITLE
linchpin: allow to configure suffix of test run results directory

### DIFF
--- a/ansible/roles/kstest-master/defaults/main/test-configuration.yml
+++ b/ansible/roles/kstest-master/defaults/main/test-configuration.yml
@@ -77,6 +77,10 @@ kstest_test_jobs: 4
 # The subdirectory name is generated from date of the run execution
 kstest_result_run_dir_prefix: ""
 
+# Suffix of the subdirectory for a test run results.
+# The subdirectory name is generated from date of the run execution
+kstest_result_run_dir_suffix: ""
+
 # Path to remote destination for sync of results.
 # Kstest user on master has to be authorized for accessing the target
 # (eg with master ssh key).

--- a/ansible/roles/kstest-master/templates/run_tests.sh.j2
+++ b/ansible/roles/kstest-master/templates/run_tests.sh.j2
@@ -31,6 +31,7 @@ HOME_DIR=/home/${KSTEST_USER}
 KSTEST_REPO_PATH=${HOME_DIR}/${KSTEST_REPO_DIR}
 RESULTS_PATH=${HOME_DIR}/${RESULTS_DIR}
 RESULT_RUN_DIR_PREFIX={{ kstest_result_run_dir_prefix }}
+RESULT_RUN_DIR_SUFFIX={{ kstest_result_run_dir_suffix }}
 BOOT_ISO=boot.kstest.iso
 ISOMD5SUM_FILENAME={{ kstest.master.file.isomd5sum }}
 RESULT_REPORT_FILENAME={{ kstest.master.file.result_report }}
@@ -62,7 +63,7 @@ fi
 
 ### Create this test result dir
 
-RESULT_PATH="${RESULTS_RUN_PATH}/${RESULT_RUN_DIR_PREFIX}${START_TIME}"
+RESULT_PATH="${RESULTS_RUN_PATH}/${RESULT_RUN_DIR_PREFIX}${START_TIME}${RESULT_RUN_DIR_SUFFIX}"
 mkdir ${RESULT_PATH}
 
 


### PR DESCRIPTION
Shows up to be more useful than prefix in some cases. Ie prefix is useful for
classes of tests, suffix for variants/test modifications.

Example: next nightly is configured to be run with some updates image for testing, or with kickstart-tests branch having some update to test. Then it would be handy to easily configure the suffix to the test run so it is easily distinguishable in the generated results history.