### PR TITLE
Updates image support

### DIFF
--- a/ansible/roles/kstest-master/defaults/main/test-configuration.yml
+++ b/ansible/roles/kstest-master/defaults/main/test-configuration.yml
@@ -12,6 +12,32 @@ kstest_updates_img: ""
 # Additional installer boot options to be used
 kstest_additional_boot_options: ""
 
+### Generating of updates image
+
+# Should the updates image be automatically generated?
+# Ignored if kstest_updates_img is set.
+# False unless "yes"
+kstest_updates_generate: ""
+
+# Installer repo from which the updates will be generated
+kstest_updates_repo: https://github.com/rhinstaller/anaconda.git
+
+# Head of the image update
+kstest_updates_head: master
+
+# Base of the image update
+# Defaults to the version of anaconda detected in the installer iso
+kstest_updates_base: ""
+
+# Path to remote destination for updates image upload
+# Kstest user on master has to be authorized for accessing the target
+# (eg with master ssh key).
+#kstest_updates_upload_path: "user@host:updates"
+kstest_updates_upload_path: ""
+
+# Url from where updates image of generated name will be available for tests after upload
+kstest_updates_dir_url: ""
+
 ### Software repositories for tests.
 
 # Override platform defaults with the repositories defined below.

--- a/ansible/roles/kstest-master/files/scripts/kstests_history.py
+++ b/ansible/roles/kstest-master/files/scripts/kstests_history.py
@@ -141,6 +141,9 @@ for result_dir in sorted(os.listdir(results_path)):
                     history_data[test].pop()
                     history_data[test].append(HISTORY_UNKNOWN)
 
