### PR TITLE
Add tests for NetworkManager assumptions.

### DIFF
--- a/bindtomac-bridge-2devs-pre.ks.in
+++ b/bindtomac-bridge-2devs-pre.ks.in
@@ -28,6 +28,8 @@ shutdown
 
 @KSINCLUDE@ post-nochroot-lib-network.sh
 
+pass_autoconnections_info_to_chroot
+
 check_bridge_has_slave_nochroot bridge0 @KSTEST_NETDEV1@ yes
 check_bridge_has_slave_nochroot bridge1 @KSTEST_NETDEV2@ yes
 check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@ bridge0 bridge1
@@ -58,11 +60,12 @@ check_device_ifcfg_value bridge0_slave_1 ONBOOT no
 
 check_device_connected bridge1 no
 
-if [[ "@KSTEST_OS_NAME@" == "rhel" ]]; then
+detect_nm_has_autoconnections_off
+nm_has_autoconnections_off=$?
+if [[ $nm_has_autoconnections_off -eq 0 ]]; then
     check_device_connected @KSTEST_NETDEV2@ no
     check_device_has_ipv4_address @KSTEST_NETDEV2@ no
 else
-    # On Fedora NM automatically activates devices without ifcfgs with default connection
     check_device_connected @KSTEST_NETDEV2@ yes
 fi
 

--- a/bridge-2devs-pre.ks.in
+++ b/bridge-2devs-pre.ks.in
@@ -28,6 +28,8 @@ shutdown
 
 @KSINCLUDE@ post-nochroot-lib-network.sh
 
+pass_autoconnections_info_to_chroot
+
 check_bridge_has_slave_nochroot bridge0 @KSTEST_NETDEV1@ yes
 check_bridge_has_slave_nochroot bridge1 @KSTEST_NETDEV2@ yes
 check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@ bridge0 bridge1
@@ -58,11 +60,12 @@ check_device_ifcfg_value bridge0_slave_1 ONBOOT no
 
 check_device_connected bridge1 no
 
-if [[ "@KSTEST_OS_NAME@" == "rhel" ]]; then
+detect_nm_has_autoconnections_off
+nm_has_autoconnections_off=$?
+if [[ $nm_has_autoconnections_off -eq 0 ]]; then
     check_device_connected @KSTEST_NETDEV2@ no
     check_device_has_ipv4_address @KSTEST_NETDEV2@ no
 else
-    # On Fedora NM automatically activates devices without ifcfgs with default connection
     check_device_connected @KSTEST_NETDEV2@ yes
 fi
 

--- a/network-autoconnections-dhcpall-httpks.ks.in
+++ b/network-autoconnections-dhcpall-httpks.ks.in
@@ -44,7 +44,7 @@ check_connection_setting "Wired Connection" connection.interface-name --
 check_connection_setting "Wired Connection" connection.autoconnect yes
 check_connection_setting "Wired Connection" 802-3-ethernet.mac-address --
 
-check_nm_has_autoconnections_off
+detect_nm_has_autoconnections_off
 nm_has_autoconnections_off=$?
 if [[ $nm_has_autoconnections_off -eq 0 ]]; then
     check_number_of_connections 2
@@ -73,9 +73,11 @@ fi
 @KSINCLUDE@ post-nochroot-lib-network.sh
 
 # First copy result from %pre stage to chroot
+copy_pre_stage_result
+pass_autoconnections_info_to_chroot
+
 check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@ @KSTEST_NETDEV3@
 
-copy_pre_stage_result
 
 %end
 
@@ -95,7 +97,7 @@ check_device_connected @KSTEST_NETDEV3@ yes
 check_connection_device "Wired Connection" @KSTEST_NETDEV2@
 check_connection_device "System @KSTEST_NETDEV2@"
 
-check_nm_has_autoconnections_off
+detect_nm_has_autoconnections_off
 nm_has_autoconnections_off=$?
 if [[ $nm_has_autoconnections_off -eq 0 ]]; then
     check_number_of_connections 4

