### PR TITLE
Tweak and fix gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
-*.ks
+/*.ks
+fragments/runtime
+*.log
+*.retry
 __pycache__


### PR DESCRIPTION
Fix .gitignore to be able to stage a new fragments but ignore fragments/runtime/ folder.

Add other missing:
retry files from ansible
logs