### PR TITLE
Add tests for default desktop and systemd target configuration

### DIFF
--- a/default-desktop.ks.in
+++ b/default-desktop.ks.in
@@ -1,0 +1,20 @@
+#version=DEVEL
+#test name: default-desktop
+#
+# Test default desktop configuration via the xconfig command.
+%ksappend repos/default.ks
+
+%ksappend common/common_no_payload.ks
+%ksappend payload/default_packages.ks
+
+xconfig --defaultdesktop GNOME
+
+%post
+
+cat /etc/sysconfig/desktop | grep GNOME
+if [[ $? -ne 0 ]]; then
+    echo "*** Default desktop environment not set to GNOME" >> /root/RESULT
+fi
+
+%ksappend validation/success_if_result_empty.ks
+%end

--- a/default-desktop.sh
+++ b/default-desktop.sh
@@ -1,0 +1,34 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="services"
+
+. ${KSTESTDIR}/functions.sh
+. ${KSTESTDIR}/validate-lib-services.sh
+
+validate() {
+    # check output kickstart via validation library function
+    validate_xconfig_defaultdesktop_in_ks $1
+    if [[ $? != 0 ]]; then
+        cat ${1}/RESULT
+        return 1
+    fi
+
+    return $(validate_RESULT ${disksdir})
+}

--- a/default-systemd-target-gui-graphical-provides.ks.in
+++ b/default-systemd-target-gui-graphical-provides.ks.in
@@ -1,0 +1,28 @@
+#version=DEVEL
+#test name: default-systemd-target-gui-graphical-login-provides
+#
+# Test graphical.target is set as the default systemd target if:
+# - the installation runs in GUI mode
+# - contains a package with provides == service(graphical-login).
+
+%ksappend repos/default.ks
+
+%ksappend common/common_no_payload.ks
+
+# run installation in GUI mode
+graphical
+
+# the gdm package provides service(graphical-login)
+%packages
+gdm
+%end
+
+%post
+
+systemctl get-default | grep graphical.target
+if [[ $? != 0 ]]; then
+    echo "*** graphical.target should be set if package with provides == service(graphical-login) is installed" >> /root/RESULT
+fi
+
+%ksappend validation/success_if_result_empty.ks
+%end

--- a/default-systemd-target-gui-graphical-provides.sh
+++ b/default-systemd-target-gui-graphical-provides.sh
@@ -1,0 +1,34 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="services"
+
+. ${KSTESTDIR}/functions.sh
+. ${KSTESTDIR}/validate-lib-services.sh
+
+validate() {
+    # check output kickstart via validation library function
+    validate_no_xconfig_skipx_command_in_ks $1
+    if [[ $? != 0 ]]; then
+        cat ${1}/RESULT
+        return 1
+    fi
+
+    return $(validate_RESULT ${disksdir})
+}

--- a/default-systemd-target-gui.ks.in
+++ b/default-systemd-target-gui.ks.in
@@ -1,0 +1,21 @@
+#version=DEVEL
+#test name: default-systemd-target-gui
+#
+# Test multi-user.target should be set by default as the default systemd target
+# when installation runs in GUI mode but not package with service(graphical-login)
+# will be installed.
+
+%ksappend repos/default.ks
+
+%ksappend common/common_no_payload.ks
+%ksappend payload/default_packages.ks
+
+%post
+
+systemctl get-default | grep multi-user.target
+if [[ $? != 0 ]]; then
+    echo "*** multi-user.target should be set as the default systemd target" >> /root/RESULT
+fi
+
+%ksappend validation/success_if_result_empty.ks
+%end

--- a/default-systemd-target-gui.sh
+++ b/default-systemd-target-gui.sh
@@ -1,0 +1,34 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="services"
+
+. ${KSTESTDIR}/functions.sh
+. ${KSTESTDIR}/validate-lib-services.sh
+
+validate() {
+    # check output kickstart via validation library function
+    validate_no_xconfig_skipx_command_in_ks $1
+    if [[ $? != 0 ]]; then
+        cat ${1}/RESULT
+        return 1
+    fi
+
+    return $(validate_RESULT ${disksdir})
+}

