### PR TITLE
Add addrepo test

### DIFF
--- a/addrepo.ks.in
+++ b/addrepo.ks.in
@@ -1,0 +1,34 @@
+#version=DEVEL
+#test name: addrepo
+
+# This test will check the installation with addrepo kernel parameter functionality.
+# The inst.addrepo boot option will add additional software repository,
+# which will be used for the installation.
+#
+
+%ksappend common/common_no_payload.ks
+%ksappend repos/default.ks
+
+%packages
+testpkg-http-core
+testpkg-share1
+%end
+
+%post
+
+rpm -q testpkg-http-core
+if [[ $? != 0 ]]; then
+    echo '*** testpkg-http-core was not installed' >> /root/RESULT
+fi
+
+rpm -q testpkg-share1
+if [[ $? != 0 ]]; then
+    echo '*** testpkg-share1 was not installed' >> /root/RESULT
+fi
+
+if [[ -e /etc/LOCAL.repo ]]; then
+    echo '*** LOCAL.repo should not be installed to the system' >> /root/RESULT
+fi
+
+%ksappend validation/success_if_result_empty.ks
+%end

--- a/addrepo.sh
+++ b/addrepo.sh
@@ -1,0 +1,54 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
+
+TESTTYPE="packaging"
+
+. ${KSTESTDIR}/functions.sh
+
+prepare() {
+    ks=$1
+    tmpdir=$2
+
+    scriptdir=$PWD/scripts
+
+    # Create the test repo
+    PYTHONPATH=${KSTESTDIR}/lib:$PYTHONPATH ${scriptdir}/make-addon-pkgs.py $tmpdir
+
+    # Start a http server and proxy server to serve the repos
+    start_httpd ${tmpdir}/http $tmpdir
+
+    echo "${ks}"
+}
+
+kernel_args() {
+    tmpdir="$1"
+
+    httpd_url="$(cat ${tmpdir}/httpd_url)"
+
+    echo ${tmpdir} -- ${httpd_url} > /tmp/addrepo-test.log
+
+    echo "${DEFAULT_BOOTOPTS} inst.addrepo=LOCAL,${httpd_url}"
+}
+
+cleanup() {
+    ### Kill the http server
+    if [ -f ${tmpdir}/httpd-pid ]; then
+        kill $(cat ${tmpdir}/httpd-pid)
+    fi
+}

--- a/functions.sh
+++ b/functions.sh
@@ -138,7 +138,7 @@ start_httpd() {
 
     # Starts a http server rooted in $httpd_root. The PID of the server will be
     # written to $tmpdir/httpd-pid, and the URL for the server will be set in
-    # $httpd_url
+    # $httpd_url and also written to $tmpdir/httpd_url file.
 
     local scriptdir=${PWD}/scripts
     local httpd_info="$(${scriptdir}/httpd.py "${httpd_root}")"
@@ -152,6 +152,9 @@ start_httpd() {
 
     # Construct a URL
     httpd_url="http://$(${scriptdir}/find-ip):${httpd_port}/"
+
+    # Save the URL
+    echo "${httpd_url}" > ${tmpdir}/httpd_url
 }
 
 start_proxy() {

--- a/scripts/launcher/lib/launcher_interface.sh
+++ b/scripts/launcher/lib/launcher_interface.sh
@@ -105,7 +105,7 @@ case $1 in
         ret=$?
         ;;
     kernel_args)
-        msg="$(kernel_args)"
+        msg="$(kernel_args ${tmpdir})"
         ret=$?
         ;;
     boot_args)


### PR DESCRIPTION
Other changes included here:

Propagate temp dir to `kernel_args()` bash function.
Store httpd url to a file in the temp file.

The main reason for this is that these functions are called separately so the only way to load something in other function than it was created is to read those from a file.

The new `httpd_url` file can be used in at least `ibft` test but I wasn't able to run that so I didn't applied the change there.