--- a/network-autoconnections-dhcpall-httpks.ks.in
+++ b/network-autoconnections-dhcpall-httpks.ks.in
@@ -1,0 +1,116 @@
+#test name: network-autoconnection-dhcpall-httpks
+# Test assumptions about connections and ifcfg files created in initramfs (by NM)
+# Also test consolidating of the connections by anaconda.
+# Variant for ip=dhcp option (which is currently equivalent to no boot options)
+%ksappend repos/default.ks
+install
+
+# Use nameserver as a difference from default autoconnection for checking
+network --device=@KSTEST_NETDEV2@ --bootproto=dhcp --no-activate  --nameserver 10.43.26.2
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+%pre
+
+# We will copy /root/RESULT to /mnt/sysimage/root/RESULT at the beginning of the %post (--nochroot) checks
+@KSINCLUDE@ post-lib-network.sh
+
+check_ifcfg_exists @KSTEST_NETDEV1@ no
+check_ifcfg_exists @KSTEST_NETDEV2@ yes
+check_ifcfg_exists @KSTEST_NETDEV3@ no
+check_device_connected @KSTEST_NETDEV1@ yes
+check_device_connected @KSTEST_NETDEV2@ yes
+check_device_connected @KSTEST_NETDEV3@ yes
+
+check_connection_device "Wired Connection" @KSTEST_NETDEV1@
+check_connection_device "Wired Connection" @KSTEST_NETDEV2@
+check_connection_device "System @KSTEST_NETDEV2@"
+check_connection_device "Wired Connection" @KSTEST_NETDEV3@
+check_connection_setting "Wired Connection" ipv4.method auto
+check_connection_setting "Wired Connection" ipv6.method auto
+check_connection_setting "Wired Connection" connection.interface-name --
+check_connection_setting "Wired Connection" connection.autoconnect yes
+check_connection_setting "Wired Connection" 802-3-ethernet.mac-address --
+
+check_nm_has_autoconnections_off
+nm_has_autoconnections_off=$?
+if [[ $nm_has_autoconnections_off -eq 0 ]]; then
+    check_number_of_connections 2
+else
+    check_number_of_connections 4
+    check_device_connected @KSTEST_NETDEV3@ yes
+    check_connection_device "Wired connection 1"
+    check_connection_setting "Wired connection 1" ipv4.method auto
+    check_connection_setting "Wired connection 1" ipv6.method auto
+    check_connection_setting "Wired connection 1" connection.interface-name "(@KSTEST_NETDEV1@|@KSTEST_NETDEV3@)"
+    check_connection_setting "Wired connection 1" connection.autoconnect yes
+    check_connection_setting "Wired connection 1" 802-3-ethernet.mac-address --
+    check_connection_device "Wired connection 2"
+    check_connection_setting "Wired connection 2" ipv4.method auto
+    check_connection_setting "Wired connection 2" ipv6.method auto
+    check_connection_setting "Wired connection 2" connection.interface-name "(@KSTEST_NETDEV1@|@KSTEST_NETDEV3@)"
+    check_connection_setting "Wired connection 2" connection.autoconnect yes
+    check_connection_setting "Wired connection 2" 802-3-ethernet.mac-address --
+fi
+
+
+%end
+
+%post --nochroot
+
+@KSINCLUDE@ post-nochroot-lib-network.sh
+
+# First copy result from %pre stage to chroot
+check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@ @KSTEST_NETDEV3@
+
+copy_pre_stage_result
+
+%end
+
+%post
+
+@KSINCLUDE@ post-lib-network.sh
+
+check_device_ifcfg_value @KSTEST_NETDEV1@ ONBOOT yes
+check_device_ifcfg_value @KSTEST_NETDEV2@ ONBOOT yes
+check_device_ifcfg_value @KSTEST_NETDEV2@ DNS1 10.43.26.2
+check_device_ifcfg_value @KSTEST_NETDEV3@ ONBOOT yes
+
+check_device_connected @KSTEST_NETDEV1@ yes
+check_device_connected @KSTEST_NETDEV2@ yes
+check_device_connected @KSTEST_NETDEV3@ yes
+
+check_connection_device "Wired Connection" @KSTEST_NETDEV2@
+check_connection_device "System @KSTEST_NETDEV2@"
+
+check_nm_has_autoconnections_off
+nm_has_autoconnections_off=$?
+if [[ $nm_has_autoconnections_off -eq 0 ]]; then
+    check_number_of_connections 4
+    check_connection_device "Wired Connection" @KSTEST_NETDEV1@
+    check_connection_device @KSTEST_NETDEV1@
+    check_connection_device "Wired Connection" @KSTEST_NETDEV3@
+    check_connection_device @KSTEST_NETDEV3@
+else
+    check_connection_device @KSTEST_NETDEV1@ @KSTEST_NETDEV1@
+    check_connection_device @KSTEST_NETDEV3@ @KSTEST_NETDEV3@
+    check_number_of_connections 4
+fi
+
+# No error was written to /root/RESULT file, everything is OK
+if [[ ! -e /root/RESULT ]]; then
+   echo SUCCESS > /root/RESULT
+fi
+%end

