### PR TITLE
Update encrypt-device test so it does not fail on RHEL

### DIFF
--- a/encrypt-device.ks.in
+++ b/encrypt-device.ks.in
@@ -20,8 +20,7 @@ timezone America/New_York --utc
 rootpw testcase
 shutdown
 
-%packages --default
-%end
+%ksappend payload/default_packages.ks
 
 %post
 root_lv_type=$(blkid -ovalue -sTYPE /dev/mapper/vg01-root_lv)


### PR DESCRIPTION
The failure reason was insufficient space.