### PR TITLE
Don't use inst.noninteractive by default for now

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -31,7 +31,7 @@ inject_ks_to_initrd() {
     echo "true"
 }
 
-DEFAULT_BASIC_BOOTOPTS="inst.noninteractive debug=1 inst.debug"
+DEFAULT_BASIC_BOOTOPTS="debug=1 inst.debug"
 
 DEFAULT_DRACUT_BOOTOPTS="rd.shell=0 rd.emergency=poweroff"
 


### PR DESCRIPTION
We are still hitting user-interaction-required race conditions
in GUI if inst.noninteractive is used for kickstart tests,
mostly for those with extensive %packages section.

While this is indeed an indication of a real bug, it also
prevents us from getting any results from package based tests.

So lets drop this from the default boo options for now
and put it back only once the race condition is fixed.