--- a/network-autoconnections-dhcpall-httpks.sh
+++ b/network-autoconnections-dhcpall-httpks.sh
@@ -1,0 +1,67 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
+
+# This is a variation of onboot-activate test.
+# In this case, kickstart is fetched via http instead of injecting in initrd.
+# The latter is causing that kickstart network commands are not applied (ifcfg
+# files created) in initramfs.
+
+TESTTYPE=${TESTTYPE:-"network"}
+
+. ${KSTESTDIR}/functions.sh
+
+
+kernel_args() {
+    . ${tmpdir}/ks_url
+    echo ${DEFAULT_BOOTOPTS} inst.ks=${ks_url}
+}
+
+# Arguments for virt-install --network options
+prepare_network() {
+    echo "network:default"
+    echo "network:default"
+    echo "network:default"
+}
+
+prepare() {
+    ks=$1
+    tmpdir=$2
+
+    # Copy the kickstart to a directory in tmpdir
+    mkdir ${tmpdir}/http
+    cp $ks ${tmpdir}/http/ks.cfg
+
+    # Start a http server to serve the included file
+    start_httpd ${tmpdir}/http $tmpdir
+
+    echo ks_url=${httpd_url}ks.cfg > ${tmpdir}/ks_url
+    echo "${ks}"
+}
+
+inject_ks_to_initrd() {
+    echo "false"
+}
+
+cleanup() {
+    tmpdir=$1
+
+    if [ -f ${tmpdir}/httpd-pid ]; then
+        kill $(cat ${tmpdir}/httpd-pid)
+    fi
+}

--- a/network-autoconnections-httpks.ks.in
+++ b/network-autoconnections-httpks.ks.in
@@ -43,7 +43,7 @@ check_connection_setting "@KSTEST_NETDEV1@" connection.interface-name @KSTEST_NE
 check_connection_setting "@KSTEST_NETDEV1@" connection.autoconnect yes
 check_connection_setting "@KSTEST_NETDEV1@" 802-3-ethernet.mac-address --
 
-check_nm_has_autoconnections_off
+detect_nm_has_autoconnections_off
 nm_has_autoconnections_off=$?
 if [[ $nm_has_autoconnections_off -eq 0 ]]; then
     check_number_of_connections 2
@@ -67,6 +67,7 @@ fi
 
 # First copy result from %pre stage to chroot
 copy_pre_stage_result
+pass_autoconnections_info_to_chroot
 
 check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@ @KSTEST_NETDEV3@
 
@@ -80,7 +81,7 @@ check_device_ifcfg_value @KSTEST_NETDEV1@ ONBOOT yes
 check_device_ifcfg_value @KSTEST_NETDEV2@ ONBOOT yes
 check_device_ifcfg_value @KSTEST_NETDEV2@ DNS1 10.43.26.2
 
-check_nm_has_autoconnections_off
+detect_nm_has_autoconnections_off
 nm_has_autoconnections_off=$?
 if [[ $nm_has_autoconnections_off -eq 0 ]]; then
     check_device_ifcfg_value @KSTEST_NETDEV3@ ONBOOT no

