### PR TITLE
Enable bridged-bond-pre test which is no more knownfailure.

### DIFF
--- a/bridged-bond-pre.sh
+++ b/bridged-bond-pre.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE="knownfailure network"
+TESTTYPE="network"
 # This is not implemented yet for %pre (ie in anaconda, just in parse-kickstart)
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
The support for bridged bond was added in
https://github.com/rhinstaller/anaconda/pull/2861