### PR TITLE
Add harddrive tests

### DIFF
--- a/fragments/platform/fedora_rawhide/section-data/server-dvd-link.ks
+++ b/fragments/platform/fedora_rawhide/section-data/server-dvd-link.ks
@@ -1,0 +1,7 @@
+# Create a variable in the pre/post section with link to a Fedora rawhide server DVD.
+# The curl tool will download this ISO and it will be processed later in the section.
+_LINK="http://ftp.fi.muni.cz/pub/linux/fedora/linux/development/rawhide/Server/x86_64/iso"
+ISO_LOCATION="$(curl -L $_LINK | grep -Po "Fedora-Server-dvd-x86_64-.*?.iso" | head -n 1)"
+ISO_LOCATION="${_LINK}/${ISO_LOCATION}"
+
+echo $ISO_LOCATION

--- a/fragments/platform/rhel8/section-data/server-dvd-link.ks
+++ b/fragments/platform/rhel8/section-data/server-dvd-link.ks
@@ -1,0 +1,7 @@
+# Create a variable in the pre/post section with link to a RHEL DVD.
+# The curl tool will download this ISO and it will be processed later in the section.
+_LINK=<ADD_LINK_TO_RHEL-8_ISO_HERE>
+ISO_LOCATION="$(curl -L $_LINK | grep -Po "RHEL-8.*?-x86_64-dvd1.iso" | head -n 1)"
+ISO_LOCATION="${_LINK}/${ISO_LOCATION}"
+
+echo $ISO_LOCATION

--- a/fragments/shared/common/common_no_storage_and_payload.ks
+++ b/fragments/shared/common/common_no_storage_and_payload.ks
@@ -1,0 +1,14 @@
+## common commands without payload and storage configuration ##
+install
+shutdown
+# network
+network --bootproto=dhcp
+# bootloader
+bootloader --timeout=1
+# l10n
+keyboard us
+lang en
+timezone America/New_York
+# user confguration
+rootpw testcase
+## common commands without payload and storage configuration - end ##

--- a/harddrive-install-tree-relative.ks.in
+++ b/harddrive-install-tree-relative.ks.in
@@ -1,0 +1,66 @@
+#version=DEVEL
+#test name: harddrive-install-tree-relative
+
+# This test is for testing the install from an harddrive ks command
+# with extracted installation tree.
+#
+# Server dvd is downloaded during the test execution. This test can be resource demanding!
+#
+# This test will use relative path for `harddrive --dir=` parameter.
+# Fix in https://github.com/rhinstaller/anaconda/pull/2419.
+#
+
+%ksappend common/common_no_storage_and_payload.ks
+
+# FIXME: ignoredisk is much better solution to avoid using the installation source HDD removal.
+# However, payload is using devicetree data to work with source so the source disk won't be
+# visible to Anaconda. Fix this when this behavior is fixed in the payload.
+
+zerombr
+clearpart --all --initlabel --drives=/dev/sda
+
+part / --fstype=ext4 --grow --size=4400 --ondisk=/dev/sda
+part /boot --fstype=ext4 --size=500 --ondisk=/dev/sda
+part swap --fstype=swap --size=500 --ondisk=/dev/sda
+
+harddrive --partition=/dev/sdb --dir=repo/
+
+%ksappend payload/default_packages.ks
+
+%pre
+# This will add ISO_LOCATION with link to an ISO
+%ksappend section-data/server-dvd-link.ks
+
+DISK="/dev/sdb"
+
+wipefs -a $DISK
+mkfs.ext4 -F $DISK
+mkdir /prep-mount
+
+
+# Mount the new source
+mount $DISK /prep-mount
+
+pushd /prep-mount
+
+# Mount the ISO
+curl -L "$ISO_LOCATION" -o source.iso
+mkdir iso-mount
+mount -oro source.iso iso-mount
+
+# Copy ISO content inside
+mkdir repo
+rsync -ahHvS --stats --exclude=/isolinux --exclude=/images --exclude=/EFI iso-mount/ repo/
+
+# Clean up
+umount iso-mount
+rm source.iso
+rm -rf iso-mount
+popd
+umount /prep-mount
+rm -rf /prep-mount
+%end
+
+%post
+%ksappend validation/success_if_result_empty.ks
+%end

--- a/harddrive-install-tree-relative.sh
+++ b/harddrive-install-tree-relative.sh
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
+
+TESTTYPE=${TESTTYPE:-"packaging"}
+
+. ${KSTESTDIR}/harddrive-install-tree.sh
+

