### PR TITLE
Revert "Change default boot options"

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -31,7 +31,7 @@ inject_ks_to_initrd() {
     echo "true"
 }
 
-DEFAULT_BASIC_BOOTOPTS="inst.noninteractive debug=1 inst.debug"
+DEFAULT_BASIC_BOOTOPTS="vnc debug=1 inst.debug"
 
 DEFAULT_DRACUT_BOOTOPTS="rd.shell=0 rd.emergency=poweroff"
 


### PR DESCRIPTION
This reverts commit 45cdfcafcd1fe906f33dfe665db5a7cc16c768c1.

The tests with noninteractive gui have still significantly worse results than
the "vnc" which should be investigated and fixed before changing the default.

Also https://github.com/rhinstaller/anaconda/pull/1961 which partially fixes
the issues should be merged first.