--- a/network-autoconnections-httpks.ks.in
+++ b/network-autoconnections-httpks.ks.in
@@ -1,0 +1,109 @@
+#test name: network-autoconnection-httpks
+# Test assumptions about connections and ifcfg files created in initramfs (by NM)
+# Also test consolidating of the connections by anaconda.
+# Variant for ip=dhcp option (which is currently equivalent to no boot options)
+%ksappend repos/default.ks
+install
+
+# Use nameserver as a difference from default autoconnection for checking
+network --device=@KSTEST_NETDEV2@ --bootproto=dhcp --no-activate  --nameserver 10.43.26.2
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+
+%pre
+
+# We will copy /root/RESULT to /mnt/sysimage/root/RESULT at the beginning of the %post (--nochroot) checks
+@KSINCLUDE@ post-lib-network.sh
+
+check_ifcfg_exists @KSTEST_NETDEV1@ no
+check_ifcfg_exists @KSTEST_NETDEV2@ yes
+check_ifcfg_exists @KSTEST_NETDEV3@ no
+
+check_device_connected @KSTEST_NETDEV1@ yes
+check_device_connected @KSTEST_NETDEV2@ no
+check_connection_device @KSTEST_NETDEV1@ @KSTEST_NETDEV1@
+check_connection_device "System @KSTEST_NETDEV2@"
+
+check_connection_setting "@KSTEST_NETDEV1@" ipv4.method auto
+check_connection_setting "@KSTEST_NETDEV1@" ipv6.method disabled
+check_connection_setting "@KSTEST_NETDEV1@" connection.interface-name @KSTEST_NETDEV1@
+check_connection_setting "@KSTEST_NETDEV1@" connection.autoconnect yes
+check_connection_setting "@KSTEST_NETDEV1@" 802-3-ethernet.mac-address --
+
+check_nm_has_autoconnections_off
+nm_has_autoconnections_off=$?
+if [[ $nm_has_autoconnections_off -eq 0 ]]; then
+    check_number_of_connections 2
+    check_device_connected @KSTEST_NETDEV3@ no
+else
+    check_number_of_connections 3
+    check_device_connected @KSTEST_NETDEV3@ yes
+    check_connection_device "Wired connection 1" @KSTEST_NETDEV3@
+    check_connection_setting "Wired connection 1" ipv4.method auto
+    check_connection_setting "Wired connection 1" ipv6.method auto
+    check_connection_setting "Wired connection 1" connection.interface-name @KSTEST_NETDEV3@
+    check_connection_setting "Wired connection 1" connection.autoconnect yes
+    check_connection_setting "Wired connection 1" 802-3-ethernet.mac-address --
+fi
+
+%end
+
+%post --nochroot
+
+@KSINCLUDE@ post-nochroot-lib-network.sh
+
+# First copy result from %pre stage to chroot
+copy_pre_stage_result
+
+check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@ @KSTEST_NETDEV3@
+
+%end
+
+%post
+
+@KSINCLUDE@ post-lib-network.sh
+
+check_device_ifcfg_value @KSTEST_NETDEV1@ ONBOOT yes
+check_device_ifcfg_value @KSTEST_NETDEV2@ ONBOOT yes
+check_device_ifcfg_value @KSTEST_NETDEV2@ DNS1 10.43.26.2
+
+check_nm_has_autoconnections_off
+nm_has_autoconnections_off=$?
+if [[ $nm_has_autoconnections_off -eq 0 ]]; then
+    check_device_ifcfg_value @KSTEST_NETDEV3@ ONBOOT no
+    check_number_of_connections 3
+    check_device_connected @KSTEST_NETDEV1@ yes
+    check_device_connected @KSTEST_NETDEV2@ no
+    check_device_connected @KSTEST_NETDEV3@ no
+    check_connection_device @KSTEST_NETDEV1@ @KSTEST_NETDEV1@
+    check_connection_device @KSTEST_NETDEV3@
+    check_connection_device "System @KSTEST_NETDEV2@"
+else
+    check_device_ifcfg_value @KSTEST_NETDEV3@ ONBOOT yes
+    check_number_of_connections 3
+    check_device_connected @KSTEST_NETDEV1@ yes
+    check_device_connected @KSTEST_NETDEV2@ no
+    check_device_connected @KSTEST_NETDEV3@ yes
+    check_connection_device @KSTEST_NETDEV1@ @KSTEST_NETDEV1@
+    check_connection_device "System @KSTEST_NETDEV2@"
+    check_connection_device @KSTEST_NETDEV3@ @KSTEST_NETDEV3@
+fi
+
+# No error was written to /root/RESULT file, everything is OK
+if [[ ! -e /root/RESULT ]]; then
+   echo SUCCESS > /root/RESULT
+fi
+%end

