### PR TITLE
linchpin: update inventory file generating for new linchpin

### DIFF
--- a/linchpin/PinFile
+++ b/linchpin/PinFile
@@ -20,7 +20,7 @@ kstests:
             profile: "{{ cloud_profile }}"
   layout:
     inventory_layout:
-      inventory_file: "{{ resource_name }}.inventory"
+      inventory_file: "{% raw -%}{{ workspace }}{%- endraw %}/inventories/{{ resource_name }}.inventory"
       vars:
         hostname: __IP__
       hosts:

--- a/linchpin/examples/example1/PinFile
+++ b/linchpin/examples/example1/PinFile
@@ -20,7 +20,7 @@ example1:
             profile: "{{ cloud_profile }}"
   layout:
     inventory_layout:
-      inventory_file: "{{ resource_name }}.inventory"
+      inventory_file: "{% raw -%}{{ workspace }}{%- endraw %}/inventories/{{ resource_name }}.inventory"
       vars:
         hostname: __IP__
       hosts:

--- a/linchpin/examples/example2/PinFile
+++ b/linchpin/examples/example2/PinFile
@@ -20,7 +20,7 @@ example2:
             profile: "{{ cloud_profile }}"
   layout:
     inventory_layout:
-      inventory_file: "{{ resource_name }}.inventory"
+      inventory_file: "{% raw -%}{{ workspace }}{%- endraw %}/inventories/{{ resource_name }}.inventory"
       vars:
         hostname: __IP__
       hosts:

--- a/linchpin/examples/example4/PinFile
+++ b/linchpin/examples/example4/PinFile
@@ -20,7 +20,7 @@ nightly1:
             profile: "{{ cloud_profile }}"
   layout:
     inventory_layout:
-      inventory_file: "{{ resource_name }}.inventory"
+      inventory_file: "{% raw -%}{{ workspace }}{%- endraw %}/inventories/{{ resource_name }}.inventory"
       vars:
         hostname: __IP__
       hosts:

--- a/linchpin/examples/example5/PinFile
+++ b/linchpin/examples/example5/PinFile
@@ -20,7 +20,7 @@ nightly-permanent:
             profile: "{{ cloud_profile }}"
   layout:
     inventory_layout:
-      inventory_file: "{{ resource_name }}.inventory"
+      inventory_file: "{% raw -%}{{ workspace }}{%- endraw %}/inventories/{{ resource_name }}.inventory"
       vars:
         hostname: __IP__
       hosts:

--- a/linchpin/examples/example6/PinFile
+++ b/linchpin/examples/example6/PinFile
@@ -20,7 +20,7 @@ kstest-runners:
             profile: "{{ cloud_profile }}"
   layout:
     inventory_layout:
-      inventory_file: "{{ resource_name }}.inventory"
+      inventory_file: "{% raw -%}{{ workspace }}{%- endraw %}/inventories/{{ resource_name }}.inventory"
       vars:
         hostname: __IP__
       hosts:

--- a/linchpin/examples/example7/PinFile
+++ b/linchpin/examples/example7/PinFile
@@ -20,7 +20,7 @@ example7:
             profile: "{{ cloud_profile }}"
   layout:
     inventory_layout:
-      inventory_file: "{{ resource_name }}.inventory"
+      inventory_file: "{% raw -%}{{ workspace }}{%- endraw %}/inventories/{{ resource_name }}.inventory"
       vars:
         hostname: __IP__
       hosts:

--- a/linchpin/layouts/kstests.yml
+++ b/linchpin/layouts/kstests.yml
@@ -1,6 +1,6 @@
 ---
 inventory_layout:
-  inventory_file: "{{ resource_name }}.inventory"
+  inventory_file: "{% raw -%}{{ workspace }}{%- endraw %}/inventories/{{ resource_name }}.inventory"
   vars:
     hostname: __IP__
   hosts:


### PR DESCRIPTION
Apparently {{ workspace }} is no more automagically prepended to relative path
configured for the file.