### PR TITLE
ansible: indicate updates image change in history summary html

### DIFF
--- a/ansible/roles/kstest-master/files/scripts/kstests_history.py
+++ b/ansible/roles/kstest-master/files/scripts/kstests_history.py
@@ -108,6 +108,7 @@ def get_params_from_file(filename):
 
 count = 0
 isomd5 = ""
+updates_img = ""
 packages_file_path = ""
 for result_dir in sorted(os.listdir(results_path)):
     result_path = os.path.join(results_path, result_dir)
@@ -131,6 +132,9 @@ for result_dir in sorted(os.listdir(results_path)):
     with open(os.path.join(result_path, md5sum_filename), "r") as f:
         isomd5 = f.read()
     new_iso = previous_isomd5 != isomd5
+
+    previous_updates_img = updates_img
+    updates_img = params.get('UPDATES_IMAGE') or ""
 
     with open(report_file) as f:
         for test, results in tests.items():
@@ -194,8 +198,11 @@ for result_dir in sorted(os.listdir(results_path)):
                     history_data[test].pop()
                     history_data[test].append(HISTORY_UNKNOWN)
 
-    if params.get('UPDATES_IMAGE'):
-        anaconda_ver += " + updates.img"
+    if updates_img:
+        anaconda_ver = "{} +&nbsp;updates{}".format(
+            anaconda_ver,
+            "&nbsp;(NEW)" if updates_img != previous_updates_img else "",
+        )
 
     header = "<a href=\"{}/{}\">{}</a></br>{}</br>{}".format(results_dir, result_dir, result_dir, anaconda_ver,
                                                              "[NEW ISO]" if new_iso else "-")
@@ -232,7 +239,7 @@ for result_dir in sorted(os.listdir(results_path)):
 
 thead = """
 
-<tr>
+<tr valign=\"top\">
 {}
 <td>STATUS from last {} runs</td>
 </tr>


### PR DESCRIPTION
I am already using it in production - see the (NEW) indicator in the table header.

![updates_NEW](https://user-images.githubusercontent.com/1220237/72518697-2a862a00-3856-11ea-8ec7-807f14e01fdd.png)
