### PR TITLE
Add dependencies required to run mkdud.py and make-addon-pkgs.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,10 +25,12 @@ First you need to install the needed dependencies:
 - libguestfs-tools
 - virt-install
 - parallel
+- createrepo
+- python3-rpmfluff
 
 On Fedora the dependencies can be installed with dnf like this::
 
-  sudo dnf install lorax-lmc-virt libguestfs-tools python3-libvirt virt-install parallel
+  sudo dnf install lorax-lmc-virt libguestfs-tools python3-libvirt virt-install parallel createrepo python3-rpmfluff
 
 Or with the install_dependencies_fedora.sh script:
 

--- a/README.rst
+++ b/README.rst
@@ -27,10 +27,11 @@ First you need to install the needed dependencies:
 - parallel
 - createrepo
 - python3-rpmfluff
+- squid
 
 On Fedora the dependencies can be installed with dnf like this::
 
-  sudo dnf install lorax-lmc-virt libguestfs-tools python3-libvirt virt-install parallel createrepo python3-rpmfluff
+  sudo dnf install lorax-lmc-virt libguestfs-tools python3-libvirt virt-install parallel createrepo python3-rpmfluff squid
 
 Or with the install_dependencies_fedora.sh script:
 

--- a/ansible/roles/kstest/tasks/main.yml
+++ b/ansible/roles/kstest/tasks/main.yml
@@ -29,6 +29,9 @@
       - libguestfs-tools # kstests
       - vim
       - rsync
+      # the two are required by mkdud.py and make-addon-pkgs.py
+      - createrepo
+      - python3-rpmfluff
     state: latest
 
 - name: Install kernel-modules (reboot if updated)

--- a/ansible/roles/kstest/tasks/main.yml
+++ b/ansible/roles/kstest/tasks/main.yml
@@ -32,6 +32,8 @@
       # the two are required by mkdud.py and make-addon-pkgs.py
       - createrepo
       - python3-rpmfluff
+      # required by launch_proxy.sh (proxy-* tests)
+      - squid
     state: latest
 
 - name: Install kernel-modules (reboot if updated)

--- a/scripts/install_dependencies_fedora.sh
+++ b/scripts/install_dependencies_fedora.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 echo "installing depndencies needed to run kickstart tests"
-sudo dnf install libguestfs-tools virt-install lorax-lmc-virt parallel python3-libvirt
+sudo dnf install libguestfs-tools virt-install lorax-lmc-virt parallel python3-libvirt createrepo python3-rpmfluff
 echo "done"

--- a/scripts/install_dependencies_fedora.sh
+++ b/scripts/install_dependencies_fedora.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 echo "installing depndencies needed to run kickstart tests"
-sudo dnf install libguestfs-tools virt-install lorax-lmc-virt parallel python3-libvirt createrepo python3-rpmfluff
+sudo dnf install libguestfs-tools virt-install lorax-lmc-virt parallel python3-libvirt createrepo python3-rpmfluff squid
 echo "done"


### PR DESCRIPTION
Currently used by proxy-* and driverdisk-disk tests.