### PR TITLE
README: Download boot.iso from official Fedora mirror, add missing scp test dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Then clone the kickstart-tests repository::
 
 And you also need a rawhide boot.iso (provided you want to run the kickstart tests on Rawhide)::
 
-  wget http://download.eng.brq.redhat.com/pub/fedora/linux/development/latest-rawhide/Server/x86_64/os/images/boot.iso
+  wget https://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Server/x86_64/os/images/boot.iso
 
 Please note that due to the dynamic nature of Rawhide the boot.iso might not always work.
 

--- a/README.rst
+++ b/README.rst
@@ -28,12 +28,9 @@ First you need to install the needed dependencies:
 - createrepo
 - python3-rpmfluff
 - squid
+- scp
 
-On Fedora the dependencies can be installed with dnf like this::
-
-  sudo dnf install lorax-lmc-virt libguestfs-tools python3-libvirt virt-install parallel createrepo python3-rpmfluff squid
-
-Or with the install_dependencies_fedora.sh script:
+On Fedora the dependencies can be installed with::
 
   ./scripts/install_dependencies_fedora.sh
 

--- a/scripts/install_dependencies_fedora.sh
+++ b/scripts/install_dependencies_fedora.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 echo "installing depndencies needed to run kickstart tests"
-sudo dnf install libguestfs-tools virt-install lorax-lmc-virt parallel python3-libvirt createrepo python3-rpmfluff squid
+sudo dnf install libguestfs-tools virt-install lorax-lmc-virt parallel python3-libvirt createrepo python3-rpmfluff squid openssh-clients
 echo "done"


### PR DESCRIPTION
There is no reason to use or expose the RedHat VPN internal mirror. Use
the official one, which automatically redirects to your closest mirror.