### PR TITLE
Fix check function name for bridge tests.

### DIFF
--- a/post-nochroot-lib-network.sh
+++ b/post-nochroot-lib-network.sh
@@ -1,8 +1,8 @@
 SYSROOT=${ANA_INSTALL_PATH:-/mnt/sysimage}
 
-# check_bridge_has_slave BRIDGE SLAVE "yes|no"
+# check_bridge_has_slave_nochroot BRIDGE SLAVE "yes|no"
 # Check that the bridge device BRIDGE has ("yes") or has not ("no") a slave device SLAVE
-function check_bridge_has_slave() {
+function check_bridge_has_slave_nochroot() {
     local bridge="$1"
     local slave="$2"
     local expected_result="$3"


### PR DESCRIPTION
Fixes this:
/tmp/ks-script-5f4f50k6: line 142: check_bridge_has_slave_nochroot: command not found
/tmp/ks-script-5f4f50k6: line 143: check_bridge_has_slave_nochroot: command not found
(which made the check pass)