### PR TITLE
ansible: fix runner deployment check

### DIFF
--- a/ansible/roles/kstest-master/templates/check_deployed_runners.sh.j2
+++ b/ansible/roles/kstest-master/templates/check_deployed_runners.sh.j2
@@ -6,7 +6,7 @@ RUNNERS=$1
 CHECKED_RUNNERS=""
 FILE_DROPPED_AFTER_DEPLOYMENT="{{ kstest_successful_deployment_file_path }}"
 for runner in ${RUNNERS}; do
-    ssh kstest@${runner} test -f ${FILE_DROPPED_AFTER_DEPLOYMENT}
+    ssh -o PasswordAuthentication=no -o StrictHostKeyChecking=no kstest@${runner} test -f ${FILE_DROPPED_AFTER_DEPLOYMENT}
     rc=$?
     if [[ ${rc} == 0 ]]; then
         CHECKED_RUNNERS="${CHECKED_RUNNERS} ${runner}"


### PR DESCRIPTION
If passing authorized keys to deployed runner failed then the check (ssh call)
hanged waiting for password blocking the whole check.