### PR TITLE
Do not use KICKSTART_NAME mechanism in .sh files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,6 +135,9 @@ A kickstart test consists of two files:
   NOTE: possible redefinintions of KICKSTART_NAME value in files included in
   the the .sh file (eg to reuse .sh file of another test) are ignored.
 
+  NOTE: The fragments (%ksappend) mechanism does not work together with
+  KICKSTART_NAME setting (%ksappend is not applied).
+
 Chapter 2. Environment Variables
 ================================
 

--- a/bindtomac-network-device-default-httpks.sh
+++ b/bindtomac-network-device-default-httpks.sh
@@ -18,6 +18,5 @@
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
 TESTTYPE="network"
-KICKSTART_NAME=bindtomac-network-device-default-httpks
 
 . ${KSTESTDIR}/network-device-default-httpks.sh

--- a/network-device-default-httpks.ks.in
+++ b/network-device-default-httpks.ks.in
@@ -1,0 +1,39 @@
+#test name: network-device-default
+%ksappend repos/default.ks
+install
+
+network --bootproto=dhcp --ipv6=2001:cafe:cafe::1/64
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+%post --nochroot
+
+@KSINCLUDE@ post-nochroot-lib-network.sh
+
+check_gui_configurations @KSTEST_NETDEV1@
+
+%end
+
+%post
+
+@KSINCLUDE@ post-lib-network.sh
+
+check_device_ifcfg_value @KSTEST_NETDEV1@ IPV6ADDR 2001:cafe:cafe::1/64
+
+# No error was written to /root/RESULT file, everything is OK
+if [[ ! -e /root/RESULT ]]; then
+   echo SUCCESS > /root/RESULT
+fi
+%end

--- a/network-device-default-httpks.sh
+++ b/network-device-default-httpks.sh
@@ -23,7 +23,6 @@
 #      (and no ksdevice set), so it will be applied in anaconda.
 
 TESTTYPE=${TESTTYPE:-"network"}
-KICKSTART_NAME=network-device-default
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
It doesn't work with fragments. %ksappend is not applied to ks file defined by
KICKSTART_NAME.