### PR TITLE
Update the module-non-default-profiles test

### DIFF
--- a/module-non-default-profiles.ks.in
+++ b/module-non-default-profiles.ks.in
@@ -6,14 +6,11 @@
 %ksappend common/common_no_payload.ks
 
 %packages
-@^Fedora Server Edition
 kernel
 vim
 @nodejs:10/development
-@postgresql:9.6/server
-@mariadb:10.3/devel
-@ghc:8.8/small
-@gimp:2.10/devel
+@postgresql:9.6/client
+@mariadb:10.4/devel
 %end
 
 %post
@@ -35,32 +32,22 @@ fi
 
 rpm -q nodejs
 if [[ $? != 0 ]]; then
-    echo '*** nodejs for module nodejs profile server not installed' >> /root/RESULT
+    echo '*** nodejs for module nodejs not installed' >> /root/RESULT
 fi
 
 rpm -q nodejs-devel
 if [[ $? != 0 ]]; then
-    echo '*** nodejs-devel for module nodejs profile development not installed' >> /root/RESULT
+    echo '*** nodejs-devel for module nodejs not installed' >> /root/RESULT
 fi
 
-rpm -q postgresql-server
+rpm -q postgresql
 if [[ $? != 0 ]]; then
-    echo '*** postgresql-server for the postgresql module profile server not installed' >> /root/RESULT
+    echo '*** postgresql-client for the postgresql module not installed' >> /root/RESULT
 fi
 
 rpm -q mariadb-devel
 if [[ $? != 0 ]]; then
-    echo '*** mariadb-server for the mariadb module profile devel not installed' >> /root/RESULT
-fi
-
-rpm -q ghc-libraries
-if [[ $? != 0 ]]; then
-    echo '*** ghc-libraries for the ghc module profile small not installed' >> /root/RESULT
-fi
-
-rpm -q gimp-devel
-if [[ $? != 0 ]]; then
-    echo '*** gimp-devel for the gimp module profile devel not installed' >> /root/RESULT
+    echo '*** mariadb-devel for the mariadb module not installed' >> /root/RESULT
 fi
 
 # next we will check if the module is seen as enabled/installed from the
@@ -73,15 +60,11 @@ dnf module list
 dnf module list --enabled nodejs | grep nodejs || echo "*** nodejs module not marked as enabled" >> /root/RESULT
 dnf module list --enabled postgresql | grep postgresql  || echo "*** postgresql module not marked as enabled" >> /root/RESULT
 dnf module list --enabled mariadb | grep mariadb  || echo "*** mariadb module not marked as enabled" >> /root/RESULT
-dnf module list --enabled ghc | grep ghc || echo "*** ghc module not marked as enabled" >> /root/RESULT
-dnf module list --enabled gimp | grep gimp || echo "*** gimp module not marked as enabled" >> /root/RESULT
 
 # check all modules are also marked as installed with the correct profile
 dnf module list --installed nodejs | grep "development \[i\]" || echo "*** nodejs module profile development not marked as installed" >> /root/RESULT
 dnf module list --installed mariadb | grep "devel \[i\]" || echo "*** mariadb profile devel not marked as installed" >> /root/RESULT
-dnf module list --installed ghc | grep "small \[i\]" || echo "*** ghc module profile small not marked as installed" >> /root/RESULT
-dnf module list --installed postgresql | grep "server \[i\]" || echo "*** postgresql module profile server not marked as installed" >> /root/RESULT
-dnf module list --installed gimp | grep "devel \[i\]" || echo "*** gimp module profile devel not marked as installed" >> /root/RESULT
+dnf module list --installed postgresql | grep "client \[i\]" || echo "*** postgresql module profile client not marked as installed" >> /root/RESULT
 
 %ksappend validation/success_if_result_empty.ks
 


### PR DESCRIPTION
Simplify the test and update versions and profiles of the installed modules.
Don't install the environment Fedora Server Edition, because it is not required.