### PR TITLE
Fix network-autoconnections-httpks test for RHEL

### DIFF
--- a/network-autoconnections-httpks.ks.in
+++ b/network-autoconnections-httpks.ks.in
@@ -27,8 +27,12 @@ shutdown
 
 # We will copy /root/RESULT to /mnt/sysimage/root/RESULT at the beginning of the %post (--nochroot) checks
 @KSINCLUDE@ post-lib-network.sh
-
-check_ifcfg_exists @KSTEST_NETDEV1@ no
+if [[ "@KSTEST_OS_NAME@" == "rhel" ]]; then
+    # No NM in initramfs in RHEL8.2 => ifcfg file is created by dracut network module
+    check_ifcfg_exists @KSTEST_NETDEV1@ yes
+else
+    check_ifcfg_exists @KSTEST_NETDEV1@ no
+fi
 check_ifcfg_exists @KSTEST_NETDEV2@ yes
 check_ifcfg_exists @KSTEST_NETDEV3@ no
 
@@ -38,7 +42,12 @@ check_connection_device @KSTEST_NETDEV1@ @KSTEST_NETDEV1@
 check_connection_device "System @KSTEST_NETDEV2@"
 
 check_connection_setting "@KSTEST_NETDEV1@" ipv4.method auto
-check_connection_setting "@KSTEST_NETDEV1@" ipv6.method disabled
+if [[ "@KSTEST_OS_NAME@" == "rhel" ]]; then
+    # No NM in initramfs in RHEL8.2 - the default differs!
+    check_connection_setting "@KSTEST_NETDEV1@" ipv6.method auto
+else
+    check_connection_setting "@KSTEST_NETDEV1@" ipv6.method disabled
+fi
 check_connection_setting "@KSTEST_NETDEV1@" connection.interface-name @KSTEST_NETDEV1@
 check_connection_setting "@KSTEST_NETDEV1@" connection.autoconnect yes
 check_connection_setting "@KSTEST_NETDEV1@" 802-3-ethernet.mac-address --


### PR DESCRIPTION
On RHEL there is no NM in initramfs yet.