### PR TITLE
Create a group that covers the basic installation cases

### DIFF
--- a/autopart-encrypted-1.sh
+++ b/autopart-encrypted-1.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
-TESTTYPE="autopart storage"
+TESTTYPE="autopart storage coverage"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/bond2-httpks.sh
+++ b/bond2-httpks.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE=${TESTTYPE:-"network"}
+TESTTYPE="${TESTTYPE:-"network"} coverage"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/bootloader-1.sh
+++ b/bootloader-1.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
-TESTTYPE="bootloader storage"
+TESTTYPE="bootloader storage coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/clearpart-3.sh
+++ b/clearpart-3.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
-TESTTYPE="clearpart storage"
+TESTTYPE="clearpart storage coverage"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/container.sh
+++ b/container.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="bootloader packaging"
+TESTTYPE="bootloader packaging coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/default-desktop.sh
+++ b/default-desktop.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
-TESTTYPE="services"
+TESTTYPE="services coverage"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/validate-lib-services.sh

--- a/default-systemd-target-tui.sh
+++ b/default-systemd-target-tui.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
-TESTTYPE="services"
+TESTTYPE="services coverage"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/validate-lib-services.sh

--- a/firewall.sh
+++ b/firewall.sh
@@ -18,6 +18,6 @@
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 #                    Martin Kolman <mkolman@redhat.com>
 
-TESTTYPE="network firewall"
+TESTTYPE="network firewall coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/hello-world.sh
+++ b/hello-world.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
-TESTTYPE="addon"
+TESTTYPE="addon coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/hostname.sh
+++ b/hostname.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="network"
+TESTTYPE="network coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/initial-setup-default.sh
+++ b/initial-setup-default.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
-TESTTYPE="initial-setup"
+TESTTYPE="initial-setup coverage"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/validate-lib-initial-setup.sh

--- a/keyboard.sh
+++ b/keyboard.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="keyboard i18n"
+TESTTYPE="keyboard i18n coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/lang.sh
+++ b/lang.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="language i18n"
+TESTTYPE="language i18n coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/lvm-1.sh
+++ b/lvm-1.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="lvm storage"
+TESTTYPE="lvm storage coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/lvm-thinp-1.sh
+++ b/lvm-thinp-1.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="lvm storage"
+TESTTYPE="lvm storage coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/mountpoint-assignment-1.sh
+++ b/mountpoint-assignment-1.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
-TESTTYPE="mount storage"
+TESTTYPE="mount storage coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-static-2-httpks.sh
+++ b/network-static-2-httpks.sh
@@ -24,7 +24,7 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
-TESTTYPE=${TESTTYPE:-"network"}
+TESTTYPE="${TESTTYPE:-"network"} coverage"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/nosave-1.sh
+++ b/nosave-1.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
-TESTTYPE="logs"
+TESTTYPE="logs coverage"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/ntp-pools.sh
+++ b/ntp-pools.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="time"
+TESTTYPE="time coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/onboot-activate.sh
+++ b/onboot-activate.sh
@@ -24,7 +24,7 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
-TESTTYPE="network"
+TESTTYPE="network coverage"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/packages-and-groups-ignoremissing.sh
+++ b/packages-and-groups-ignoremissing.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="packaging"
+TESTTYPE="packaging coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/raid-1.sh
+++ b/raid-1.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="raid storage"
+TESTTYPE="raid storage coverage"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/reqpart.sh
+++ b/reqpart.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="storage"
+TESTTYPE="storage coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/rootpw-basic.sh
+++ b/rootpw-basic.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="users"
+TESTTYPE="users coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/rootpw-lock.sh
+++ b/rootpw-lock.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="users"
+TESTTYPE="users coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/selinux-enforcing.sh
+++ b/selinux-enforcing.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="selinux"
+TESTTYPE="selinux coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/services.sh
+++ b/services.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="services"
+TESTTYPE="services coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/snapshot-post.sh
+++ b/snapshot-post.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 
-TESTTYPE="snapshot lvm storage"
+TESTTYPE="snapshot lvm storage coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/team-pre.sh
+++ b/team-pre.sh
@@ -24,7 +24,7 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
-TESTTYPE=${TESTTYPE:-"network"}
+TESTTYPE="${TESTTYPE:-"network"} coverage"
 
 . ${KSTESTDIR}/team.sh
 

--- a/user-multiple.sh
+++ b/user-multiple.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
-TESTTYPE="users"
+TESTTYPE="users coverage"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Use the group `coverage` to quickly test your changes for the most common
uses cases of the installation.