### PR TITLE
Adjust network-noipv4* tests for QEMU user network

### DIFF
--- a/network-noipv4-httpks.ks.in
+++ b/network-noipv4-httpks.ks.in
@@ -41,19 +41,16 @@ check_config_key_exists @KSTEST_NETDEV4@ BOOTPROTO no ipv4 method disabled
 check_device_connected @KSTEST_NETDEV3@ yes
 check_device_has_ipv4_address @KSTEST_NETDEV3@ no
 
-# TODO create test with virtual network having ipv6 enabled (ipv6 only connection)
-#      libvirt default net does not have ipv6 enabled
+# TODO create test with virtual network having ipv6-only connection
 detect_nm_has_autoconnections_off
 nm_has_autoconnections_off=$?
+check_device_has_ipv4_address @KSTEST_NETDEV4@ no
 if [[ $nm_has_autoconnections_off -eq 0 ]]; then
     check_device_connected @KSTEST_NETDEV4@ no
-    check_device_has_ipv4_address @KSTEST_NETDEV4@ no
 else
-    # connection fails to activate (RA timeout, no ip config)
-    # and default con. created by NM (Wired connection 2) is autoactivated again
     check_device_connected @KSTEST_NETDEV4@ yes
-    check_device_has_ipv4_address @KSTEST_NETDEV4@ yes
-    check_connection_device "Wired connection 2" @KSTEST_NETDEV4@
+    # NM created default connection has same name as the interface
+    check_connection_device @KSTEST_NETDEV4@ @KSTEST_NETDEV4@
 fi
 
 # No error was written to /root/RESULT file, everything is OK

--- a/network-noipv4-pre.ks.in
+++ b/network-noipv4-pre.ks.in
@@ -44,19 +44,16 @@ check_config_key_exists @KSTEST_NETDEV4@ BOOTPROTO no ipv4 method disabled
 check_device_connected @KSTEST_NETDEV3@ yes
 check_device_has_ipv4_address @KSTEST_NETDEV3@ no
 
-# TODO create test with virtual network having ipv6 enabled (ipv6 only connection)
-#      libvirt default net does not have ipv6 enabled
+# TODO create test with virtual network having ipv6-only connection
 detect_nm_has_autoconnections_off
 nm_has_autoconnections_off=$?
+check_device_has_ipv4_address @KSTEST_NETDEV4@ no
 if [[ $nm_has_autoconnections_off -eq 0 ]]; then
     check_device_connected @KSTEST_NETDEV4@ no
-    check_device_has_ipv4_address @KSTEST_NETDEV4@ no
 else
-    # connection fails to activate (RA timeout, no ip config)
-    # and default con. created by NM (Wired connection 2) is autoactivated again
     check_device_connected @KSTEST_NETDEV4@ yes
-    check_device_has_ipv4_address @KSTEST_NETDEV4@ yes
-    check_connection_device "Wired connection 2" @KSTEST_NETDEV4@
+    # NM created default connection has same name as the interface
+    check_connection_device @KSTEST_NETDEV4@ @KSTEST_NETDEV4@
 fi
 
 # No error was written to /root/RESULT file, everything is OK


### PR DESCRIPTION
Commit 9a5b5daf98 broke these tests as the user network behaves slightly
differently than libvirt's default network. In particular, it is fully
IPv6 enabled.

Fix the `check_device_has_ipv4_address` check to be always "no", as
that's what the configuration actually requests (it's not clear why it
previously got an IPv4 address despite disabling IPv4). Also adjust the
NM connection name for the enp4s0 device -- it's now the same as the
device name, not "Wired connection 2".