### PR TITLE
Fix module installation tests

### DIFF
--- a/module-enable-many.ks.in
+++ b/module-enable-many.ks.in
@@ -8,12 +8,11 @@
 module --name=nodejs --stream=10
 module --name=django --stream=1.6
 module --name=postgresql --stream=9.6
-module --name=mysql --stream=5.6
-module --name=meson --stream=latest
-module --name=gimp --stream=2.10
+module --name=mysql --stream=8.0
+module --name=perl --stream=5.32
+module --name=ruby --stream=master
 
 %packages
-@^Fedora Server Edition
 kernel
 vim
 %end
@@ -65,14 +64,14 @@ if [[ $? == 0 ]]; then
     echo '*** community-mysql-server for the only enabled mysql module installed' >> /root/RESULT
 fi
 
-rpm -q meson
+rpm -q perl
 if [[ $? == 0 ]]; then
-    echo '*** meson for the only enabled meson module installed' >> /root/RESULT
+    echo '*** perl for the only enabled perl module installed' >> /root/RESULT
 fi
 
-rpm -q gimp
+rpm -q ruby
 if [[ $? == 0 ]]; then
-    echo '*** gimp for the only enabled gimp module installed' >> /root/RESULT
+    echo '*** ruby for the only enabled ruby module installed' >> /root/RESULT
 fi
 
 # next we will check if the module is seen as enabled/installed from the
@@ -86,16 +85,16 @@ dnf module list --enabled django | grep django || echo "django module not marked
 dnf module list --enabled nodejs | grep nodejs || echo "nodejs module not marked as enabled" >> /root/RESULT
 dnf module list --enabled postgresql | grep postgresql  || echo "postgresql module not marked as enabled" >> /root/RESULT
 dnf module list --enabled mysql | grep mysql || echo "mysql module not marked as enabled" >> /root/RESULT
-dnf module list --enabled meson | grep meson || echo "meson module not marked as enabled" >> /root/RESULT
-dnf module list --enabled gimp | grep gimp || echo "gimp module not marked as enabled" >> /root/RESULT
+dnf module list --enabled perl | grep perl || echo "perl module not marked as enabled" >> /root/RESULT
+dnf module list --enabled ruby | grep ruby || echo "ruby module not marked as enabled" >> /root/RESULT
 
 # check all modules are also marked as installed
 dnf module list --installed django | grep django && echo "django module marked as installed" >> /root/RESULT
 dnf module list --installed nodejs | grep nodejs && echo "nodejs module marked as installed" >> /root/RESULT
 dnf module list --installed postgresql | grep ostgresql && echo "postgresql module marked as installed" >> /root/RESULT
 dnf module list --installed mysql | grep mysql && echo "mysql module marked as installed" >> /root/RESULT
-dnf module list --installed meson | grep meson && echo "meson module marked as installed" >> /root/RESULT
-dnf module list --installed gimp | grep gimp && echo "gimp module marked as installed" >> /root/RESULT
+dnf module list --installed perl | grep perl && echo "perl module marked as installed" >> /root/RESULT
+dnf module list --installed ruby | grep ruby && echo "ruby module marked as installed" >> /root/RESULT
 
 %ksappend validation/success_if_result_empty.ks
 %end

--- a/module-install-4.ks.in
+++ b/module-install-4.ks.in
@@ -8,11 +8,10 @@
 %ksappend repos/default.ks
 %ksappend common/common_no_payload.ks
 
-module --name=cri-o --stream=1.11
+module --name=avocado --stream=latest
 
 %packages
-@^Fedora Server Edition
-@cri-o:1.11/default
+@avocado:latest/default
 kernel
 vim
 %end
@@ -34,25 +33,22 @@ if [[ $? != 0 ]]; then
     echo '*** kernel package not installed' >> /root/RESULT
 fi
 
-rpm -q cri-o
+rpm -q python3-avocado
 if [[ $? != 0 ]]; then
-    echo '*** cri-o package for cri-o module not installed' >> /root/RESULT
+    echo '*** python3-avocado package for avocado module not installed' >> /root/RESULT
 fi
 
-rpm -q cri-tools
+rpm -q python3-avocado-plugins-output-html
 if [[ $? != 0 ]]; then
-    echo '*** cri-tools package for cri-o module not installed' >> /root/RESULT
+    echo '*** python3-avocado-plugins-output-html package for avocado module not installed' >> /root/RESULT
 fi
 
 # next we will check if the module is seen as enabled/installed from the
 # metadata/DNF point of view
-dnf module list --enabled cri-o | grep cri-o || echo "*** cri-o module not marked as enabled" >> /root/RESULT
-dnf module list --installed cri-o | grep cri-o || echo "*** cri-o module not marked as installed" >> /root/RESULT
+dnf module list --enabled avocado | grep avocado || echo "*** avocado module not marked as enabled" >> /root/RESULT
+dnf module list --installed avocado | grep avocado || echo "*** avocado module not marked as installed" >> /root/RESULT
 
-# check the stream and profile as well
-# - commented out due to DNF output breakage, see:
-#   https://bugzilla.redhat.com/show_bug.cgi?id=1602028#c1
-#dnf module list --installed cri-o | grep "default \[i\]" || echo "*** cri-o module default profile not marked as installed" >> /root/RESULT
+dnf module list --installed avocado | grep "default \[d\] \[i\]" || echo "*** avocado module default profile not marked as installed" >> /root/RESULT
 
 %ksappend validation/success_if_result_empty.ks
 