--- a/default-systemd-target-skipx.ks.in
+++ b/default-systemd-target-skipx.ks.in
@@ -1,0 +1,20 @@
+#version=DEVEL
+#test name: default-systemd-target-skipx
+#
+# Test default systemd target is correctly set via the skipx command.
+%ksappend repos/default.ks
+
+%ksappend common/common_no_payload.ks
+%ksappend payload/default_packages.ks
+
+skipx
+
+%post
+
+systemctl get-default | grep multi-user.target
+if [[ $? != 0 ]]; then
+    echo "*** multi-user.target should be set as the default systemd target" >> /root/RESULT
+fi
+
+%ksappend validation/success_if_result_empty.ks
+%end

--- a/default-systemd-target-skipx.sh
+++ b/default-systemd-target-skipx.sh
@@ -1,0 +1,34 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="services"
+
+. ${KSTESTDIR}/functions.sh
+. ${KSTESTDIR}/validate-lib-services.sh
+
+validate() {
+    # check output kickstart via validation library function
+    validate_skipx_in_ks $1
+    if [[ $? != 0 ]]; then
+        cat ${1}/RESULT
+        return 1
+    fi
+
+    return $(validate_RESULT ${disksdir})
+}

--- a/default-systemd-target-startxonboot.ks.in
+++ b/default-systemd-target-startxonboot.ks.in
@@ -1,0 +1,20 @@
+#version=DEVEL
+#test name: default-systemd-target-startxonboot
+#
+# Test default systemd target configuration via the xconfig --startxonboot command.
+%ksappend repos/default.ks
+
+%ksappend common/common_no_payload.ks
+%ksappend payload/default_packages.ks
+
+xconfig --startxonboot
+
+%post
+
+systemctl get-default | grep graphical.target
+if [[ $? != 0 ]]; then
+    echo "*** graphical.target should be set as the default systemd target" >> /root/RESULT
+fi
+
+%ksappend validation/success_if_result_empty.ks
+%end

--- a/default-systemd-target-startxonboot.sh
+++ b/default-systemd-target-startxonboot.sh
@@ -1,0 +1,34 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="services"
+
+. ${KSTESTDIR}/functions.sh
+. ${KSTESTDIR}/validate-lib-services.sh
+
+validate() {
+    # check output kickstart via validation library function
+    validate_xconfig_startxonboot_in_ks $1
+    if [[ $? != 0 ]]; then
+        cat ${1}/RESULT
+        return 1
+    fi
+
+    return $(validate_RESULT ${disksdir})
+}

--- a/default-systemd-target-tui-graphical-provides.ks.in
+++ b/default-systemd-target-tui-graphical-provides.ks.in
@@ -1,0 +1,29 @@
+#version=DEVEL
+#test name: default-systemd-target-tui-graphical-provides
+#
+# Test multi-user.target is set as the default systemd target if:
+# - the installation tuns in text mode
+# - the installation transaction contains a package which provides service(graphical-login)
+# Basically the text mode should override the provides.
+
+%ksappend repos/default.ks
+
+%ksappend common/common_no_payload.ks
+
+# run the installation in text mode
+text
+
+# the gdm package provides service(graphical-login)
+%packages
+gdm
+%end
+
+%post
+
+systemctl get-default | grep multi-user.target
+if [[ $? != 0 ]]; then
+    echo "*** multi-user.target should be set for text installs even if package with service(graphical-login) is installed" >> /root/RESULT
+fi
+
+%ksappend validation/success_if_result_empty.ks
+%end

--- a/default-systemd-target-tui-graphical-provides.sh
+++ b/default-systemd-target-tui-graphical-provides.sh
@@ -1,0 +1,34 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="services"
+
+. ${KSTESTDIR}/functions.sh
+. ${KSTESTDIR}/validate-lib-services.sh
+
+validate() {
+    # check output kickstart via validation library function
+    validate_skipx_in_ks $1
+    if [[ $? != 0 ]]; then
+        cat ${1}/RESULT
+        return 1
+    fi
+
+    return $(validate_RESULT ${disksdir})
+}

