### PR TITLE
Remove rpm since it is not required again

### DIFF
--- a/container.ks.in
+++ b/container.ks.in
@@ -31,7 +31,7 @@ clearpart --all
 -kernel
 -systemd
 bash
-rpm
+-rpm
 %end
 
 %post


### PR DESCRIPTION
See https://github.com/rhinstaller/anaconda/pull/2922 on which it also depends.