### PR TITLE
Handle a message about a detected degraded array

### DIFF
--- a/scripts/launcher/lib/log_monitor/log_handler.py
+++ b/scripts/launcher/lib/log_monitor/log_handler.py
@@ -24,12 +24,20 @@ class VirtualLogRequestHandler(LogRequestHandler):
 
     # Specify the error lines you want to ignore.
     ignored_simple_tests = [
+        # Non critical error blocking the installation.
+        "CRIT systemd-coredump:",
+
+        # Based on the bug #1886809, it is a non critical error.
+        "CRIT mdadm:DegradedArray event detected",
+
+        # Ignore a call trace during debugging.
         # "Call Trace:"
     ]
 
     # Specify error lines you want to add on top
     # of the default ones contained in Lorax
     simple_tests = LogRequestHandler.simple_tests + [
+        "CRIT",
         "Payload setup error:",
         "Out of memory:",
         "Would you like to ignore this and continue with installation?",

--- a/scripts/launcher/lib/validator.py
+++ b/scripts/launcher/lib/validator.py
@@ -109,23 +109,6 @@ class KickstartValidator(Validator):
 
 class LogValidator(Validator):
 
-    def check_install_errors(self, install_log):
-        ret_code = 0
-
-        with open(install_log, 'rt') as log_f:
-            for line in log_f:
-
-                # non critical error blocking the installation
-                if "CRIT systemd-coredump:" in line:
-                    log.info("Non critical error: {}".format(replace_new_lines(line)))
-                    continue
-                elif "CRIT" in line:
-                    self._result_msg = replace_new_lines(line)
-                    self._return_code = 1
-                    break
-
-        return ret_code
-
     def check_virt_errors(self, virt_log_path):
         with open(virt_log_path, 'rt') as virt_log:
             for line in virt_log:

--- a/scripts/launcher/run_one_test.py
+++ b/scripts/launcher/run_one_test.py
@@ -170,11 +170,7 @@ class Runner(object):
 
     def _validate_logs(self, virt_configuration):
         validator = LogValidator(self._conf.ks_test_name)
-        validator.check_install_errors(virt_configuration.install_logpath)
-
-        if validator.result:
-            validator.check_virt_errors(virt_configuration.log_path)
-
+        validator.check_virt_errors(virt_configuration.log_path)
         return validator
 
     def _validate_result(self):


### PR DESCRIPTION
Move the validation of the installation logs to the VirtualLogRequestHandler
class. Kill the installation if there is a critical message with the exception
of a core dump and a detected degraded array.

Related: rhbz#1886809