--- a/default-systemd-target-tui.ks.in
+++ b/default-systemd-target-tui.ks.in
@@ -1,0 +1,24 @@
+#version=DEVEL
+#test name: default-systemd-target-tui
+#
+# Test multi-user.target should be set by default as the default systemd target when:
+# - the installation runs in text mode
+# - no package providing service(graphical-login) is installed
+
+%ksappend repos/default.ks
+
+%ksappend common/common_no_payload.ks
+%ksappend payload/default_packages.ks
+
+# run the installation in text mode
+text
+
+%post
+
+systemctl get-default | grep multi-user.target
+if [[ $? != 0 ]]; then
+    echo "*** multi-user.target should be set as the default systemd target for text mode installations" >> /root/RESULT
+fi
+
+%ksappend validation/success_if_result_empty.ks
+%end

--- a/default-systemd-target-tui.sh
+++ b/default-systemd-target-tui.sh
@@ -1,0 +1,34 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="services"
+
+. ${KSTESTDIR}/functions.sh
+. ${KSTESTDIR}/validate-lib-services.sh
+
+validate() {
+    # check output kickstart via validation library function
+    validate_skipx_in_ks $1
+    if [[ $? != 0 ]]; then
+        cat ${1}/RESULT
+        return 1
+    fi
+
+    return $(validate_RESULT ${disksdir})
+}

--- a/default-systemd-target-vnc-graphical-provides.ks.in
+++ b/default-systemd-target-vnc-graphical-provides.ks.in
@@ -1,0 +1,31 @@
+#version=DEVEL
+#test name: default-systemd-target-vnc-graphical-provides
+#
+# Test multi-user.target is set as the default systemd target if:
+# - the installation runs in VNC mode
+# - the installation transaction contains a package providing service(graphical-login)
+# Text mode overrides the provides & for this VNC installation is considered to be
+# similar to textmode, as while controlled remotely over VNC, the installation run
+# itself runs in text mode.
+
+%ksappend repos/default.ks
+
+%ksappend common/common_no_payload.ks
+
+# run the installation in VNC mode
+vnc
+
+# the gdm package provides service(graphical-login)
+%packages
+gdm
+%end
+
+%post
+
+systemctl get-default | grep multi-user.target
+if [[ $? != 0 ]]; then
+    echo "*** multi-user.target should be set for VNC installs even is package with service(graphical-login) is installed" >> /root/RESULT
+fi
+
+%ksappend validation/success_if_result_empty.ks
+%end

--- a/default-systemd-target-vnc-graphical-provides.sh
+++ b/default-systemd-target-vnc-graphical-provides.sh
@@ -1,0 +1,34 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="services"
+
+. ${KSTESTDIR}/functions.sh
+. ${KSTESTDIR}/validate-lib-services.sh
+
+validate() {
+    # check output kickstart via validation library function
+    validate_skipx_in_ks $1
+    if [[ $? != 0 ]]; then
+        cat ${1}/RESULT
+        return 1
+    fi
+
+    return $(validate_RESULT ${disksdir})
+}

--- a/default-systemd-target-vnc.ks.in
+++ b/default-systemd-target-vnc.ks.in
@@ -1,0 +1,24 @@
+#version=DEVEL
+#test name: default-systemd-target-vnc
+#
+# Test multi-user.target should be set by default as the default systemd target
+# for VNC installs. While controlled remotely over VNC the installation itslef runs
+# in text mode and should behave as such.
+
+%ksappend repos/default.ks
+
+%ksappend common/common_no_payload.ks
+%ksappend payload/default_packages.ks
+
+# run the installation in VNC mode
+vnc
+
+%post
+
+systemctl get-default | grep multi-user.target
+if [[ $? != 0 ]]; then
+    echo "*** multi-user.target should be set as the default systemd target for VNC installs" >> /root/RESULT
+fi
+
+%ksappend validation/success_if_result_empty.ks
+%end

