### PR TITLE
Add missing genisoimage dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,7 @@ First you need to install the needed dependencies:
 - python3-rpmfluff
 - squid
 - scp
+- genisoimage
 
 On Fedora the dependencies can be installed with::
 

--- a/containers/runner/Dockerfile
+++ b/containers/runner/Dockerfile
@@ -9,9 +9,14 @@ RUN dnf -y update && \
     git \
     virt-install \
     libguestfs-tools \
+    genisoimage \
     lorax-lmc-virt \
     parallel \
-    python3-libvirt && \
+    python3-libvirt \
+    createrepo \
+    python3-rpmfluff \
+    squid \
+    openssh-clients && \
     dnf -y clean all
 
 ENV APP_ROOT=/opt/kstest

--- a/scripts/install_dependencies_fedora.sh
+++ b/scripts/install_dependencies_fedora.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 echo "installing depndencies needed to run kickstart tests"
-sudo dnf install libguestfs-tools virt-install lorax-lmc-virt parallel python3-libvirt createrepo python3-rpmfluff squid openssh-clients
+sudo dnf install libguestfs-tools virt-install lorax-lmc-virt parallel python3-libvirt createrepo python3-rpmfluff squid openssh-clients genisoimage
 echo "done"


### PR DESCRIPTION
scripts/Makefile.prereqs and ibft.sh both use isoinfo, so install it.

Also add the other recently added dependencies to
containers/runner/Dockerfile.