### PR TITLE
Make SElinux context test run after fixing these

### DIFF
--- a/selinux-contexts.ks.in
+++ b/selinux-contexts.ks.in
@@ -1,13 +1,28 @@
 #test name: selinux-contexts
-%ksappend repos/default.ks
 
+%ksappend repos/default.ks
 %ksappend common/common_no_payload.ks
 %ksappend payload/default_packages.ks
 
+# Check files with wrong SElinux contexts. This *must* run in %post after the
+# "stock" %post script 80-setfilecons.ks. Thus, include that file before our
+# code, to make sure it is executed in the right order.
+
+%include /usr/share/anaconda/post-scripts/80-setfilecons.ks
+
 %post
 
-# Collect files with bad contexts
-restorecon -rvn / -e /dev -e /mnt -e /proc -e /run -e /sys > /root/RESULT
+echo "Listing files with wrong SElinux contexts..."
+restorecon -rvn / -e /mnt -e /proc -e /run -e /sys > /root/RESULT
 
-%ksappend validation/success_if_result_empty.ks
+# Report success if no errors have been reported to /root/RESULT
+if [ ! -s /root/RESULT ]
+then
+    # result file empty or none -> success
+    echo SUCCESS > /root/RESULT
+else
+    # some errors happened
+    exit 1
+fi
+
 %end


### PR DESCRIPTION
The fixing of contexts happens in a custom %post script that is appended to the kickstart read in. A %post script as used in this test previously - directly in the kickstart file - was read before the fixing script, and thus reported too much.

Now the ks test uses a %pre script to write a %post script with the actual test, such that it is appended to all the other %post scripts (except for log gathering).