### PR TITLE
Add unified test

### DIFF
--- a/fragments/platform/fedora_rawhide/payload/unified_packages.ks
+++ b/fragments/platform/fedora_rawhide/payload/unified_packages.ks
@@ -1,0 +1,6 @@
+# Fedora Rawhide unified ISO created by create_dvd script [1] should contain test-rpm rpm
+# [1]: https://github.com/rhinstaller/devel-tools/tree/master/create_unified_iso
+
+%packages
+test-rpm
+%end

--- a/fragments/platform/fedora_rawhide/repos/unified-nfs.ks
+++ b/fragments/platform/fedora_rawhide/repos/unified-nfs.ks
@@ -1,0 +1,2 @@
+# Unified ISO for Rawhide served on NFS server
+nfs --server NFS_SERVER --dir NFS_DIR

--- a/fragments/platform/fedora_rawhide/repos/unified.ks
+++ b/fragments/platform/fedora_rawhide/repos/unified.ks
@@ -1,0 +1,2 @@
+# Unified ISO for Rawhide served on http server
+url UNIFIED_ISO_URL_GOES_HERE

--- a/fragments/platform/fedora_rawhide/section-data/unified-iso.ks
+++ b/fragments/platform/fedora_rawhide/section-data/unified-iso.ks
@@ -1,0 +1,3 @@
+# Create a variable in the pre/post section with link to a Rawhide unified ISO
+# The curl tool will download this ISO and it will be processed later in the section.
+ISO_LOCATION=<link to a unified ISO>

--- a/fragments/platform/fedora_rawhide/validation/unified.ks
+++ b/fragments/platform/fedora_rawhide/validation/unified.ks
@@ -1,0 +1,6 @@
+# Validate installed packages on Fedora rawhide system.
+
+# Check that the test package was correctly installed.
+if ! rpm -q test-rpm ; then
+    echo '*** test-rpm package was not installed!' >> /root/RESULT
+fi

--- a/fragments/platform/rhel8/payload/unified_packages.ks
+++ b/fragments/platform/rhel8/payload/unified_packages.ks
@@ -1,0 +1,7 @@
+# RHEL 8 packages section from unified DVD.
+# The unified DVD should contain under one link both BaseOS and AppStream so install AppStream specific package.
+
+%packages
+# Anaconda package is part of the AppStream repository. It is not contained in the BaseOS.
+anaconda
+%end

--- a/fragments/platform/rhel8/repos/unified-nfs.ks
+++ b/fragments/platform/rhel8/repos/unified-nfs.ks
@@ -1,0 +1,2 @@
+# Unified ISO for RHEL-8 served on NFS server
+nfs --server NFS_SERVER --dir NFS_DIR

--- a/fragments/platform/rhel8/repos/unified.ks
+++ b/fragments/platform/rhel8/repos/unified.ks
@@ -1,0 +1,3 @@
+# Unified ISO for RHEL 8 served on http server
+# BaseOS and AppStream repositories should be loaded automatically from the unified repo
+url RHEL8_UNIFIED_REPO_URL_GOES_HERE

--- a/fragments/platform/rhel8/section-data/unified-iso.ks
+++ b/fragments/platform/rhel8/section-data/unified-iso.ks
@@ -1,0 +1,3 @@
+# Create a variable in the pre/post section with link to a RHEL-8 unified ISO
+# The curl tool will download this ISO and it will be processed later in the section.
+ISO_LOCATION=<link to a unified ISO>

--- a/fragments/platform/rhel8/validation/unified.ks
+++ b/fragments/platform/rhel8/validation/unified.ks
@@ -1,0 +1,6 @@
+# Validate installed packages on RHEL 8 system.
+
+# Check that the anaconda package was correctly installed.
+if ! rpm -q anaconda ; then
+    echo '*** anaconda package was not installed!' >> /root/RESULT
+fi