--- a/network-autoconnections-httpks.sh
+++ b/network-autoconnections-httpks.sh
@@ -1,0 +1,67 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
+
+# This is a variation of onboot-activate test.
+# In this case, kickstart is fetched via http instead of injecting in initrd.
+# The latter is causing that kickstart network commands are not applied (ifcfg
+# files created) in initramfs.
+
+TESTTYPE=${TESTTYPE:-"network"}
+
+. ${KSTESTDIR}/functions.sh
+
+
+kernel_args() {
+    . ${tmpdir}/ks_url
+    echo ${DEFAULT_BOOTOPTS} ip=${KSTEST_NETDEV1}:dhcp inst.ks=${ks_url}
+}
+
+# Arguments for virt-install --network options
+prepare_network() {
+    echo "network:default"
+    echo "network:default"
+    echo "network:default"
+}
+
+prepare() {
+    ks=$1
+    tmpdir=$2
+
+    # Copy the kickstart to a directory in tmpdir
+    mkdir ${tmpdir}/http
+    cp $ks ${tmpdir}/http/ks.cfg
+
+    # Start a http server to serve the included file
+    start_httpd ${tmpdir}/http $tmpdir
+
+    echo ks_url=${httpd_url}ks.cfg > ${tmpdir}/ks_url
+    echo "${ks}"
+}
+
+inject_ks_to_initrd() {
+    echo "false"
+}
+
+cleanup() {
+    tmpdir=$1
+
+    if [ -f ${tmpdir}/httpd-pid ]; then
+        kill $(cat ${tmpdir}/httpd-pid)
+    fi
+}

--- a/network-missing-ifcfg-httpks.ks.in
+++ b/network-missing-ifcfg-httpks.ks.in
@@ -21,6 +21,8 @@ shutdown
 
 @KSINCLUDE@ post-nochroot-lib-network.sh
 
+pass_autoconnections_info_to_chroot
+
 check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@
 
 %end
@@ -34,12 +36,15 @@ check_device_ifcfg_value @KSTEST_NETDEV1@ ONBOOT yes
 check_ifcfg_key_exists @KSTEST_NETDEV1@ HWADDR no
 check_device_connected @KSTEST_NETDEV1@ yes
 
-# @KSTEST_NETDEV2@ is configured neigher via boot options nor via kickstart so anaconda
+# @KSTEST_NETDEV2@ is configured neither via boot options nor via kickstart so anaconda
 # creates default ifcfg file (rhel) or dumps it from default connection created
 # by NM on Fedora
 check_device_ifcfg_value @KSTEST_NETDEV2@ DEVICE @KSTEST_NETDEV2@
 check_ifcfg_key_exists @KSTEST_NETDEV2@ HWADDR no
-if [[ "@KSTEST_OS_NAME@" == "rhel" ]]; then
+
+detect_nm_has_autoconnections_off
+nm_has_autoconnections_off=$?
+if [[ $nm_has_autoconnections_off -eq 0 ]]; then
     check_device_ifcfg_value @KSTEST_NETDEV2@ ONBOOT no
     check_device_connected @KSTEST_NETDEV2@ no
 else

--- a/network-static-2-pre.ks.in
+++ b/network-static-2-pre.ks.in
@@ -34,6 +34,8 @@ shutdown
 
 @KSINCLUDE@ post-nochroot-lib-network.sh
 
+pass_autoconnections_info_to_chroot
+
 check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@ @KSTEST_NETDEV3@ @KSTEST_NETDEV4@ @KSTEST_NETDEV5@
 
 %end
