### PR TITLE
update network noipv4 tests for kickstart applied in stage 2

### DIFF
--- a/network-noipv4-httpks.ks.in
+++ b/network-noipv4-httpks.ks.in
@@ -3,7 +3,8 @@
 install
 
 network --device=@KSTEST_NETDEV2@ --noipv4 --no-activate --onboot=yes
-network --device=@KSTEST_NETDEV3@ --noipv4 --activate --onboot=no
+network --device=@KSTEST_NETDEV3@ --noipv4 --noipv6 --activate --onboot=no
+network --device=@KSTEST_NETDEV4@ --noipv4 --activate --onboot=no
 
 bootloader --timeout=1
 zerombr
@@ -23,7 +24,9 @@ shutdown
 
 @KSINCLUDE@ post-nochroot-lib-network.sh
 
-check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@ @KSTEST_NETDEV3@
+pass_autoconnections_info_to_chroot
+
+check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@ @KSTEST_NETDEV3@ @KSTEST_NETDEV4@
 
 %end
 
@@ -33,11 +36,25 @@ check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@ @KSTEST_NETDEV3@
 
 check_config_key_exists @KSTEST_NETDEV2@ BOOTPROTO no ipv4 method disabled
 check_config_key_exists @KSTEST_NETDEV3@ BOOTPROTO no ipv4 method disabled
+check_config_key_exists @KSTEST_NETDEV4@ BOOTPROTO no ipv4 method disabled
+
+check_device_connected @KSTEST_NETDEV3@ yes
+check_device_has_ipv4_address @KSTEST_NETDEV3@ no
 
 # TODO create test with virtual network having ipv6 enabled (ipv6 only connection)
 #      libvirt default net does not have ipv6 enabled
-check_device_connected @KSTEST_NETDEV3@ no
-check_device_has_ipv4_address @KSTEST_NETDEV3@ no
+detect_nm_has_autoconnections_off
+nm_has_autoconnections_off=$?
+if [[ $nm_has_autoconnections_off -eq 0 ]]; then
+    check_device_connected @KSTEST_NETDEV4@ no
+    check_device_has_ipv4_address @KSTEST_NETDEV4@ no
+else
+    # connection fails to activate (RA timeout, no ip config)
+    # and default con. created by NM (Wired connection 2) is autoactivated again
+    check_device_connected @KSTEST_NETDEV4@ yes
+    check_device_has_ipv4_address @KSTEST_NETDEV4@ yes
+    check_connection_device "Wired connection 2" @KSTEST_NETDEV4@
+fi
 
 # No error was written to /root/RESULT file, everything is OK
 if [[ ! -e /root/RESULT ]]; then

--- a/network-noipv4-httpks.sh
+++ b/network-noipv4-httpks.sh
@@ -32,6 +32,7 @@ prepare_network() {
     echo "network:default"
     echo "network:default"
     echo "network:default"
+    echo "network:default"
 }
 
 prepare() {

--- a/network-noipv4-pre.ks.in
+++ b/network-noipv4-pre.ks.in
@@ -5,7 +5,8 @@ install
 %include /tmp/ksinclude
 %pre
 echo "network --device=@KSTEST_NETDEV2@ --noipv4 --no-activate --onboot=yes" >> /tmp/ksinclude
-echo "network --device=@KSTEST_NETDEV3@ --noipv4 --activate --onboot=no" >> /tmp/ksinclude
+echo "network --device=@KSTEST_NETDEV3@ --noipv4 --noipv6 --activate --onboot=no" >> /tmp/ksinclude
+echo "network --device=@KSTEST_NETDEV4@ --noipv4 --activate --onboot=no" >> /tmp/ksinclude
 %end
 
 bootloader --timeout=1
@@ -28,7 +29,7 @@ shutdown
 
 pass_autoconnections_info_to_chroot
 
-check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@ @KSTEST_NETDEV3@
+check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@ @KSTEST_NETDEV3@ @KSTEST_NETDEV4@
 
 %end
 
@@ -38,18 +39,24 @@ check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@ @KSTEST_NETDEV3@
 
 check_config_key_exists @KSTEST_NETDEV2@ BOOTPROTO no ipv4 method disabled
 check_config_key_exists @KSTEST_NETDEV3@ BOOTPROTO no ipv4 method disabled
+check_config_key_exists @KSTEST_NETDEV4@ BOOTPROTO no ipv4 method disabled
+
+check_device_connected @KSTEST_NETDEV3@ yes
+check_device_has_ipv4_address @KSTEST_NETDEV3@ no
+
 # TODO create test with virtual network having ipv6 enabled (ipv6 only connection)
 #      libvirt default net does not have ipv6 enabled
 detect_nm_has_autoconnections_off
 nm_has_autoconnections_off=$?
 if [[ $nm_has_autoconnections_off -eq 0 ]]; then
-    check_device_connected @KSTEST_NETDEV3@ no
-    check_device_has_ipv4_address @KSTEST_NETDEV3@ no
+    check_device_connected @KSTEST_NETDEV4@ no
+    check_device_has_ipv4_address @KSTEST_NETDEV4@ no
 else
-    # connection from %pre fails to activate (RA timeout, no ip config)
-    # and default con. created by NM (Wired connection 1) is autoactivated again
-    check_device_connected @KSTEST_NETDEV3@ yes
-    check_device_has_ipv4_address @KSTEST_NETDEV3@ yes
+    # connection fails to activate (RA timeout, no ip config)
+    # and default con. created by NM (Wired connection 2) is autoactivated again
+    check_device_connected @KSTEST_NETDEV4@ yes
+    check_device_has_ipv4_address @KSTEST_NETDEV4@ yes
+    check_connection_device "Wired connection 2" @KSTEST_NETDEV4@
 fi
 
 # No error was written to /root/RESULT file, everything is OK

--- a/network-noipv4-pre.sh
+++ b/network-noipv4-pre.sh
@@ -31,5 +31,6 @@ prepare_network() {
     echo "network:default"
     echo "network:default"
     echo "network:default"
+    echo "network:default"
 }
 


### PR DESCRIPTION
With processing of kickstart in stage 2 the code path of ordinary kickstart is
almost the same as for the configuration in %pre section, therefore the -httpks
and -pre versions of the test are converging to do the same checks. In the
future, when we are sure processing kickstart in stage2 has no fatal drawbacks
I am probably going to remove (or reduce to a few cases) the number of -pre
variants of networking tests.

Add a device with both --noipv4 and --noipv6 - in this case the connection is
activated.

Fix the case with --noipv4 only - in this case the connection is not activated
and is replaced by default autoconnection (on systems where default
autoconnections are enabled).