--- a/unified-cdrom.ks.in
+++ b/unified-cdrom.ks.in
@@ -1,0 +1,25 @@
+#version=DEVEL
+#test name: unified
+
+# This test is for testing the install from an unified repository.
+#
+# You have to have unified ISO as a source mounted on the HTTP server.
+# To create unified ISO for Fedora you can use this tool:
+# https://github.com/rhinstaller/devel-tools/tree/master/create_unified_iso
+#
+
+#
+# This installation has to be booted by the unified ISO instead of boot ISO.
+#
+
+%ksappend common/common_no_payload.ks
+
+cdrom
+
+%ksappend payload/unified_packages.ks
+
+%post
+%ksappend validation/unified.ks
+
+%ksappend validation/success_if_result_empty.ks
+%end

--- a/unified-cdrom.sh
+++ b/unified-cdrom.sh
@@ -1,0 +1,30 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
+
+#TESTTYPE="packaging"
+
+#
+# This installation has to be booted by the unified ISO instead of boot ISO.
+# The reason is that cdrom command will take the first cdrom in the system
+# which will be the want used for booting in our case.
+#
+
+TESTTYPE="knownfailure"
+
+. ${KSTESTDIR}/functions.sh

--- a/unified-cmdline.ks.in
+++ b/unified-cmdline.ks.in
@@ -1,0 +1,19 @@
+#version=DEVEL
+#test name: unified
+
+# This test is for testing the install from an unified repository.
+#
+# You have to have unified ISO as a source mounted on the HTTP server.
+# To create unified ISO for Fedora you can use this tool:
+# https://github.com/rhinstaller/devel-tools/tree/master/create_unified_iso
+#
+
+%ksappend common/common_no_payload.ks
+
+%ksappend payload/unified_packages.ks
+
+%post
+%ksappend validation/unified.ks
+
+%ksappend validation/success_if_result_empty.ks
+%end

--- a/unified-cmdline.sh
+++ b/unified-cmdline.sh
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
+
+#TESTTYPE="packaging"
+
+TESTTYPE="knownfailure"
+
+. ${KSTESTDIR}/functions.sh
+
+
+# This test is created for manual testing mainly.
+# You have to set unified server in the inst.repo here but we don't have
+# a reasonable way how to do that in the shell file.
+
+kernel_args() {
+    # Enable to test the boot option.
+    # HTTP
+    # echo inst.repo=http://<unified-server>
+    # FTP
+    # echo inst.repo=ftp://<unified-server>
+    # NFS
+    # echo inst.repo=nfs:<server>:<path>
+    # CDROM (have to be booted with unified ISO)
+    # echo inst.repo=cdrom:<device>
+
+    # Enable for manual testing.
+    # echo vnc=0 debug=1 inst.nokill
+
+    # Choose UI for manual testing.
+    # echo inst.text
+    # echo inst.graphical
+}

--- a/unified-harddrive.ks.in
+++ b/unified-harddrive.ks.in
@@ -1,0 +1,57 @@
+#version=DEVEL
+#test name: unified-nfs
+
+# This test is for testing the install from an unified repository.
+#
+# You have to have unified ISO as a source mounted on the NFS server.
+# To create unified ISO for Fedora you can use this tool:
+# https://github.com/rhinstaller/devel-tools/tree/master/create_unified_iso
+#
+# This test has to have access to the NFS server. However NFS won't mount
+# if the VM is behind a NAT (NFS problem). So this test won't work on our setup
+# right now.
+#
+
+%ksappend common/common_no_payload.ks
+
+harddrive --partition=/dev/sdb1 --dir=/
+
+%ksappend payload/unified_packages.ks
+
+%pre
+# Add ISO_LOCATION with an url to the unified-iso
+%ksappend section-data/unified-iso.ks
+DISK="/dev/sdb"
+PARTITION="/dev/sdb1"
+
+# Prepare partition on the new disk
+parted $DISK mklabel msdos
+parted --align=none $DISK mkpart primary 0 14G
+mkfs.ext4 $PARTITION
+mkdir /prep-mount
+mount $PARTITION /prep-mount
+
+# Download the ISO
+pushd /prep-mount
+mkdir iso
+curl -L $ISO_LOCATION -o ./iso/unified.iso
+
+# Mount the ISO
+mkdir iso-mount
+mount ./iso/unified.iso iso-mount
+
+# Copy ISO content inside
+rsync -ahHvS --stats iso-mount/ ./
+
+# Clean up
+umount iso-mount
+popd
+umount /prep-mount
+rmdir /prep-mount
+%end
+
+%post
+%ksappend validation/unified.ks
+
+%ksappend validation/success_if_result_empty.ks
+%end

