### PR TITLE
Check package requirements are added for teamd and firewalld

### DIFF
--- a/firewall-disable-with-options.ks.in
+++ b/firewall-disable-with-options.ks.in
@@ -12,6 +12,13 @@
 firewall --disable --port=22001:tcp,6400:udp --service=tftp,smtp
 
 %post
+# firewalld package should be installed as long as the firewall command is present
+# in the input kickstart, regardless of its options
+rpm -q firewalld
+if [[ $? != 0 ]]; then
+    echo '*** firewalld package should have been installed' >> /root/RESULT
+fi
+
 # The firewall --disable kickstart command gets translated into firewall-offline-cmd --disable,
 # which simply disables the firewalld systemd unit. So by checking if the unit is disabled,
 # we can check if the kickstart command works correctly.

--- a/firewall-disable.ks.in
+++ b/firewall-disable.ks.in
@@ -11,6 +11,13 @@
 firewall --disable
 
 %post
+# firewalld package should be installed as long as the firewall command is present
+# in the input kickstart, regardless of its options
+rpm -q firewalld
+if [[ $? != 0 ]]; then
+    echo '*** firewalld package should have been installed' >> /root/RESULT
+fi
+
 # The firewall --disable kickstart command gets translated into firewall-offline-cmd --disable,
 # which simply disables the firewalld systemd unit. So by checking if the unit is disabled,
 # we can check if the kickstart command works correctly.

--- a/firewall-use-system-defaults-ignore-options.ks.in
+++ b/firewall-use-system-defaults-ignore-options.ks.in
@@ -21,6 +21,12 @@ firewall --use-system-defaults --port=22001:tcp,6400:udp --service=tftp,smtp
 %end
 
 %post
+# firewalld package should be installed as long as the firewall command is present
+# in the input kickstart, regardless of its options
+rpm -q firewalld
+if [[ $? != 0 ]]; then
+    echo '*** firewalld package should have been installed' >> /root/RESULT
+fi
 
 ## TEST PROCEDURE
 # Test for 22001/TCP

--- a/firewall-use-system-defaults.ks.in
+++ b/firewall-use-system-defaults.ks.in
@@ -15,6 +15,13 @@
 firewall --use-system-defaults
 
 %post
+# firewalld package should be installed as long as the firewall command is present
+# in the input kickstart, regardless of its options
+rpm -q firewalld
+if [[ $? != 0 ]]; then
+    echo '*** firewalld package should have been installed' >> /root/RESULT
+fi
+
 # On Fedora firewall is enabled by default.
 systemctl is-enabled firewall
 if [[ $? -eq 0 ]]; then

--- a/firewall-use-system-defaults.ks.in
+++ b/firewall-use-system-defaults.ks.in
@@ -16,7 +16,7 @@ firewall --use-system-defaults
 
 %post
 # On Fedora firewall is enabled by default.
-systemctl is-enabled firewalld
+systemctl is-enabled firewall
 if [[ $? -eq 0 ]]; then
     echo "*** firewall should be enabled" >> /root/RESULT
 fi

--- a/firewall.ks.in
+++ b/firewall.ks.in
@@ -9,6 +9,12 @@
 firewall --enable --port=22001:tcp,6400:udp --service=tftp,smtp
 
 %post
+# firewalld package should be installed as long as the firewall command is present
+# in the input kickstart, regardless of its options
+rpm -q firewalld
+if [[ $? != 0 ]]; then
+    echo '*** firewalld package should have been installed' >> /root/RESULT
+fi
 
 ## TEST PROCEDURE
 # Test for 22001/TCP

--- a/team-httpks.ks.in
+++ b/team-httpks.ks.in
@@ -53,6 +53,12 @@ check_device_ifcfg_value team1_slave_1 TEAM_MASTER team1
 check_device_ifcfg_value team1_slave_2 TEAM_MASTER team1
 check_device_connected team1 no
 
+# teamd package should have been installed as long as team devices are present
+rpm -q teamd
+if [[ $? != 0 ]]; then
+    echo '*** teamd package should have been installed' >> /root/RESULT
+fi
+
 # No error was written to /root/RESULT file, everything is OK
 if [[ ! -e /root/RESULT ]]; then
    echo SUCCESS > /root/RESULT

--- a/team-pre.ks.in
+++ b/team-pre.ks.in
@@ -61,6 +61,12 @@ check_device_ifcfg_value team1_slave_2 TEAM_MASTER team1
 
 check_device_connected team1 no
 
+# teamd package should have been installed as long as team devices are present
+rpm -q teamd
+if [[ $? != 0 ]]; then
+    echo '*** teamd package should have been installed' >> /root/RESULT
+fi
+
 # No error was written to /root/RESULT file, everything is OK
 if [[ ! -e /root/RESULT ]]; then
    echo SUCCESS > /root/RESULT

--- a/team.ks.in
+++ b/team.ks.in
@@ -53,6 +53,12 @@ check_device_ifcfg_value team1_slave_1 TEAM_MASTER team1
 check_device_ifcfg_value team1_slave_2 TEAM_MASTER team1
 check_device_connected team1 no
 
+# teamd package should have been installed as long as team devices are present
+rpm -q teamd
+if [[ $? != 0 ]]; then
+    echo '*** teamd package should have been installed' >> /root/RESULT
+fi
+
 # No error was written to /root/RESULT file, everything is OK
 if [[ ! -e /root/RESULT ]]; then
    echo SUCCESS > /root/RESULT


### PR DESCRIPTION
The first commit fixes a typo in in firewall related kickstart tests, while the second commit adds the package installation checks for teamd and firewalld.