### PR TITLE
Update default FTP mirror

### DIFF
--- a/scripts/defaults.sh
+++ b/scripts/defaults.sh
@@ -9,4 +9,4 @@
 source network-device-names.cfg
 export KSTEST_URL='--url=https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/$basearch/os/'
 export KSTEST_MODULAR_URL='https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Modular/$basearch/os/'
-export KSTEST_FTP_URL='ftp://mirror.utexas.edu/pub/fedora/linux/development/rawhide/Everything/$basearch/os/'
+export KSTEST_FTP_URL='ftp://ftp.tu-chemnitz.de/pub/linux/fedora/linux/development/rawhide/Everything/$basearch/os/'


### PR DESCRIPTION
The previous one ceased to exist. FTP mirrors fall out of fashion more
and more, but there are still a few European ones.

Note that this still does not work with dnf 4.2.23 at least, due to
zchunk failing with FTP: https://bugzilla.redhat.com/show_bug.cgi?id=1886706

----

In CI we also override this with an internal mirror (download.eng.brq..) which also ceased to exist. I.e. the FTP server itself still works, but /pub/fedora/ is no more. There are a few released snapshots (like /released/fedora/F-33/Beta/), but it may be easier to just use the default mirror here. Where is this configured? Somewhere in Jenkins?