### PR TITLE
Fix validation / result based on CRIT in log

### DIFF
--- a/scripts/launcher/run_one_test.py
+++ b/scripts/launcher/run_one_test.py
@@ -160,8 +160,7 @@ class Runner(object):
 
         if validator and not validator.result:
             validator.report_result()
-            self._shell.cleanup()
-            return validator.return_code
+            return validator
 
         ret = self._validate_result()
         if ret.check_ret_code():


### PR DESCRIPTION
Example of the problem:
CRIT message in log:
```
10:46:42,423 INFO anaconda:packaging: Installed: jasper-libs-2.0.16-2.fc32.x86_64 1580277359 f811a624d1488c7ffa66509a9f6d3314afa9234601f3c700b2c9223d12e64329
10:46:42,475 INFO anaconda:packaging: Configuring (running scriptlet for): libutempter-1.1.6-18.fc32.x86_64 1580298606 aa1cc6efd7d18c1f6f2b319b851f79376b3a883764e9d3e7190bd64f9be12a28
10:46:42,547 NOTICE audit:AVC avc:  denied  { read } for  pid=2616 comm="groupadd" path="pipe:[83887]" dev="pipefs" ino=83887 scontext=system_u:system_r:groupadd_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=fifo_file permissive=1
10:46:42,566 CRIT groupadd:unknown configuration item `HOME_MODE'
10:46:42,599 NOTICE audit:AVC avc:  denied  { ioctl } for  pid=2616 comm="groupadd" path="pipe:[83887]" dev="pipefs" ino=83887 ioctlcmd=0x5401 scontext=system_u:system_r:groupadd_t:s0 tcontext=system_u:system_r:kernel_t:s0 tclass=fifo_file permissive=1
10:46:42,599 NOTICE audit:ADD_GROUP pid=2616 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:groupadd_t:s0 msg='op=add-group id=22 exe="/usr/sbin/groupadd" hostname=? addr=? terminal=? res=success'
10:46:42,600 INFO groupadd:group added to /etc/group: name=utmp, GID=22
```
Results in this validation failure:
```
............................................................................................................
Failed to run subprocess: '['/home/kstest/git/kickstart-tests/scripts/launcher/lib/launcher_interface.sh', '-i', '/home/kstest/git/install_images/boot.kstest.iso', '-k', '1', '-w', '/var/tmp/kstest-bindtomac-network-static-2-httpks.5z_g9ynr', '-t', '/home/kstest/git/kickstart-tests/bindtomac-network-static-2-httpks.sh', 'cleanup']'
stderr:
error: failed to get network 'kstest-bindtomac-network-static-2-httpks.5z_g9ynr'
error: Network not found: no network with matching name 'kstest-bindtomac-network-static-2-httpks.5z_g9ynr'
/home/kstest/git/kickstart-tests/network-static-2-httpks.sh: line 97: kill: (16337) - No such process

2020-03-18 10:21:51,648: install_log = /var/tmp/kstest-bindtomac-network-static-2-httpks.5z_g9ynr/virt-install.log
2020-03-18 10:21:51,792: Starting virtual machine
2020-03-18 10:21:51,792: Running virt-install.
2020-03-18 10:21:51,792: virt-install ['-n', 'kstest-bindtomac-network-static-2-httpks_(fdddb0af-8c8c-4ce8-8df9-183f5b3a3b5a)', '-r', '2048', '--noautoconsole', '--vcpus', '1', '--rng', '/dev/random', '--noreboot', '--graphics', 'vnc', '--disk', 'path=/var/tmp/kstest-bindtomac-network-static-2-httpks.5z_g9ynr/disk-a.img,cache=unsafe,bus=sata', '--network', 'network:default', '--network', 'network:kstest-bindtomac-network-static-2-httpks.5z_g9ynr', '--network', 'network:kstest-bindtomac-network-static-2-httpks.5z_g9ynr', '--network', 'network:kstest-bindtomac-network-static-2-httpks.5z_g9ynr', '--network', 'network:kstest-bindtomac-network-static-2-httpks.5z_g9ynr', '--disk', 'path=/var/tmp/kstest-bindtomac-network-static-2-httpks.5z_g9ynr/boot.kstest.iso,device=cdrom,readonly=on,shareable=on', '--extra-args', ' debug=1 inst.debug rd.shell=0 rd.emergency=poweroff ip=enp1s0:dhcp ip=enp2s0:dhcp ip=enp3s0:dhcp inst.ks=http://10.0.138.147:40001/ks.cfg inst.kernel.hung_task_timeout_secs=1200 stage2=hd:CDLABEL=Fedora-E-dvd-x86_64-rawh', '--location', '/var/tmp/kstest-bindtomac-network-static-2-httpks.5z_g9ynr/boot.kstest.iso,kernel=isolinux/vmlinuz,initrd=isolinux/initrd.img', '--channel', 'tcp,host=127.0.0.1:52709,mode=connect,target_type=virtio,name=org.fedoraproject.anaconda.log.0']
2020-03-18 10:39:58,690: Install finished. Or at least virt shut down.
2020-03-18 10:39:58,699: shutting down kstest-bindtomac-network-static-2-httpks_(fdddb0af-8c8c-4ce8-8df9-183f5b3a3b5a)
2020-03-18 10:39:58,855: unmounting the iso
2020-03-18 10:39:58,883: Disk Image install successful
2020-03-18 10:39:58,911: SUMMARY
-------
Logs are in /var/tmp/kstest-bindtomac-network-static-2-httpks.5z_g9ynr
Disk image(s) at /var/tmp/kstest-bindtomac-network-static-2-httpks.5z_g9ynr/disk-a.img,cache=unsafe
Results are in /var/tmp/kstest-bindtomac-network-static-2-httpks.5z_g9ynr

2020-03-18 10:39:58,913: RESULT:bindtomac-network-static-2-httpks::FAILED:10:28:54,392 CRIT groupadd:unknown configuration item `HOME_MODE'

Traceback (most recent call last):
  File "scripts/launcher/run_one_test.py", line 205, in <module>
    ret_code = run_test_in_temp(config)
  File "scripts/launcher/run_one_test.py", line 195, in run_test_in_temp
    rc = runner.run_test()
  File "scripts/launcher/run_one_test.py", line 117, in run_test
    return ret.return_code
AttributeError: 'int' object has no attribute 'return_code'
================================================================
```