@@ -56,7 +58,9 @@ check_device_connected @KSTEST_NETDEV4@ yes
 check_device_ipv4_address @KSTEST_NETDEV4@ @KSTEST_STATIC_IP3@
 
 check_device_ifcfg_value @KSTEST_NETDEV5@ IPADDR @KSTEST_STATIC_IP4@
-if [[ "@KSTEST_OS_NAME@" == "rhel" ]]; then
+detect_nm_has_autoconnections_off
+nm_has_autoconnections_off=$?
+if [[ $nm_has_autoconnections_off -eq 0 ]]; then
     check_device_connected @KSTEST_NETDEV5@ no
 else
     # Fedora autoactivates default connections (Wired Connection 2)

--- a/onboot-activate.ks.in
+++ b/onboot-activate.ks.in
@@ -23,6 +23,8 @@ shutdown
 
 @KSINCLUDE@ post-nochroot-lib-network.sh
 
+pass_autoconnections_info_to_chroot
+
 check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@ @KSTEST_NETDEV3@
 
 %end
@@ -35,7 +37,9 @@ check_device_ifcfg_value @KSTEST_NETDEV1@ ONBOOT no
 check_device_ifcfg_value @KSTEST_NETDEV2@ ONBOOT yes
 check_device_ifcfg_value @KSTEST_NETDEV3@ ONBOOT no
 
-if [[ "@KSTEST_OS_NAME@" == "rhel" ]]; then
+detect_nm_has_autoconnections_off
+nm_has_autoconnections_off=$?
+if [[ $nm_has_autoconnections_off -eq 0 ]]; then
     check_device_connected @KSTEST_NETDEV2@ no
 else
     # On Fedora, default autoconnection "Wired connection 1" is activated

--- a/post-lib-network.sh
+++ b/post-lib-network.sh
@@ -179,3 +179,54 @@ function check_hostname() {
         echo "*** Failed check: ${hostname} is set in /etc/hostname" >> /root/RESULT
     fi
 }
+
+# check_number_of_connections NUMBER
+# Check that there is exactly NUMBER of NM connections
+function check_number_of_connections() {
+    local number="$1"
+
+    local ncons=$(nmcli -t -f NAME con | wc -l)
+
+    if [[ ${ncons} -ne ${number} ]]; then
+        echo "*** Failed check: number of connections upon start: ${number}" >> /root/RESULT
+    fi
+}
+
+# check_connection_device CONNECTION DEVICE
+# Check that CONNECTION exists and is active on DEVICE
+# Provide empty DEVICE ('')  for connection not active on any device.
+function check_connection_device() {
+    local con=$1
+    local dev=$2
+
+    nmcli -t -f NAME,DEVICE con | egrep -q ^${con}:${dev}$
+    if [[ $? -ne 0 ]]; then
+        echo "*** Failed check: connection ${con} exists and is active on ${dev}" >> /root/RESULT
+    fi
+}
+
+# check_connection_setting CONNECTION SETTING VALUE
+# Check that NM CONNECTION has SETTING set to VALUE ("--" for default/not set)
+# The value can be an egrep regexp
+function check_connection_setting () {
+    local con=$1
+    local setting=$2
+    local value=$3
+
+    nmcli -f ${setting} con show "${con}" | egrep -q ^[[:space:]]*${setting}:[[:space:]]*${value}[[:space:]]*$
+    if [[ $? -ne 0 ]]; then
+        echo "*** Failed check: connection ${con} setting ${setting} has value ${value}" >> /root/RESULT
+    fi
+}
+
+ANACONDA_NM_CONFIG_FILE_PATH=/etc/NetworkManager/conf.d/90-anaconda-no-auto-default.conf
+CHROOT_ANACONDA_NM_CONFIG_FILE_PATH=/root/90-anaconda-no-auto-default.conf
+# Check if NetworkManager has autoconnections turned off
+# Returns 0 if yes, 1 of not
+function check_nm_has_autoconnections_off() {
+    local config_file=${CHROOT_ANACONDA_NM_CONFIG_FILE_PATH}
+    if [[ ! -e $config_file ]]; then
+        config_file=${ANACONDA_NM_CONFIG_FILE_PATH}
+    fi
+    egrep -q ^[[:space:]]*no-auto-default=\\*[[:space:]]*$ ${config_file}
+}

