### PR TITLE
Fix container test crash due to missing rpm

### DIFF
--- a/container.ks.in
+++ b/container.ks.in
@@ -31,6 +31,7 @@ clearpart --all
 -kernel
 -systemd
 bash
+rpm
 %end
 
 %post


### PR DESCRIPTION
The test was failing on importing the RPM keys:

```
 File "/usr/lib64/python3.9/site-packages/pyanaconda/payload/dnf/payload.py", line 2040, in post_install
    self._import_rpm_keys()
  File "/usr/lib64/python3.9/site-packages/pyanaconda/payload/dnf/payload.py", line 1998, in _import_rpm_keys
    util.execInSysroot("rpm", ["--import", interpolated_key])
[...]
FileNotFoundError: [Errno 2] No such file or directory: 'rpm'
```

It is reasonable to expect that at least our package manager is
contained in the installed target, otherwise it's just a really
bare-bones bash+coreutils environment. (For containers *that* small
you'd not choose Anaconda anyway, but build something from
docker.io/busybox).