--- a/harddrive-install-tree.ks.in
+++ b/harddrive-install-tree.ks.in
@@ -1,0 +1,63 @@
+#version=DEVEL
+#test name: harddrive-install-tree
+
+# This test is for testing the install from an harddrive ks command
+# with extracted installation tree.
+#
+# Server dvd is downloaded during the test execution. This test can be resource demanding!
+#
+
+%ksappend common/common_no_storage_and_payload.ks
+
+# FIXME: ignoredisk is much better solution to avoid using the installation source HDD removal.
+# However, payload is using devicetree data to work with source so the source disk won't be
+# visible to Anaconda. Fix this when this behavior is fixed in the payload.
+
+zerombr
+clearpart --all --initlabel --drives=/dev/sda
+
+part / --fstype=ext4 --grow --size=4400 --ondisk=/dev/sda
+part /boot --fstype=ext4 --size=500 --ondisk=/dev/sda
+part swap --fstype=swap --size=500 --ondisk=/dev/sda
+
+harddrive --partition=/dev/sdb --dir=/repo/
+
+%ksappend payload/default_packages.ks
+
+%pre
+# This will add ISO_LOCATION with link to an ISO
+%ksappend section-data/server-dvd-link.ks
+
+DISK="/dev/sdb"
+
+wipefs -a $DISK
+mkfs.ext4 -F $DISK
+mkdir /prep-mount
+
+
+# Mount the new source
+mount $DISK /prep-mount
+
+pushd /prep-mount
+
+# Mount the ISO
+curl -L "$ISO_LOCATION" -o source.iso
+mkdir iso-mount
+mount -oro source.iso iso-mount
+
+# Copy ISO content inside
+mkdir repo
+rsync -ahHvS --stats --exclude=/isolinux --exclude=/images --exclude=/EFI iso-mount/ repo/
+
+# Clean up
+umount iso-mount
+rm source.iso
+rm -rf iso-mount
+popd
+umount /prep-mount
+rm -rf /prep-mount
+%end
+
+%post
+%ksappend validation/success_if_result_empty.ks
+%end

--- a/harddrive-install-tree.sh
+++ b/harddrive-install-tree.sh
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
+
+TESTTYPE=${TESTTYPE:-"packaging"}
+
+. ${KSTESTDIR}/functions.sh
+
+prepare_disks() {
+    tmpdir=$1
+
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-a.img 10G
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-b.img 12G
+
+    echo ${tmpdir}/disk-a.img ${tmpdir}/disk-b.img
+}

--- a/harddrive-iso.ks.in
+++ b/harddrive-iso.ks.in
@@ -1,0 +1,54 @@
+#version=DEVEL
+#test name: harddrive-iso
+
+# This test is for testing the install from an harddrive ks command with ISO.
+#
+# Server dvd is downloaded during the test execution. This test can be resource demanding!
+#
+
+%ksappend common/common_no_storage_and_payload.ks
+
+# FIXME: ignoredisk is much better solution to avoid using the installation source HDD removal.
+# However, payload is using devicetree data to work with source so the source disk won't be
+# visible to Anaconda. Fix this when this behavior is fixed in the payload.
+
+zerombr
+clearpart --all --initlabel --drives=/dev/sda
+
+part / --fstype=ext4 --grow --size=4400 --ondisk=/dev/sda
+part /boot --fstype=ext4 --size=500 --ondisk=/dev/sda
+part swap --fstype=swap --size=500 --ondisk=/dev/sda
+
+harddrive --partition=/dev/sdb --dir=/
+
+%ksappend payload/default_packages.ks
+
+%pre
+# This will add ISO_LOCATION with link to an ISO
+%ksappend section-data/server-dvd-link.ks
+
+DISK="/dev/sdb"
+
+wipefs -a $DISK
+mkfs.ext4 -F $DISK
+mkdir /prep-mount
+
+
+pushd /prep-mount
+
+# Mount the new source
+mkdir hdd-mount
+mount $DISK hdd-mount
+
+# Download iso to the DVD
+curl -L "$ISO_LOCATION" -o hdd-mount/dvd.iso
+
+# Clean up
+umount hdd-mount
+popd
+rm -rf /prep-mount
+%end
+
+%post
+%ksappend validation/success_if_result_empty.ks
+%end

--- a/harddrive-iso.sh
+++ b/harddrive-iso.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
+
+TESTTYPE=${TESTTYPE:-"packaging"}
+
+. ${KSTESTDIR}/harddrive-install-tree.sh


### PR DESCRIPTION
Add tests for installation from harddrive.

They all work that in pre-section they will download Server DVD iso and place that in some form to one of the harddrives.

These tests could be resource demanding because each test is downloading DVD iso.

RHEL variants was not tested.