### PR TITLE
staging ground for test run improvements

### DIFF
--- a/scripts/launcher/run_one_test.py
+++ b/scripts/launcher/run_one_test.py
@@ -33,7 +33,6 @@
 # 99 - Test preparation failed
 
 import os
-import shutil
 import subprocess
 import socket
 
@@ -75,7 +74,7 @@ class Runner(object):
 
     def _prepare_test(self):
         log.debug("Preparing test")
-        self._copy_image_to_tmp()
+        self._link_image_to_tmp()
 
         try:
             self._ks_file = self._shell.prepare()
@@ -93,9 +92,9 @@ class Runner(object):
 
         return True
 
-    def _copy_image_to_tmp(self):
-        log.info("Copying image to temp directory {}".format(self._tmp_dir))
-        shutil.copy2(self._conf.boot_image_path, self._tmp_dir)
+    def _link_image_to_tmp(self):
+        log.info("Linking image to temp directory {}".format(self._tmp_dir))
+        os.symlink(os.path.abspath(self._conf.boot_image_path), os.path.join(self._tmp_dir, "boot.iso"))
 
     def run_test(self):
         if not self._prepare_test():


### PR DESCRIPTION
This is a dumping ground for introducing a safe, efficient, and easy way to run kickstart-tests locally and on our or public infrastructure. I'll regularly break this out into smaller PRs which are ready to land.

 - [x] PR #371 
 - [x] PR #375
 - [x] PR #377
 - [x] PR #378
 - [x] PR #382
 - [x] PR #383
 - [x] PR #385
 - [x] PR #386
 - [x] PR #388
 - [x] PR #390
 - [x] PR #391
 - [x] PR #392
 - [x] Work around virt-install creation race (sent fix to https://github.com/virt-manager/virt-manager/pull/175): PR #396
 - [x] Investigate libvirt storage pool race: https://bugzilla.redhat.com/show_bug.cgi?id=1894359: Fixed in https://github.com/virt-manager/virt-manager/pull/179 ; can we pull that fix into the image somehow?
 - [ ] Figure out why current infra breaks on symlinking boot.iso (commit b94e277562f8)
