### PR TITLE
Rewrite probe_boot_iso.sh to not require privileges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -217,8 +217,9 @@ The following environment variables are currently supported:
   contains a name of the OS. Possible names can be "fedora", "rhel".
 
 - KSTEST_OS_VERSION - This variable is read from the input boot.iso and it
-  contains version of the OS. For example Fedora 26 have
-  KSTEST_OS_VERSION = 26 and RHEL 7.3 have KSTEST_OS_VERSION = 7.3 .
+  contains version of the OS. For example Fedora 26 has
+  KSTEST_OS_VERSION = 26, Fedora rawhide has "Rawhide", and RHEL 7.3 has
+  KSTEST_OS_VERSION = 7.3 .
 
 Chapter 3. Sharing common code in kickstart (.ks.in) files
 ==========================================================

--- a/containers/runner/README.md
+++ b/containers/runner/README.md
@@ -16,11 +16,6 @@ Dependencies needed to be installed are defined in `host_packages` variable of [
 sudo dnf install git podman
 ```
 
-The `squashfs` kernel module needs to be running on the host. To check run:
-```
-lsmod | grep squashfs
-```
-
 The host needs to have enough available loop device nodes created to be able to mount various images.
 To check existing nodes run:
 ```

--- a/scripts/probe_boot_iso.sh
+++ b/scripts/probe_boot_iso.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright (C) 2014, 2015  Red Hat, Inc.
 #
@@ -21,25 +21,13 @@
 # Probe boot.iso and grab useful information for kickstart tests. Output of
 # this script is returned to stdout as `KEY=value`. Every key-value will be
 # printed on a separate line.
-# You need to run this script as the root user, this is because of usage of
-# mount and umount commands inside of the script.
 #
 # This script returns:
 # NAME=name of the system in boot.iso. (e.g. "fedora", "rhel")
 # VERSION=version number of this system. (e.g. "7.3", "25")
 #
 
-
-function clean_and_exit() {
-    local msg="$1"
-    local root_dir="$2"
-
-    echo "$msg" >&2
-    echo "Cleaning mounted directories" >&2
-    umount $root_dir/stage2 $root_dir/image $root_dir/iso &>>/dev/null
-    rm -rf $root_dir
-    exit 3
-}
+set -eu
 
 if [[ $# -ne 1 ]];then
     echo "Exactly one parameter is required" >&2
@@ -50,49 +38,29 @@ fi
 
 IMAGE="$1"
 
-# Probe stage 2 in the input boot.iso and dig useful information from it.
+# Probe boot.iso → install.img → stage 2 and dig out useful information from it.
+ISO_TMP=$(mktemp -d /tmp/kstest-iso.XXXXXXX)
+trap "rm -rf '$ISO_TMP'" EXIT INT QUIT PIPE
 
-# Mount boot.iso -> install.img -> stage2
-ISO_TMP=$(mktemp -d /tmp/kstest-iso-mount.XXXXXXX)
-if [[ -n $ISO_TMP ]]; then
-
-    # 1) Mount boot.iso
-    mkdir $ISO_TMP/iso
-    mount -o loop,ro $IMAGE $ISO_TMP/iso
-    if [[ $? -ne 0 ]]; then
-        clean_and_exit "Error: Can't mount boot iso" $ISO_TMP
-    fi
-
-    # 2) Mount install.img
-    mkdir $ISO_TMP/image
-    # Try Fedora directory structure
-    mount $ISO_TMP/iso/images/install.img $ISO_TMP/image 2>/dev/null
-    if [[ $? -ne 0 ]]; then
-        # Try RHEL-7 directory structure
-        mount $ISO_TMP/iso/LiveOS/squashfs.img $ISO_TMP/image
-        if [[ $? -ne 0 ]]; then
-            clean_and_exit "Error: Can't mount image from boot iso" $ISO_TMP
-        fi
-    fi
-
-    # 3) Mount stage2
-    mkdir $ISO_TMP/stage2
-    mount $ISO_TMP/image/LiveOS/rootfs.img $ISO_TMP/stage2
-    if [[ $? -ne 0 ]]; then
-        clean_and_exit "Error: Can't mount stage2 from install.img" $ISO_TMP
+# Extract install.img
+# Try Fedora directory structure (isoinfo does not fail on nonexisting files)
+isoinfo -R -i "$IMAGE" -x /images/install.img > "$ISO_TMP/install.img"
+if [ ! -s "$ISO_TMP/install.img" ]; then
+    # Try RHEL-7 directory structure
+    isoinfo -R -i "$IMAGE" -x /LiveOS/squashfs.img > "$ISO_TMP/install.img"
+    if [ ! -s "$ISO_TMP/install.img" ]; then
+        echo "Error: Did not find install image inside $IMAGE" >&2
+        exit 3
     fi
 fi
 
-# Take required information from stage2
-ISO_OS_NAME=$(egrep -h "^ID=" $ISO_TMP/stage2/etc/*-release)
-ISO_OS_NAME=$(echo ${ISO_OS_NAME#ID=} | tr -d \")
-ISO_OS_VERSION=$(egrep -h "^VERSION_ID=" $ISO_TMP/stage2/etc/*-release)
-ISO_OS_VERSION=$(echo ${ISO_OS_VERSION#VERSION_ID=} | tr -d \")
+# Extract stage2
+unsquashfs -no-xattrs -quiet -no-progress -d "$ISO_TMP/stage2" "$ISO_TMP/install.img"
+rm "$ISO_TMP/install.img"
 
-# Return useful information to the stdout
-echo "NAME=$ISO_OS_NAME"
-echo "VERSION=$ISO_OS_VERSION"
+# Extract required information from stage2
+virt-cat -a "$ISO_TMP/stage2/LiveOS/rootfs.img" /etc/os-release > "$ISO_TMP/os-release"
 
-# Clean when work is done
-umount $ISO_TMP/stage2 $ISO_TMP/image $ISO_TMP/iso
-rm -rf $ISO_TMP
+# Return useful information to stdout
+echo "NAME=$(. "$ISO_TMP/os-release"; echo "$ID")"
+echo "VERSION=$(. "$ISO_TMP/os-release"; echo "$VERSION_ID")"

--- a/scripts/probe_boot_iso.sh
+++ b/scripts/probe_boot_iso.sh
@@ -38,6 +38,20 @@ fi
 
 IMAGE="$1"
 
+# Fast path if ./discinfo is present (for Fedora); if it exists, it looks like this:
+#    1587584254.021611
+#    32
+#    x86_64
+DISCINFO_VER=$(isoinfo -R -x /.discinfo -i "$IMAGE" | sed -n '2 p')
+if [ -n "$DISCINFO_VER" ]; then
+    # make sure it looks like a Fedora version name/number
+    if [ "$DISCINFO_VER" = "Rawhide" ] || [ "$DISCINFO_VER" -gt 30 ]; then
+        echo "NAME=Fedora"
+        echo "VERSION=$DISCINFO_VER"
+        exit 0
+    fi
+fi
+
 # Probe boot.iso → install.img → stage 2 and dig out useful information from it.
 ISO_TMP=$(mktemp -d /tmp/kstest-iso.XXXXXXX)
 trap "rm -rf '$ISO_TMP'" EXIT INT QUIT PIPE

--- a/scripts/run_kickstart_tests.sh
+++ b/scripts/run_kickstart_tests.sh
@@ -153,7 +153,7 @@ if [[ -e $HOME/.kstests.defaults.sh ]]; then
 fi
 
 # Grab useful data from boot.iso
-output="$(sudo ./scripts/probe_boot_iso.sh $IMAGE)"
+output="$(./scripts/probe_boot_iso.sh $IMAGE)"
 if [[ $? -ne 0 ]]; then
     echo "Can't run probe_boot_iso" >&2
     exit 3


### PR DESCRIPTION
 * Use isoinfo, unsquashfs, and libguestfs to unpack the boot.iso
   Matroshka, instead of relying on mount and the host kernel. That also
   works in an unprivileged container.

 * Robustify cleanup with a trap instead of error exit paths.

 * Enable `set -eu` for script robustness, and drop the explicit error
   handlers.

 * Source os-release instead of parsing it with shell/grep.

As this is quite expensive (takes ~ 40 seconds on my 10 year old laptop), I also added a fast path for Fedora (which takes virtually no time). I realize that this is disputable, and I appreciate some feedback about it. I'm happy to remove this if you prefer, or  we change it to divine what the current "Rawhide" version number is (I didn't find a  good and obvious way how to do that).

This is split out from #373 to make it easier to review, and it's a rather independent change.

I tested this with a Fedora rawhide, 32, and RHEL 8 boot.iso:

```
[kstest@0bd53c2e5471 kickstart-tests]$ scripts/probe_boot_iso.sh ../data/images/boot.iso
NAME=fedora
VERSION=Rawhide
[kstest@0bd53c2e5471 kickstart-tests]$ scripts/probe_boot_iso.sh ../data/images/boot-f32.iso
NAME=fedora
VERSION=32
[kstest@0bd53c2e5471 kickstart-tests]$ scripts/probe_boot_iso.sh ../data/images/boot-r8.iso 
NAME=rhel
VERSION=8.4
```

Without the fastpath, the first output has `VERSION=34` instead. In that case it's identical to the current master version.