--- a/post-lib-network.sh
+++ b/post-lib-network.sh
@@ -221,12 +221,16 @@ function check_connection_setting () {
 
 ANACONDA_NM_CONFIG_FILE_PATH=/etc/NetworkManager/conf.d/90-anaconda-no-auto-default.conf
 CHROOT_ANACONDA_NM_CONFIG_FILE_PATH=/root/90-anaconda-no-auto-default.conf
-# Check if NetworkManager has autoconnections turned off
+# Detect if NetworkManager has autoconnections turned off
+# If run in chroot, requires pass_autoconnection_info_to_chroot to be run in nochroot.
 # Returns 0 if yes, 1 of not
-function check_nm_has_autoconnections_off() {
+function detect_nm_has_autoconnections_off() {
     local config_file=${CHROOT_ANACONDA_NM_CONFIG_FILE_PATH}
     if [[ ! -e $config_file ]]; then
         config_file=${ANACONDA_NM_CONFIG_FILE_PATH}
+        if [[ ! -e $config_file ]]; then
+            echo "*** Broken check: can't find info about autoconnections. Was pass_autoconnection_info_to_chroot run?" >> /root/RESULT
+        fi
     fi
     egrep -q ^[[:space:]]*no-auto-default=\\*[[:space:]]*$ ${config_file}
 }

--- a/post-nochroot-lib-network.sh
+++ b/post-nochroot-lib-network.sh
@@ -138,13 +138,18 @@ function check_gui_configurations() {
     # TODO check that no other devices were added
 }
 
-ANACONDA_NM_CONFIG_FILE_PATH=/etc/NetworkManager/conf.d/90-anaconda-no-auto-default.conf
-CHROOT_ANACONDA_NM_CONFIG_FILE_PATH=/root/90-anaconda-no-auto-default.conf
+# Copy result from the %pre stage
 function copy_pre_stage_result() {
-    # Copy result from the %pre stage
     if [[ -e /root/RESULT ]]; then
        cp /root/RESULT $SYSROOT/root/RESULT
     fi
+}
+
+# Pass information about autoconnections configuration to target system chroot
+# to be available for detect_nm_has_autoconnection_off
+ANACONDA_NM_CONFIG_FILE_PATH=/etc/NetworkManager/conf.d/90-anaconda-no-auto-default.conf
+CHROOT_ANACONDA_NM_CONFIG_FILE_PATH=/root/90-anaconda-no-auto-default.conf
+function pass_autoconnections_info_to_chroot() {
     if [[ -e ${ANACONDA_NM_CONFIG_FILE_PATH} ]]; then
         cp ${ANACONDA_NM_CONFIG_FILE_PATH} ${SYSROOT}${CHROOT_ANACONDA_NM_CONFIG_FILE_PATH}
     else

--- a/post-nochroot-lib-network.sh
+++ b/post-nochroot-lib-network.sh
@@ -137,3 +137,17 @@ function check_gui_configurations() {
 
     # TODO check that no other devices were added
 }
+
+ANACONDA_NM_CONFIG_FILE_PATH=/etc/NetworkManager/conf.d/90-anaconda-no-auto-default.conf
+CHROOT_ANACONDA_NM_CONFIG_FILE_PATH=/root/90-anaconda-no-auto-default.conf
+function copy_pre_stage_result() {
+    # Copy result from the %pre stage
+    if [[ -e /root/RESULT ]]; then
+       cp /root/RESULT $SYSROOT/root/RESULT
+    fi
+    if [[ -e ${ANACONDA_NM_CONFIG_FILE_PATH} ]]; then
+        cp ${ANACONDA_NM_CONFIG_FILE_PATH} ${SYSROOT}${CHROOT_ANACONDA_NM_CONFIG_FILE_PATH}
+    else
+        echo "# no anaconda config file was found => autoconnections are on" > ${SYSROOT}${CHROOT_ANACONDA_NM_CONFIG_FILE_PATH}
+    fi
+}


### PR DESCRIPTION
Test assumptions about connections and ifcfg files created in initramfs (by
NM).  Also test consolidating of the connections by anaconda into persistent
connections that can be configured during installation.