### PR TITLE
Remove miss-leading unified harddrive comment

### DIFF
--- a/unified-harddrive.ks.in
+++ b/unified-harddrive.ks.in
@@ -7,10 +7,6 @@
 # To create unified ISO for Fedora you can use this tool:
 # https://github.com/rhinstaller/devel-tools/tree/master/create_unified_iso
 #
-# This test has to have access to the NFS server. However NFS won't mount
-# if the VM is behind a NAT (NFS problem). So this test won't work on our setup
-# right now.
-#
 
 %ksappend common/common_no_payload.ks
 


### PR DESCRIPTION
It's not working with NFS so comment about NFS is just leftover from unified-nfs.