### PR TITLE
Enforce the LVM partitioning when necessary

### DIFF
--- a/bootloader-4.ks.in
+++ b/bootloader-4.ks.in
@@ -4,7 +4,7 @@ network --bootproto=dhcp
 
 bootloader --timeout=1 --boot-drive=sdb --driveorder=sda,sdb,sdx
 
-autopart
+autopart --type lvm
 clearpart --all --initlabel
 zerombr
 

--- a/bootloader-5.ks.in
+++ b/bootloader-5.ks.in
@@ -4,7 +4,7 @@ network --bootproto=dhcp
 
 bootloader --timeout=1 --driveorder=sdx,sdb,sda
 
-autopart
+autopart --type lvm
 clearpart --all --initlabel
 zerombr
 

--- a/clearpart-1.ks.in
+++ b/clearpart-1.ks.in
@@ -6,7 +6,7 @@ network --bootproto=dhcp
 
 bootloader --timeout=1
 clearpart --none --initlabel
-autopart
+autopart --type lvm
 
 keyboard us
 lang en_US.UTF-8

--- a/clearpart-2.ks.in
+++ b/clearpart-2.ks.in
@@ -6,7 +6,7 @@ network --bootproto=dhcp
 
 bootloader --timeout=1 --boot-drive=sda
 clearpart --all --drives=sda --initlabel
-autopart
+autopart --type lvm
 
 keyboard us
 lang en_US.UTF-8

--- a/clearpart-3.ks.in
+++ b/clearpart-3.ks.in
@@ -6,7 +6,7 @@ network --bootproto=dhcp
 
 bootloader --timeout=1 --boot-drive=sda
 clearpart --list=sda1 --initlabel
-autopart
+autopart --type lvm
 
 keyboard us
 lang en_US.UTF-8

--- a/clearpart-4.ks.in
+++ b/clearpart-4.ks.in
@@ -6,7 +6,7 @@ network --bootproto=dhcp
 
 bootloader --timeout=1 --boot-drive=sda
 clearpart --linux --initlabel
-autopart
+autopart --type lvm
 
 keyboard us
 lang en_US.UTF-8


### PR DESCRIPTION
The change of the default partitioning scheme to Btrfs broke some of the
kickstart tests, so enforce the LVM partitioning scheme to fix them.