### PR TITLE
Revert "Don't copy boot.iso into output directory"

### DIFF
--- a/scripts/launcher/run_one_test.py
+++ b/scripts/launcher/run_one_test.py
@@ -33,6 +33,7 @@
 # 99 - Test preparation failed
 
 import os
+import shutil
 import subprocess
 import socket
 
@@ -74,7 +75,7 @@ class Runner(object):
 
     def _prepare_test(self):
         log.debug("Preparing test")
-        self._link_image_to_tmp()
+        self._copy_image_to_tmp()
 
         try:
             self._ks_file = self._shell.prepare()
@@ -92,9 +93,9 @@ class Runner(object):
 
         return True
 
-    def _link_image_to_tmp(self):
-        log.info("Linking image to temp directory {}".format(self._tmp_dir))
-        os.symlink(os.path.abspath(self._conf.boot_image_path), os.path.join(self._tmp_dir, "boot.iso"))
+    def _copy_image_to_tmp(self):
+        log.info("Copying image to temp directory {}".format(self._tmp_dir))
+        shutil.copy2(self._conf.boot_image_path, self._tmp_dir)
 
     def run_test(self):
         if not self._prepare_test():


### PR DESCRIPTION
This broke the tests in the current CI infra:

    The iso /var/tmp/kstest-firewall.1jlt8l1g/boot.kstest.iso is missing.

This reverts commit b94e277562f8cc547684d154c685add2a1caa355.