--- a/module-install-many.ks.in
+++ b/module-install-many.ks.in
@@ -6,18 +6,13 @@
 %ksappend common/common_no_payload.ks
 
 %packages
-@^Fedora Server Edition
 @nodejs:10/default
-@django:1.6/default
 # the postgress module has no default profile,
 # so we set some explicitly here
 @postgresql:9.6/server
 @postgresql:9.6/client
 # according to modulemd default "server" should be the default profile
-@mariadb:10.3/server
-@meson:latest/default
-@swig:3.0/default
-@gimp:2.10/default
+@swig:4.0/default
 kernel
 vim
 %end
@@ -44,11 +39,6 @@ if [[ $? != 0 ]]; then
     echo '*** nodejs for module nodejs not installed' >> /root/RESULT
 fi
 
-rpm -q python2-django
-if [[ $? != 0 ]]; then
-    echo '*** python2-django for the django module not installed' >> /root/RESULT
-fi
-
 rpm -q postgresql
 if [[ $? != 0 ]]; then
     echo '*** postgresql for the postgresql module client profile not installed' >> /root/RESULT
@@ -59,24 +49,9 @@ if [[ $? != 0 ]]; then
     echo '*** postgresql for the postgresql module server profile not installed' >> /root/RESULT
 fi
 
-rpm -q mariadb-server
-if [[ $? != 0 ]]; then
-    echo '*** mariadb-server for the mariadb module server (default) profile not installed' >> /root/RESULT
-fi
-
-rpm -q meson
-if [[ $? != 0 ]]; then
-    echo '*** meson for the meson module not installed' >> /root/RESULT
-fi
-
 rpm -q swig
 if [[ $? != 0 ]]; then
     echo '*** package swig for the swig module default profile not installed' >> /root/RESULT
-fi
-
-rpm -q gimp
-if [[ $? != 0 ]]; then
-    echo '*** gimp for the gimp module not installed' >> /root/RESULT
 fi
 
 # next we will check if the module is seen as enabled/installed from the
@@ -86,34 +61,22 @@ fi
 dnf module list
 
 # all installed modules should be also enabled
-dnf module list --enabled django | grep django || echo "*** django module not marked as enabled" >> /root/RESULT
 dnf module list --enabled nodejs | grep nodejs || echo "*** nodejs module not marked as enabled" >> /root/RESULT
 dnf module list --enabled postgresql | grep postgresql  || echo "*** postgresql module not marked as enabled" >> /root/RESULT
-dnf module list --enabled mariadb | grep mariadb || echo "*** mariadb module not marked as enabled" >> /root/RESULT
-dnf module list --enabled meson | grep meson || echo "*** meson module not marked as enabled" >> /root/RESULT
 dnf module list --enabled swig | grep swig  || echo "*** swig module not marked as enabled" >> /root/RESULT
-dnf module list --enabled gimp | grep gimp  || echo "*** gimp module not marked as enabled" >> /root/RESULT
 
 # check all modules are also marked as installed
-dnf module list --installed django | grep django || echo "*** django module not marked as installed" >> /root/RESULT
 dnf module list --installed nodejs | grep nodejs || echo "*** nodejs module not marked as installed" >> /root/RESULT
 dnf module list --installed postgresql | grep postgresql  || echo "*** postgresql module not marked as installed" >> /root/RESULT
-dnf module list --installed mariadb | grep mariadb || echo "*** mariadb module not marked as installed" >> /root/RESULT
-dnf module list --installed meson | grep meson || echo "*** meson module not marked as installed" >> /root/RESULT
 dnf module list --installed swig | grep swig  || echo "*** swig module not marked as installed" >> /root/RESULT
-dnf module list --installed gimp | grep gimp  || echo "*** gimp module not marked as installed" >> /root/RESULT
 
 # check the stream and profile as well
-dnf module list --installed django | grep "default \[d\] \[i\]" || echo "*** django module default profile not marked as installed" >> /root/RESULT
 dnf module list --installed nodejs | grep "default \[d\] \[i\]" || echo "*** nodejs module default profile not marked as installed" >> /root/RESULT
 # both server and client profiles have been explicitly installed
 dnf module list --installed postgresql | grep "client \[i\]" || echo "*** postgresql module client profile not marked as installed" >> /root/RESULT
-dnf module list --installed postgresql | grep "server \[i\]" || echo "*** postgresql module server profile not marked as installed" >> /root/RESULT
+dnf module list --installed postgresql | grep "server \[d\] \[i\]" || echo "*** postgresql module server profile not marked as installed" >> /root/RESULT
 # according to modulemd default the server profile should be installed
-dnf module list --installed mariadb | grep "server \[d\] \[i\]" || echo "*** mariadb module default profile not marked as installed" >> /root/RESULT
-dnf module list --installed meson | grep "default \[d\] \[i\]" || echo "*** meson module default profile not marked as installed" >> /root/RESULT
 dnf module list --installed swig grep "default \[i\]" || echo "*** swig module default profile not marked as installed" >> /root/RESULT
-dnf module list --installed gimp | grep "default \[d\] \[i\]" || echo "*** gimp module default profile not marked as installed" >> /root/RESULT
 
 %ksappend validation/success_if_result_empty.ks
 


### PR DESCRIPTION
Fix module and stream names to reflect changes in Fedora module
landscape. Also drop the Fedora Server environment from the tests
as that's no longer needed for the tests to work correctly.