### PR TITLE
In worker deployment task update packages first

### DIFF
--- a/ansible/roles/kstest/tasks/main.yml
+++ b/ansible/roles/kstest/tasks/main.yml
@@ -2,6 +2,11 @@
 
 ### Install required packages
 
+- name: Update all packages
+  dnf:
+    name: "*"
+    state: latest
+
 - name: Install required groups
   dnf:
     name:
@@ -22,11 +27,6 @@
       - libguestfs-tools # kstests
       - vim
       - rsync
-    state: latest
-
-- name: Update all packages
-  dnf:
-    name: "*"
     state: latest
 
 - name: Install kernel-modules (reboot if updated)


### PR DESCRIPTION
In worker deployment task update packages first,
before installing groups and packages.

This way the system would be up to date, including DNF
and possibly avoiding some obscure but still nasty issues
with file conflicts that can happen when installing individual
groups or packages to a system that is out of date.