### PR TITLE
containers: define a container for single test runner

### DIFF
--- a/containers/README.md
+++ b/containers/README.md
@@ -1,0 +1,3 @@
+Containers for running kickstart tests.
+
+* runner - Run a kickstart test in a container.

--- a/containers/runner/Dockerfile
+++ b/containers/runner/Dockerfile
@@ -1,0 +1,49 @@
+FROM fedora:30
+LABEL maintainer='anaconda-devel-list@redhat.com'
+
+RUN dnf -y update && \
+    dnf -y install \
+    python3 \
+    vim \
+    rsync \
+    git \
+    virt-install \
+    libguestfs-tools \
+    lorax-lmc-virt \
+    parallel \
+    python3-libvirt && \
+    dnf -y clean all
+
+ENV APP_ROOT=/opt/kstest
+ENV PATH=${APP_ROOT}/bin:${PATH} \
+    APP_DATA=${APP_ROOT}/data \
+    KSTEST_USER=kstest
+
+RUN groupadd -g 1001 -r ${KSTEST_USER} -f && \
+    useradd -u 1001 -r -g ${KSTEST_USER} -m -c "Kickstart test user" ${KSTEST_USER} && \
+    mkdir -p ${APP_DATA} && \
+    # Add kstest to sudoers which is required by run_kickstart_tests.sh script
+    echo "kstest ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/${KSTEST_USER} && \
+    chmod 0440 /etc/sudoers.d/${KSTEST_USER}
+
+# This is what OpenShift does with random user he is using
+# BUT it does not seem to work, kstest user is not in the root group
+# so it can't for example create dirs in APP_ROOT
+#RUN usermod -a -G root ${KSTEST_USER}
+
+COPY run-kstest runlibvirt ${APP_ROOT}/bin/
+
+# OpenShift
+RUN  chgrp -R 0 ${APP_ROOT} && \
+     chmod -R g=u ${APP_ROOT} && \
+# This is needed as the group above does not work
+     chmod -R ugo+w ${APP_ROOT}
+
+# Inputs: boot.iso
+# Outputs: logs
+VOLUME ${APP_DATA}
+
+USER ${KSTEST_USER}
+WORKDIR ${APP_ROOT}
+
+CMD ["run-kstest"]