--- a/default-systemd-target-vnc.sh
+++ b/default-systemd-target-vnc.sh
@@ -1,0 +1,34 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+TESTTYPE="services"
+
+. ${KSTESTDIR}/functions.sh
+. ${KSTESTDIR}/validate-lib-services.sh
+
+validate() {
+    # check output kickstart via validation library function
+    validate_skipx_in_ks $1
+    if [[ $? != 0 ]]; then
+        cat ${1}/RESULT
+        return 1
+    fi
+
+    return $(validate_RESULT ${disksdir})
+}

--- a/validate-lib-services.sh
+++ b/validate-lib-services.sh
@@ -1,0 +1,59 @@
+# Common functions for validation of Services DBus module tests
+. ${KSTESTDIR}/functions.sh
+
+# check that no xconfig or skipx commands are present in output kickstart
+function validate_no_xconfig_skipx_command_in_ks() {
+    disksdir=$1
+    args=$(for d in ${disksdir}/disk-*img; do echo -a ${d}; done)
+    # Copy the output kickstart
+    run_with_timeout 1000s "virt-copy-out ${args} /root/anaconda-ks.cfg ${disksdir}"
+    egrep -i "^skipx" ${disksdir}/anaconda-ks.cfg
+    if [[ $? == 0 ]]; then
+        echo '*** skipx command present in output kickstart' >> ${disksdir}/RESULT
+        return 1
+    fi
+    egrep -i "^xconfig" ${disksdir}/anaconda-ks.cfg
+    if [[ $? == 0 ]]; then
+        echo '*** xconfig command present in output kickstart' >> ${disksdir}/RESULT
+        return 1
+    fi
+}
+
+# check the skipx command is in output kickstart
+function validate_skipx_in_ks() {
+    disksdir=$1
+    args=$(for d in ${disksdir}/disk-*img; do echo -a ${d}; done)
+    # Copy the output kickstart
+    run_with_timeout 1000s "virt-copy-out ${args} /root/anaconda-ks.cfg ${disksdir}"
+    egrep -i "^skipx" ${disksdir}/anaconda-ks.cfg
+    if [[ $? != 0 ]]; then
+        echo '*** skipx command not present in output kickstart' >> ${disksdir}/RESULT
+        return 1
+    fi
+}
+
+# check the xconfig --startxonboot command is in output kickstart
+function validate_xconfig_startxonboot_in_ks() {
+    disksdir=$1
+    args=$(for d in ${disksdir}/disk-*img; do echo -a ${d}; done)
+    # Copy the output kickstart
+    run_with_timeout 1000s "virt-copy-out ${args} /root/anaconda-ks.cfg ${disksdir}"
+    egrep -i "^xconfig.*--startxonboot" ${disksdir}/anaconda-ks.cfg
+    if [[ $? != 0 ]]; then
+        echo '*** xconfig --startxonboot command not present in output kickstart' >> ${disksdir}/RESULT
+        return 1
+    fi
+}
+
+# check the xconfig --startxonboot command is in output kickstart
+function validate_xconfig_defaultdesktop_in_ks() {
+    disksdir=$1
+    args=$(for d in ${disksdir}/disk-*img; do echo -a ${d}; done)
+    # Copy the output kickstart
+    run_with_timeout 1000s "virt-copy-out ${args} /root/anaconda-ks.cfg ${disksdir}"
+    egrep -i "^xconfig.*--defaultdesktop=" ${disksdir}/anaconda-ks.cfg
+    if [[ $? != 0 ]]; then
+        echo '*** xconfig --defaultdesktop command not present in output kickstart' >> ${disksdir}/RESULT
+        return 1
+    fi
+}


### PR DESCRIPTION
Test that the default desktop and default systemd target are correctly
configured when the xconfig and skipx commands are used.