### PR TITLE
Fix the kickstart test of the default filesystem type

### DIFF
--- a/default-fstype-rhel.ks.in
+++ b/default-fstype-rhel.ks.in
@@ -1,0 +1,41 @@
+#version=DEVEL
+#test name: default-fstype-rhel
+%ksappend repos/default.ks
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+part /boot --size=500 --label=boot
+part pv.1 --fstype=lvmpv --size=4504
+volgroup rhel pv.1
+logvol swap --name=swap --vgname=rhel --size=500 --fstype=swap
+logvol / --name=root --vgname=rhel --size=4000 --label=root
+
+keyboard us
+lang en_US.UTF-8
+timezone America/New_York --utc
+rootpw testcase
+shutdown
+
+%packages
+%end
+
+%post
+expected_fstype="xfs"
+
+root_fstype=$(blkid -o value -t LABEL=root -s TYPE -l)
+if [ "$root_fstype" != "$expected_fstype" ]; then
+    echo "default fstype is incorrect (got $root_fstype; expected $expected_fstype)" >> /root/RESULT
+fi
+
+boot_fstype=$(blkid -o value -t LABEL=boot -s TYPE -l)
+if [ "$boot_fstype" != "$expected_fstype" ]; then
+    echo "default boot fstype is incorrect (got $boot_fstype; expected $expected_fstype)" >> /root/RESULT
+fi
+
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+%end

--- a/default-fstype-rhel.sh
+++ b/default-fstype-rhel.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Chris Lumens <clumens@redhat.com>
+
+TESTTYPE="storage rhel-only"
+
+. ${KSTESTDIR}/functions.sh

--- a/default-fstype-workstation.ks.in
+++ b/default-fstype-workstation.ks.in
@@ -1,5 +1,5 @@
 #version=DEVEL
-#test name: default-fstype
+#test name: default-fstype-workstation
 %ksappend repos/default.ks
 install
 network --bootproto=dhcp
@@ -23,11 +23,7 @@ shutdown
 %end
 
 %post
-
 expected_fstype="ext4"
-if [ "@KSTEST_OS_NAME@" == "rhel" ]; then
-    expected_fstype="xfs"
-fi
 
 root_fstype=$(blkid -o value -t LABEL=root -s TYPE -l)
 if [ "$root_fstype" != "$expected_fstype" ]; then

--- a/default-fstype-workstation.sh
+++ b/default-fstype-workstation.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015  Red Hat, Inc.
+# Copyright (C) 2020  Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -15,8 +15,10 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-# Red Hat Author(s): Chris Lumens <clumens@redhat.com>
-
-TESTTYPE="storage"
+TESTTYPE="storage fedora-only"
 
 . ${KSTESTDIR}/functions.sh
+
+kernel_args() {
+    echo ${DEFAULT_BOOTOPTS} inst.product=Fedora inst.variant=Workstation
+}


### PR DESCRIPTION
Split the test into two tests: one for Fedora Workstation and one for RHEL.