--- a/containers/runner/README.md
+++ b/containers/runner/README.md
@@ -1,0 +1,117 @@
+Running kickstart tests in containers
+-------------------------------------
+
+Tooling for running tests in VMs in cloud (OpenStack) is in [../../linchpin](../../linchpin).
+
+The motivation for moving from VMs to containers to run kickstart tests is:
+* To be able to use containers tooling for deployment, scheduling and scaling of resources for batches of kickstart tests.
+* To allow the user to run a kickstart test manually in an easy way.
+
+
+Host requirements
+-----------------
+
+Dependencies needed to be installed are defined in `host_packages` variable of [vars.yml](vars.yml).
+```
+sudo dnf install git policycoreutils-python-utils podman
+```
+
+The `squashfs` kernel module needs to be running on the host. To check run:
+```
+lsmod | grep squashfs
+```
+
+The host needs to have enough available loop device nodes created to be able to mount various images.
+To check existing nodes run:
+```
+ls /dev/loop[0-9]*
+```
+To check used nodes run:
+```
+losetup
+```
+There should be at least three available nodes.
+To create a new node on the host run mknod, for example to create /dev/loop<NUM> run:
+```
+sudo mknod /dev/loop<NUM> b 7 <NUM>
+```
+
+There is a [playbook](runner-host.yml) for deployment of the host on Fedora Cloud Base Image. See [Troubleshooting] for preferred version to be used.
+
+Run a test in a container
+-------------------------
+
+Build the container:
+```
+sudo podman build -t kstest-runner .
+```
+Note: we can't use rootless containers because of mounting of images in the contaier.
+
+Define the directory for passing of data between the container and the system (via volume):
+```
+export VOLUME_DIR=${PWD}/data
+```
+
+Create subdirs for test inputs (installation image) and outputs (logs):
+```
+mkdir -p ${VOLUME_DIR}/images
+mkdir -p ${VOLUME_DIR}/logs
+```
+Set the proper selinux context for the volume directory:
+```
+./set-volume-dir-permissions.sh ${VOLUME_DIR}
+```
+
+Download the test subject (installer boot iso):
+```
+curl http://mirror.karneval.cz/pub/linux/fedora/linux/releases/32/Everything/x86_64/os/images/boot.iso --output ${VOLUME_DIR}/images/boot.iso
+```
+
+Run the test:
+```
+sudo podman run --env KSTESTS_TEST=keyboard -v ${VOLUME_DIR}:/opt/kstest/data --name last-kstest --privileged=true --device=/dev/kvm kstest-runner
+```
+Instead of keeping named container you can remove it after the test by replacing `--name last-kstest` option with `--rm`.
+
+See the results:
+```
+tree -L 3 ${VOLUME_DIR}/logs
+cat ${VOLUME_DIR}/logs/kstest-*/anaconda/anaconda.log
+```
+
+Configuration of the test
+-------------------------
+
+Environment variables for the container (`--env` option):
+* KSTESTS_TEST - name of the test to be run
+* UPDATES_IMAGE - HTTP URL of updates image to be used
+* KSTESTS_REPOSITORY - kickstart-tests git repository to be used
+* KSTESTS_BRANCH - kickstart-tests git branch to be used
+* BOOT_ISO - name of the installer boot iso from ${VOLUME_DIR}/images to be tested (default is "boot.iso")
+
+
+Troubleshooting
+---------------
+
+### Host and container base image version
+Fedora 30 seems to be the container base image version with the highest chances of being able to run the tests (with regard to the libvirt version). It was run successfuly on Fedora 30 Cloud Base image deployed with the [playbook](runner-host.yml). On Fedora 30 Workstation on bare metal also Fedora 31 container worked.
+
+Other combinations failed with errors:
+* F32 host, F30 container image:
+```
+2020-05-12 12:36:28.714+0000: 16: error : virCgroupSetValueStr:477 : Unable to write to '/sys/fs/cgroup//cgroup.subtree_control': Operation not supported
+```
+* F32 container image:
+```
+2020-05-12 12:51:32,856 INFO: ERROR    Requested operation is not valid: network 'default' is not active
+```
+* F31 host, F31 container image:
+```
+2020-05-12 12:54:53.713+0000: 14: error : virCgroupV2ParseControllersFile:281 : Unable to read from '/sys/fs/cgroup/machine/cgroup.controllers': No such file or directory
+```
+Some likely related BZs:
+* [https://bugzilla.redhat.com/show_bug.cgi?id=1751120](https://bugzilla.redhat.com/show_bug.cgi?id=1751120)
+* [https://bugzilla.redhat.com/show_bug.cgi?id=1760233](https://bugzilla.redhat.com/show_bug.cgi?id=1760233)
+
+### Tests runnable in container
+Some tests require services, resources, or configration in VM hypervisor that might not be working in container. Checking the tests and trying to resolve the issues is TBD.

--- a/containers/runner/roles/runner-host/handlers/main.yml
+++ b/containers/runner/roles/runner-host/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Reboot machine
+  reboot:
+    reboot_timeout: 300
+    msg: "Reboot after kernel modules installation"

--- a/containers/runner/roles/runner-host/tasks/main.yml
+++ b/containers/runner/roles/runner-host/tasks/main.yml
@@ -1,0 +1,18 @@
+- name: Update all packages
+  dnf:
+    name: "*"
+    state: latest
+
+- name: Install packages
+  dnf:
+    name: "{{ host_packages }}"
+    state: latest
+
+- name: Install kernel-modules (reboot if updated)
+  dnf:
+    name: "kernel-modules"
+    state: present
+  notify:
+    - Reboot machine
+
+

--- a/containers/runner/run-kstest
+++ b/containers/runner/run-kstest
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+set -x
+
+KSTESTS_REPOSITORY=${KSTESTS_REPOSITORY:-https://github.com/rhinstaller/kickstart-tests}
+KSTESTS_BRANCH=${KSTESTS_BRANCH:-master}
+KSTESTS_DIR=${APP_ROOT}/kickstart-tests
+KSTESTS_TEST=${KSTESTS_TEST:-team}
+
+UPDATES_IMAGE=${UPDATES_IMAGE:-""}
+BOOT_ISO=${BOOT_ISO:-boot.iso}
+ISO_DIR=${APP_DATA}/images
+LOGS_DIR=${APP_DATA}/logs
+
+runlibvirt
+
+git clone ${KSTESTS_REPOSITORY} ${KSTESTS_DIR}
+git -C ${KSTESTS_DIR} checkout ${KSTESTS_BRANCH}
+git -C ${KSTESTS_DIR} remote -v
+
+# Prepare the configuration
+UPDATES_IMAGE_ARG=""
+if [[ -n "${UPDATES_IMAGE}" ]]; then
+  UPDATES_IMAGE_ARG="-u ${UPDATES_IMAGE}"
+fi
+
+# Run the test
+pushd ${KSTESTS_DIR}
+scripts/run_kickstart_tests.sh -k 2 -i ${ISO_DIR}/${BOOT_ISO} ${UPDATES_IMAGE_ARG} ${KSTESTS_TEST}
+popd
+
+# Copy logs to a volume
+# Fixup permissions
+sudo chown -R ${KSTEST_USER}:${KSTEST_USER} /var/tmp/kstest-*
+sudo chmod -R a+r /var/tmp/kstest-*
+# Clean up (artifacts from broken test)
+find /var/tmp/kstest-${KSTESTS_TEST}* -name "*.iso" -delete
+find /var/tmp/kstest-${KSTESTS_TEST}* -name "*.img" -delete
+# Move to target logs directory
+sudo cp -r /var/tmp/kstest-${KSTESTS_TEST}* ${LOGS_DIR}

--- a/containers/runner/runlibvirt
+++ b/containers/runner/runlibvirt
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+sudo libvirtd &
+sudo virtlogd &

--- a/containers/runner/runner-host.yml
+++ b/containers/runner/runner-host.yml
@@ -1,0 +1,19 @@
+---
+
+- hosts: runner-host
+  become: yes
+  gather_facts: no
+  tasks:
+
+    - name: Make sure python is installed for ansible
+      raw: dnf -y install python3 python3-dnf
+      register: python_installed
+      changed_when: "'Nothing to do' in python_installed.stdout"
+
+- hosts: runner-host
+  become: yes
+  vars_files:
+    - vars.yml
+  roles:
+    - runner-host
+

--- a/containers/runner/set-volume-dir-permissions.sh
+++ b/containers/runner/set-volume-dir-permissions.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+if [ $# -ne 1 ] ; then
+    echo "Usage: $0 <directory>"
+    exit 1
+fi
+
+DIR=$1
+
+echo ${DIR}
+
+sudo semanage fcontext -a -t container_file_t "${DIR}(/.*)?"
+sudo restorecon -R ${DIR}

--- a/containers/runner/vars.yml
+++ b/containers/runner/vars.yml
@@ -1,0 +1,7 @@
+# Variables for container host
+
+# Package dependencies
+host_packages:
+  - git
+  - policycoreutils-python-utils
+  - podman


### PR DESCRIPTION
Runner container will run kickstart test(s) VM(s).

It corresponds to master in linchpin tooling. There will be no runners in sense
of linchpin tooling (or remote runners in sense of run_kickstart_tests.sh) as
we move planning, scheduling and scaling to a higher level.  Moving from using
parallel in run_kickstart_tests.sh which distributes tests to runner hosts
(VMs) to runner container being worker for a test queue.