--- a/unified-harddrive.sh
+++ b/unified-harddrive.sh
@@ -1,0 +1,35 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
+
+#TESTTYPE="packaging rhel-only"
+
+TESTTYPE="knownfailure"
+
+. ${KSTESTDIR}/functions.sh
+
+UNIFIED_ISO=/home/jkonecny/RH/projects/kickstart-tests/work/Rawhide-server-unified.iso
+
+prepare_disks() {
+    tmpdir=$1
+
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-a.img 10G
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-b.img 15G
+
+    echo ${tmpdir}/disk-a.img ${tmpdir}/disk-b.img
+}

--- a/unified-nfs.ks.in
+++ b/unified-nfs.ks.in
@@ -1,0 +1,25 @@
+#version=DEVEL
+#test name: unified-nfs
+
+# This test is for testing the install from an unified repository.
+#
+# You have to have unified ISO as a source mounted on the NFS server.
+# To create unified ISO for Fedora you can use this tool:
+# https://github.com/rhinstaller/devel-tools/tree/master/create_unified_iso
+#
+# This test has to have access to the NFS server. However NFS won't mount
+# if the VM is behind a NAT (NFS problem). So this test won't work on our setup
+# right now.
+#
+
+%ksappend common/common_no_payload.ks
+
+%ksappend repos/unified-nfs.ks
+
+%ksappend payload/unified_packages.ks
+
+%post
+%ksappend validation/unified.ks
+
+%ksappend validation/success_if_result_empty.ks
+%end

--- a/unified-nfs.sh
+++ b/unified-nfs.sh
@@ -1,0 +1,24 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
+
+#TESTTYPE="packaging rhel-only"
+
+TESTTYPE="knownfailure"
+
+. ${KSTESTDIR}/functions.sh

--- a/unified.ks.in
+++ b/unified.ks.in
@@ -1,0 +1,21 @@
+#version=DEVEL
+#test name: unified
+
+# This test is for testing the install from an unified repository.
+#
+# You have to have unified ISO as a source mounted on the HTTP server.
+# To create unified ISO for Fedora you can use this tool:
+# https://github.com/rhinstaller/devel-tools/tree/master/create_unified_iso
+#
+
+%ksappend common/common_no_payload.ks
+
+%ksappend repos/unified.ks
+
+%ksappend payload/unified_packages.ks
+
+%post
+%ksappend validation/unified.ks
+
+%ksappend validation/success_if_result_empty.ks
+%end

--- a/unified.sh
+++ b/unified.sh
@@ -1,0 +1,24 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
+
+#TESTTYPE="packaging"
+
+TESTTYPE="knownfailure"
+
+. ${KSTESTDIR}/functions.sh

--- a/unified.sh
+++ b/unified.sh
@@ -17,8 +17,6 @@
 #
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 
-#TESTTYPE="packaging"
-
-TESTTYPE="knownfailure"
+TESTTYPE="packaging rhel-only"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Add new unified tests.

1) Installation from HTTP server with unified content
2) Installation from inst.repo variants with unified ISO
3) Installation from NFS unified repository
4) Installation from harddrive
  - unified ISO is downloaded and extracted in the %pre section
5) Installation from cdrom
  - unified ISO has to be used as boot ISO

From the all above only the HTTP server variant can be used for automatic testing and that is only for RHEL-8. All the others are usable only with a special setup.

_Note:_
NFS tests in general will be problematic because NFS can't be mounted behind NAT and that is our setup everywhere. So NFS tests can't be run as the KS tests only by taking the generated kickstart and running that outside.