+    if params.get('UPDATES_IMAGE'):
+        anaconda_ver += " + updates.img"
+
     with open(os.path.join(result_path, md5sum_filename), "r") as f:
         isomd5 = f.read()
     header = "<a href=\"{}/{}\">{}</a></br>{}</br>{}".format(results_dir, result_dir, result_dir, anaconda_ver,

--- a/ansible/roles/kstest-master/files/scripts/kstests_history.py
+++ b/ansible/roles/kstest-master/files/scripts/kstests_history.py
@@ -4,6 +4,7 @@ import os
 import sys
 import re
 from argparse import ArgumentParser
+from configparser import ConfigParser
 
 parser = ArgumentParser(description="""
 Create summary html page from directory containing results of kickstart test runs.
@@ -37,18 +38,29 @@ HISTORY_FAILED = 1
 HISTORY_UNKNOWN = 2
 HISTORY_NOT_RUN = 3
 
-ANACONDA_VER_RE = re.compile(r'.*main:\s*/sbin/anaconda\s*(.*)')
+ANACONDA_VERSION_IN_ANACONDA_LOG_RE = re.compile(r'.*main:\s*/sbin/anaconda\s*(.*)')
 
 results_dir = os.path.basename(results_path)
 
-def get_anconda_ver(result_path):
+def get_anconda_version_from_log(result_path):
     anaconda_log = os.path.join(result_path, "anaconda/anaconda.log")
     if os.path.exists(anaconda_log):
         with open(anaconda_log, "r") as flog:
             for line in flog:
-                m = ANACONDA_VER_RE.match(line)
+                m = ANACONDA_VERSION_IN_ANACONDA_LOG_RE.match(line)
                 if m:
                     return (m.groups(1)[0])
+    return ""
+
+def get_params_from_file(filename):
+    config = ConfigParser()
+    if not os.path.isfile(filename):
+        print("Can't get test parameters from {}: not found".format(params_file), file=sys.stderr)
+        config.read_string("[top]\n")
+    else:
+        with open(filename) as stream:
+            config.read_string("[top]\n" + stream.read())
+    return config['top']
 
 count = 0
 old_isomd5 = ""
@@ -61,7 +73,11 @@ for result_dir in sorted(os.listdir(results_path)):
         continue
 
     count = count + 1
-    anaconda_ver = ""
+
+    params_file = os.path.join(result_path, params_filename)
+    params = get_params_from_file(params_file)
+
+    anaconda_ver = params.get('ANACONDA_VERSION') or ""
 
     with open(report_file) as f:
         for test, results in tests.items():
@@ -108,7 +124,7 @@ for result_dir in sorted(os.listdir(results_path)):
                     ref = "{}/{}/{}".format(results_dir, result_dir, test_log_dirs[0])
                     if not anaconda_ver:
                         res_path = os.path.join(results_path, result_dir, test_log_dirs[0])
-                        anaconda_ver = get_anconda_ver(res_path)
+                        anaconda_ver = get_anconda_version_from_log(res_path)
                 tests[test].pop()
                 if ref:
                     tests[test].append("<a href={}>{}</a> {}".format(ref, result, detail))
@@ -131,7 +147,6 @@ for result_dir in sorted(os.listdir(results_path)):
                                                              "[NEW ISO]" if isomd5 != old_isomd5 else "-")
     old_isomd5 = isomd5
 
-    params_file = os.path.join(result_path, params_filename)
     if not os.path.isfile(params_file):
         print("Can't parse out test run time from {}: not found".format(params_file), file=sys.stderr)
     else:

--- a/ansible/roles/kstest-master/templates/run_tests.sh.j2
+++ b/ansible/roles/kstest-master/templates/run_tests.sh.j2
@@ -21,6 +21,13 @@ ADDITIONAL_BOOT_OPTIONS="{{ kstest_additional_boot_options }}"
 TEST_DEFAULTS_FILE=scripts/defaults.sh
 FRAGMENTS_OVERRIDE_DIR="{{ kstest.master.fragments_override_dir}}"
 
+UPDATES_GENERATE="{{ kstest_updates_generate }}"
+UPDATES_REPO="{{ kstest_updates_repo }}"
+UPDATES_HEAD="{{ kstest_updates_head }}"
+UPDATES_BASE="{{ kstest_updates_base }}"
+UPDATES_UPLOAD_PATH="{{ kstest_updates_upload_path }}"
+UPDATES_DIR_URL="{{ kstest_updates_dir_url }}"
+
 COMPOSE_BOOT_ISO=images/boot.iso
 KSTEST_USER=kstest
 RESULTS_DIR={{ kstest.master.dir.results }}
@@ -122,7 +129,6 @@ KSTEST_URL=${KSTEST_URL}
 BOOT_ISO_URL=${BOOT_ISO_URL}
 TEST_REMOTES=${TEST_REMOTES}
 TEST_JOBS=${TEST_JOBS}
-UPDATES_IMAGE=${UPDATES_IMAGE}
 GIT_REPO=${GIT_REPO}
 GIT_BRANCH=${GIT_BRANCH}
 EOF
@@ -174,11 +180,47 @@ rm -rf ${BOOT_ISO_MOUNT_DIR}
 ANACONDA_VERSION=$(egrep '^anaconda-[0-9]' ${LORAX_PACKAGES_PATH} | rev | cut -d"." -f1-2 --complement | rev)
 echo "ANACONDA_VERSION=${ANACONDA_VERSION}" >> ${TEST_PARAMETERS_FILE}
 
+
+### Generate updates image
+
+if [[ -z "${UPDATES_IMAGE}" && "${UPDATES_GENERATE}" == "yes" ]]; then
+
+    if [[ -z "${UPDATES_BASE}" ]]; then
+        UPDATES_BASE=${ANACONDA_VERSION}
+    fi
+
+    ANACONDA_CHECKOUT_TMP_DIR=$(mktemp -d)
+    pushd ${ANACONDA_CHECKOUT_TMP_DIR}
+    git clone ${UPDATES_REPO}
+    cd anaconda
+    git checkout ${UPDATES_HEAD}
+    UPDATES_HEAD_HASH=$(git rev-parse HEAD)
+    scripts/makeupdates -t ${UPDATES_BASE}
+    UPDATES_GENERATED_IMG_NAME=updates.${UPDATES_HEAD_HASH}.img
+
+    scp updates.img ${UPDATES_UPLOAD_PATH}/${UPDATES_GENERATED_IMG_NAME}
+    popd
+    rm -rf ${ANACONDA_CHECKOUT_TMP_DIR}
+
+    UPDATES_IMAGE=${UPDATES_DIR_URL}/${UPDATES_GENERATED_IMG_NAME}
+
+    cat >> ${TEST_PARAMETERS_FILE} <<- EOF
+UPDATES_REPO=${UPDATES_REPO}
+UPDATES_HEAD=${UPDATES_HEAD}
+UPDATES_BASE=${UPDATES_BASE}
+UPDATES_UPLOAD_PATH=${UPDATES_UPLOAD_PATH}
+EOF
+
+fi
+
+TIME_OF_GENERATIG_UPDATES_IMAGE=$(date +%s)
+
 ### Use updates image
 
 UPDATES_IMAGE_ARG=""
 if [[ -n "${UPDATES_IMAGE}" ]]; then
     UPDATES_IMAGE_ARG="-u ${UPDATES_IMAGE}"
+    echo "UPDATES_IMAGE=${UPDATES_IMAGE}" >> ${TEST_PARAMETERS_FILE}
 fi
 
 

--- a/ansible/roles/kstest-master/templates/run_tests.sh.j2
+++ b/ansible/roles/kstest-master/templates/run_tests.sh.j2
@@ -40,6 +40,11 @@ LOG_FILENAME={{ kstest.master.file.log }}
 RUN_FILE_PATH=${HOME_DIR}/{{ kstest.master.file.run }}
 FRAGMENTS_OVERRIDE_PATH=${HOME_DIR}/${FRAGMENTS_OVERRIDE_DIR}
 
+ISO_IMAGE_PATH={{ kstest.master.iso.image_path }}
+ISO_IMAGE_ROOTFS_PATH={{ kstest.master.iso.rootfs_path }}
+IMAGE_LORAX_PACKAGES_PATH={{ kstest.master.iso.lorax_packages_path }}
+LORAX_PACKAGES_FILENAME={{ kstest.master.file.lorax_packages}}
+
 # Test run id
 START_TIME=$(date +%F-%H_%M_%S)
 
@@ -138,6 +143,36 @@ TIME_OF_DOWNLOADING_ISO=$(date +%s)
 ISO_MD5_SUM_FILE="${RESULT_PATH}/${ISOMD5SUM_FILENAME}"
 echo ${ISO_MD5_SUM} > ${ISO_MD5_SUM_FILE}
 
+
+### Get lorax packages info
+
+BOOT_ISO_MOUNT_DIR=$(mktemp -d)
+BOOT_ISO_MOUNT_DIR_ISO=${BOOT_ISO_MOUNT_DIR}/iso
+BOOT_ISO_MOUNT_DIR_IMAGE=${BOOT_ISO_MOUNT_DIR}/image
+BOOT_ISO_MOUNT_DIR_ROOTFS=${BOOT_ISO_MOUNT_DIR}/rootfs
+mkdir ${BOOT_ISO_MOUNT_DIR_ISO}
+mkdir ${BOOT_ISO_MOUNT_DIR_IMAGE}
+mkdir ${BOOT_ISO_MOUNT_DIR_ROOTFS}
+
+sudo mount ${BOOT_ISO} ${BOOT_ISO_MOUNT_DIR_ISO}
+sudo mount ${BOOT_ISO_MOUNT_DIR_ISO}${ISO_IMAGE_PATH} ${BOOT_ISO_MOUNT_DIR_IMAGE}
+sudo mount ${BOOT_ISO_MOUNT_DIR_IMAGE}${ISO_IMAGE_ROOTFS_PATH} ${BOOT_ISO_MOUNT_DIR_ROOTFS}
+
+LORAX_PACKAGES_PATH=${RESULT_PATH}/${LORAX_PACKAGES_FILENAME}
+sudo cp ${BOOT_ISO_MOUNT_DIR_ROOTFS}${IMAGE_LORAX_PACKAGES_PATH} ${LORAX_PACKAGES_PATH}
+sudo chown ${KSTEST_USER}:${KSTEST_USER} ${LORAX_PACKAGES_PATH}
+
+sudo umount ${BOOT_ISO_MOUNT_DIR_ROOTFS}
+sudo umount ${BOOT_ISO_MOUNT_DIR_IMAGE}
+sudo umount ${BOOT_ISO_MOUNT_DIR_ISO}
+
+rm -rf ${BOOT_ISO_MOUNT_DIR}
+
+
+### Get anaconda version info
+
+ANACONDA_VERSION=$(egrep '^anaconda-[0-9]' ${LORAX_PACKAGES_PATH} | rev | cut -d"." -f1-2 --complement | rev)
+echo "ANACONDA_VERSION=${ANACONDA_VERSION}" >> ${TEST_PARAMETERS_FILE}
 
 ### Use updates image
 

--- a/ansible/roles/kstest-master/vars/main/main.yml
+++ b/ansible/roles/kstest-master/vars/main/main.yml
@@ -20,7 +20,17 @@ kstest:
       result_report: result_report.txt
       test_parameters: test_parameters.txt
       isomd5sum: isomd5sum.txt
+      lorax_packages: lorax-packages.log
     # relative path in home directory
     dir:
       results: results
       git_repo: git/kickstart-tests
+
+    ### Facts about installer iso image structure
+    iso:
+      # path to the image on the iso
+      image_path: /images/install.img
+      # rootfs path inside the image
+      rootfs_path: /LiveOS/rootfs.img
+      # path to file containing rpm versions used to build to the image
+      lorax_packages_path: /root/lorax-packages.log


### PR DESCRIPTION
The purpose if this patch-set is adding support for running tests with automatically generated updates image from git repository.

To achieve that I had to obtain anaconda version in the tested iso before running the test (to get default base reference/tag for updates image) and I decided to use lorax-packages.log from the tested iso. I added the file to the test results so we can:
- Start to get the version for the summary page from the file instead of anaconda.log of the tests which does not have to be always available - eg if all tests fail earlier, or if log files are deleted to save space. This is done by one of the patches.
- Add package changes info to the summary page (eg bottom of the column) by easy update of the script generating the summary (this is for another PR later)