### PR TITLE
Adapt to change of NM autoconnections upon initramfs connections (#17…

### DIFF
--- a/network-autoconnections-dhcpall-httpks.ks.in
+++ b/network-autoconnections-dhcpall-httpks.ks.in
@@ -34,6 +34,8 @@ check_device_connected @KSTEST_NETDEV1@ yes
 check_device_connected @KSTEST_NETDEV2@ yes
 check_device_connected @KSTEST_NETDEV3@ yes
 
+check_number_of_connections 2
+
 check_connection_device "Wired Connection" @KSTEST_NETDEV1@
 check_connection_device "Wired Connection" @KSTEST_NETDEV2@
 check_connection_device "System @KSTEST_NETDEV2@"
@@ -43,28 +45,6 @@ check_connection_setting "Wired Connection" ipv6.method auto
 check_connection_setting "Wired Connection" connection.interface-name --
 check_connection_setting "Wired Connection" connection.autoconnect yes
 check_connection_setting "Wired Connection" 802-3-ethernet.mac-address --
-
-detect_nm_has_autoconnections_off
-nm_has_autoconnections_off=$?
-if [[ $nm_has_autoconnections_off -eq 0 ]]; then
-    check_number_of_connections 2
-else
-    check_number_of_connections 4
-    check_device_connected @KSTEST_NETDEV3@ yes
-    check_connection_device "Wired connection 1"
-    check_connection_setting "Wired connection 1" ipv4.method auto
-    check_connection_setting "Wired connection 1" ipv6.method auto
-    check_connection_setting "Wired connection 1" connection.interface-name "(@KSTEST_NETDEV1@|@KSTEST_NETDEV3@)"
-    check_connection_setting "Wired connection 1" connection.autoconnect yes
-    check_connection_setting "Wired connection 1" 802-3-ethernet.mac-address --
-    check_connection_device "Wired connection 2"
-    check_connection_setting "Wired connection 2" ipv4.method auto
-    check_connection_setting "Wired connection 2" ipv6.method auto
-    check_connection_setting "Wired connection 2" connection.interface-name "(@KSTEST_NETDEV1@|@KSTEST_NETDEV3@)"
-    check_connection_setting "Wired connection 2" connection.autoconnect yes
-    check_connection_setting "Wired connection 2" 802-3-ethernet.mac-address --
-fi
-
 
 %end
 
@@ -97,19 +77,11 @@ check_device_connected @KSTEST_NETDEV3@ yes
 check_connection_device "Wired Connection" @KSTEST_NETDEV2@
 check_connection_device "System @KSTEST_NETDEV2@"
 
-detect_nm_has_autoconnections_off
-nm_has_autoconnections_off=$?
-if [[ $nm_has_autoconnections_off -eq 0 ]]; then
-    check_number_of_connections 4
-    check_connection_device "Wired Connection" @KSTEST_NETDEV1@
-    check_connection_device @KSTEST_NETDEV1@
-    check_connection_device "Wired Connection" @KSTEST_NETDEV3@
-    check_connection_device @KSTEST_NETDEV3@
-else
-    check_connection_device @KSTEST_NETDEV1@ @KSTEST_NETDEV1@
-    check_connection_device @KSTEST_NETDEV3@ @KSTEST_NETDEV3@
-    check_number_of_connections 4
-fi
+check_number_of_connections 4
+check_connection_device "Wired Connection" @KSTEST_NETDEV1@
+check_connection_device @KSTEST_NETDEV1@
+check_connection_device "Wired Connection" @KSTEST_NETDEV3@
+check_connection_device @KSTEST_NETDEV3@
 
 # No error was written to /root/RESULT file, everything is OK
 if [[ ! -e /root/RESULT ]]; then


### PR DESCRIPTION
…58468)

NM doesn't create default autoconnection if the device has "Wired Connetction"
from initramfs.