### PR TITLE
Fix the test for the lang command

### DIFF
--- a/lang.ks.in
+++ b/lang.ks.in
@@ -33,12 +33,6 @@ if ! rpm -q langpacks-cs langpacks-ru ; then
     echo '*** langpacks packages were not installed' >> /root/RESULT
 fi
 
-# there is one langonly group for ru, which contains one non-optional package.
-# check that it got installed
-if ! rpm -q paratype-pt-sans-fonts ; then
-    echo '*** langonly group for ru not installed' >> /root/RESULT
-fi
-
 if [[ ! -e /root/RESULT ]]; then
     echo SUCCESS > /root/RESULT
 fi


### PR DESCRIPTION
Don't check the dependencies of the langpacks-ru package, because they can
change. It is enough to check that the langpacks-ru package is installed on
the new system.