### PR TITLE
Add a kickstart test for the RPM OSTree payload

### DIFF
--- a/rpm-ostree.ks.in
+++ b/rpm-ostree.ks.in
@@ -1,0 +1,30 @@
+#test name: rpm-ostree
+
+# Use the default settings.
+%ksappend common/common_no_payload.ks
+
+# Set up the RPM OSTree source.
+ostreesetup --nogpg --osname=fedora-iot --remote=fedora-iot --url=https://kojipkgs.fedoraproject.org/compose/iot/repo/ --ref=fedora/rawhide/${basearch}/iot
+
+%post
+# Check the name of the remote.
+name="$(ostree remote list)"
+
+if [ "${name}" != "fedora-iot" ]; then
+    echo "Unexpected name: ${name}" >> /root/RESULT
+fi
+
+# Check the url of the remote.
+url="$(ostree remote show-url fedora-iot)"
+
+if [ "${url}" != "https://kojipkgs.fedoraproject.org/compose/iot/repo/" ]; then
+    echo "Unexpected URL: ${url}" >> /root/RESULT
+fi
+
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+
+# Write the result into logs.
+cat /root/RESULT
+%end

--- a/rpm-ostree.sh
+++ b/rpm-ostree.sh
@@ -1,0 +1,42 @@
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+
+TESTTYPE="payload ostree fedora-only"
+
+. ${KSTESTDIR}/functions.sh
+
+kernel_args() {
+    # Enforce the Fedora-IoT configuration.
+    echo ${DEFAULT_BOOTOPTS} inst.product=Fedora-IoT inst.variant=IoT
+}
+
+validate() {
+    # We are not able to copy files from the system.
+    # Look for the result in the logs we have.
+    local disksdir=$1
+    cat "${disksdir}/virt-install.log" | grep -q "SUCCESS"
+
+    if [[ $? != 0 ]]; then
+        status=1
+        echo '*** The test has failed.'
+        return 1
+    fi
+
+    return 0
+}


### PR DESCRIPTION
Use Fedora IoT for testing of the RPM OSTree payload.