### PR TITLE
Fix packages-excludedocs on RHEL

### DIFF
--- a/packages-excludedocs.ks.in
+++ b/packages-excludedocs.ks.in
@@ -10,13 +10,6 @@
 %ksappend common/common_no_payload.ks
 
 %packages --excludedocs
-@container-management
-@core
-@domain-client
-@hardware-support
-@headless-management
-@server-product
-@standard
 %end
 
 %post


### PR DESCRIPTION
Remove group that is not available on rhel and remove package that
stores license in /usr/share/doc folder.