### PR TITLE
Drop unsquashfs -quiet option

### DIFF
--- a/scripts/probe_boot_iso.sh
+++ b/scripts/probe_boot_iso.sh
@@ -69,7 +69,7 @@ if [ ! -s "$ISO_TMP/install.img" ]; then
 fi
 
 # Extract stage2
-unsquashfs -no-xattrs -quiet -no-progress -d "$ISO_TMP/stage2" "$ISO_TMP/install.img"
+unsquashfs -no-xattrs -no-progress -d "$ISO_TMP/stage2" "$ISO_TMP/install.img"
 rm "$ISO_TMP/install.img"
 
 # Extract required information from stage2


### PR DESCRIPTION
It does not yet exist in the version that is running on the infra.

----

Today's rhel-8 run failed on this: http://cobra02/trees/kstests/rhel8/results/runs/rhel8-nightly.2020-10-21-00_16_35.8.4/kstest.log

@rvykydal : I only lightly tested this, that it works in the current container. If it still fails after this on the infra, then please revert commit 61303efa for now, and I'll look at it next week. Thanks, and sorry for the breakage!

