### PR TITLE
Fix runner container, make it unprivileged, auto-build to quay.io

### DIFF
--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -1,0 +1,29 @@
+# We cannot fully self-validate the new container, as running all kickstart tests just takes too long.
+# So tag the containers by build date, so that in the worst case we can always reset :latest to the previously working tag.
+name: Build and push containers
+on:
+  schedule:
+    - cron: 0 18 * * 6
+  # be able to start this action manually from a actions tab when needed
+  workflow_dispatch:
+
+jobs:
+  runner:
+    name: Build kstest-runner container
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Login to container registry
+        run: docker login -u ${{ secrets.QUAY_USERNAME }} -p ${{ secrets.QUAY_PASSWORD }} quay.io
+
+      - name: Build and push container
+        run: |
+          TAG=$(date --iso-8601)
+          NAME=quay.io/${{ secrets.QUAY_USERNAME }}/kstest-runner
+          docker build -t $NAME:$TAG containers/runner
+          docker tag $NAME:$TAG $NAME:latest
+
+          docker push $NAME:$TAG
+          docker push $NAME:latest

--- a/containers/runner/Dockerfile
+++ b/containers/runner/Dockerfile
@@ -27,17 +27,14 @@ ENV PATH=${APP_ROOT}/bin:${PATH} \
 
 RUN groupadd -g 1001 -r ${KSTEST_USER} -f && \
     useradd -u 1001 -r -g ${KSTEST_USER} -m -c "Kickstart test user" ${KSTEST_USER} && \
-    mkdir -p ${APP_DATA} && \
-    # Add kstest to sudoers which is required by run_kickstart_tests.sh script
-    echo "kstest ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/${KSTEST_USER} && \
-    chmod 0440 /etc/sudoers.d/${KSTEST_USER}
+    mkdir -p ${APP_DATA}
 
 # This is what OpenShift does with random user he is using
 # BUT it does not seem to work, kstest user is not in the root group
 # so it can't for example create dirs in APP_ROOT
 #RUN usermod -a -G root ${KSTEST_USER}
 
-COPY run-kstest runlibvirt ${APP_ROOT}/bin/
+COPY run-kstest ${APP_ROOT}/bin/
 
 # OpenShift
 RUN  chgrp -R 0 ${APP_ROOT} && \

--- a/containers/runner/README.md
+++ b/containers/runner/README.md
@@ -23,9 +23,8 @@ Run a test in a container
 
 Build the container:
 ```
-sudo podman build -t kstest-runner .
+podman build -t kstest-runner .
 ```
-Note: we can't use rootless containers because of mounting of images in the contaier.
 
 Define the directory for passing of data between the container and the system (via volume):
 ```
@@ -35,7 +34,7 @@ export VOLUME_DIR=${PWD}/data
 Create subdirs for test inputs (installation image) and outputs (logs):
 ```
 mkdir -p ${VOLUME_DIR}/images
-mkdir -p ${VOLUME_DIR}/logs
+mkdir -p -m 777 ${VOLUME_DIR}/logs
 ```
 
 Download the test subject (installer boot iso):
@@ -45,7 +44,7 @@ curl -L https://download.fedoraproject.org/pub/fedora/linux/development/rawhide/
 
 Run the test:
 ```
-sudo podman run --env KSTESTS_TEST=keyboard -v ${VOLUME_DIR}:/opt/kstest/data:z --name last-kstest --privileged=true --device=/dev/kvm kstest-runner
+podman run --env KSTESTS_TEST=keyboard -v ${VOLUME_DIR}:/opt/kstest/data:z --name last-kstest --device=/dev/kvm kstest-runner
 ```
 Instead of keeping named container you can remove it after the test by replacing `--name last-kstest` option with `--rm`.
 

--- a/containers/runner/README.md
+++ b/containers/runner/README.md
@@ -67,7 +67,7 @@ Environment variables for the container (`--env` option):
 * UPDATES_IMAGE - HTTP URL of updates image to be used
 * KSTESTS_REPOSITORY - kickstart-tests git repository to be used
 * KSTESTS_BRANCH - kickstart-tests git branch to be used
-* BOOT_ISO - name of the installer boot iso from ${VOLUME_DIR}/images to be tested (default is "boot.iso")
+* BOOT_ISO - name of the installer boot iso from `${VOLUME_DIR}/images` to be tested (default is "boot.iso")
 
 
 Troubleshooting

--- a/containers/runner/README.md
+++ b/containers/runner/README.md
@@ -48,6 +48,8 @@ podman run --env KSTESTS_TEST=keyboard -v ${VOLUME_DIR}:/opt/kstest/data:z --nam
 ```
 Instead of keeping named container you can remove it after the test by replacing `--name last-kstest` option with `--rm`.
 
+If you have enough RAM, you can run the entire test VM in RAM with `--tmpfs /var/tmp/`, so that it will run faster. This is particularly helpful when running tests in parallel.
+
 See the results:
 ```
 tree -L 3 ${VOLUME_DIR}/logs

--- a/containers/runner/README.md
+++ b/containers/runner/README.md
@@ -21,9 +21,14 @@ There is a [playbook](runner-host.yml) for deployment of the host on Fedora Clou
 Run a test in a container
 -------------------------
 
-Build the container:
+Download the [automatically built](.github/workflows/container-autoupdate.yml) official container image:
 ```
-podman build -t kstest-runner .
+podman pull quay.io/rhinstaller/kstest-runner
+```
+
+Or build the container yourself:
+```
+podman build -t rhinstaller/kstest-runner .
 ```
 
 Define the directory for passing of data between the container and the system (via volume):
@@ -44,7 +49,7 @@ curl -L https://download.fedoraproject.org/pub/fedora/linux/development/rawhide/
 
 Run the test:
 ```
-podman run --env KSTESTS_TEST=keyboard -v ${VOLUME_DIR}:/opt/kstest/data:z --name last-kstest --device=/dev/kvm kstest-runner
+podman run --env KSTESTS_TEST=keyboard -v ${VOLUME_DIR}:/opt/kstest/data:z --name last-kstest --device=/dev/kvm rhinstaller/kstest-runner
 ```
 Instead of keeping named container you can remove it after the test by replacing `--name last-kstest` option with `--rm`.
 

--- a/containers/runner/README.md
+++ b/containers/runner/README.md
@@ -62,7 +62,7 @@ cat ${VOLUME_DIR}/logs/kstest-*/anaconda/virt-install.log
 ```
 
 This will check out and use kickstart-tests master from GitHub. To run against
-your local development branch instead, pass `-v .:/opt/kstest/kickstart-tests`
+your local development branch instead, pass `-v .:/kickstart-tests:ro`
 to `podman run`.
 
 Configuration of the test

--- a/containers/runner/run-kstest
+++ b/containers/runner/run-kstest
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -x
+set -ex
 
 KSTESTS_REPOSITORY=${KSTESTS_REPOSITORY:-https://github.com/rhinstaller/kickstart-tests}
 KSTESTS_BRANCH=${KSTESTS_BRANCH:-master}
@@ -20,13 +20,14 @@ fi
 
 # Prepare the configuration
 UPDATES_IMAGE_ARG=""
-if [[ -n "${UPDATES_IMAGE}" ]]; then
+if [ -n "${UPDATES_IMAGE}" ]; then
   UPDATES_IMAGE_ARG="-u ${UPDATES_IMAGE}"
 fi
 
 # Run the test
 pushd ${KSTESTS_DIR}
-scripts/run_kickstart_tests.sh -k 2 -i ${ISO_DIR}/${BOOT_ISO} ${UPDATES_IMAGE_ARG} ${KSTESTS_TEST}
+RC=0
+scripts/run_kickstart_tests.sh -k 2 -i ${ISO_DIR}/${BOOT_ISO} ${UPDATES_IMAGE_ARG} ${KSTESTS_TEST} || RC=$?
 popd
 
 # Copy logs to a volume
@@ -35,5 +36,7 @@ chmod -R a+r /var/tmp/kstest-*
 # Clean up (artifacts from broken test)
 find /var/tmp/kstest-${KSTESTS_TEST}* -name "*.iso" -delete
 find /var/tmp/kstest-${KSTESTS_TEST}* -name "*.img" -delete
-# Move to target logs directory
-cp -r /var/tmp/kstest-${KSTESTS_TEST}* ${LOGS_DIR}
+# Move to target logs directory; this sometimes fails on nested directory permission/ownership
+cp -r /var/tmp/kstest-${KSTESTS_TEST}* ${LOGS_DIR} || true
+
+exit $RC

--- a/containers/runner/run-kstest
+++ b/containers/runner/run-kstest
@@ -6,6 +6,7 @@ KSTESTS_REPOSITORY=${KSTESTS_REPOSITORY:-https://github.com/rhinstaller/kickstar
 KSTESTS_BRANCH=${KSTESTS_BRANCH:-master}
 KSTESTS_DIR=${APP_ROOT}/kickstart-tests
 KSTESTS_TEST=${KSTESTS_TEST:-team}
+KSTESTS_KEEP=${KSTESTS_KEEP:-1}
 
 UPDATES_IMAGE=${UPDATES_IMAGE:-""}
 BOOT_ISO=${BOOT_ISO:-boot.iso}
@@ -27,7 +28,7 @@ fi
 # Run the test
 pushd ${KSTESTS_DIR}
 RC=0
-scripts/run_kickstart_tests.sh -k 2 -i ${ISO_DIR}/${BOOT_ISO} ${UPDATES_IMAGE_ARG} ${KSTESTS_TEST} || RC=$?
+scripts/run_kickstart_tests.sh -k ${KSTESTS_KEEP} -i ${ISO_DIR}/${BOOT_ISO} ${UPDATES_IMAGE_ARG} ${KSTESTS_TEST} || RC=$?
 popd
 
 # Copy logs to a volume

--- a/containers/runner/run-kstest
+++ b/containers/runner/run-kstest
@@ -13,7 +13,12 @@ BOOT_ISO=${BOOT_ISO:-boot.iso}
 ISO_DIR=${APP_DATA}/images
 LOGS_DIR=${APP_DATA}/logs
 
-if ! [ -d "${KSTESTS_DIR}" ]; then
+# user can bind-mount a local kickstart-tests dir to test that
+if [ -d /kickstart-tests ]; then
+    # copy it so that we can write our *.ks files, fragments/, and so on
+    cp -r /kickstart-tests ${KSTESTS_DIR}
+else
+    # if not given, check out current git
     git clone ${KSTESTS_REPOSITORY} ${KSTESTS_DIR}
     git -C ${KSTESTS_DIR} checkout ${KSTESTS_BRANCH}
     git -C ${KSTESTS_DIR} remote -v

--- a/containers/runner/run-kstest
+++ b/containers/runner/run-kstest
@@ -12,8 +12,6 @@ BOOT_ISO=${BOOT_ISO:-boot.iso}
 ISO_DIR=${APP_DATA}/images
 LOGS_DIR=${APP_DATA}/logs
 
-runlibvirt
-
 if ! [ -d "${KSTESTS_DIR}" ]; then
     git clone ${KSTESTS_REPOSITORY} ${KSTESTS_DIR}
     git -C ${KSTESTS_DIR} checkout ${KSTESTS_BRANCH}
@@ -33,10 +31,9 @@ popd
 
 # Copy logs to a volume
 # Fixup permissions
-sudo chown -R ${KSTEST_USER}:${KSTEST_USER} /var/tmp/kstest-*
-sudo chmod -R a+r /var/tmp/kstest-*
+chmod -R a+r /var/tmp/kstest-*
 # Clean up (artifacts from broken test)
 find /var/tmp/kstest-${KSTESTS_TEST}* -name "*.iso" -delete
 find /var/tmp/kstest-${KSTESTS_TEST}* -name "*.img" -delete
 # Move to target logs directory
-sudo cp -r /var/tmp/kstest-${KSTESTS_TEST}* ${LOGS_DIR}
+cp -r /var/tmp/kstest-${KSTESTS_TEST}* ${LOGS_DIR}

--- a/containers/runner/run-kstest
+++ b/containers/runner/run-kstest
@@ -35,9 +35,11 @@ popd
 # Fixup permissions
 chmod -R a+r /var/tmp/kstest-*
 # Clean up (artifacts from broken test)
-find /var/tmp/kstest-${KSTESTS_TEST}* -name "*.iso" -delete
-find /var/tmp/kstest-${KSTESTS_TEST}* -name "*.img" -delete
-# Move to target logs directory; this sometimes fails on nested directory permission/ownership
-cp -r /var/tmp/kstest-${KSTESTS_TEST}* ${LOGS_DIR} || true
+for t in ${KSTESTS_TEST}; do
+    find /var/tmp/kstest-${t}* -name "*.iso" -delete
+    find /var/tmp/kstest-${t}* -name "*.img" -delete
+    # Move to target logs directory; this sometimes fails on nested directory permission/ownership
+    cp -r /var/tmp/kstest-${t}* ${LOGS_DIR} || true
+done
 
 exit $RC

--- a/containers/runner/runlibvirt
+++ b/containers/runner/runlibvirt
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-sudo libvirtd &
-sudo virtlogd &

--- a/scripts/Makefile.prereqs
+++ b/scripts/Makefile.prereqs
@@ -6,9 +6,6 @@
 # IMAGE - the boot.iso
 # KSTESTDIR - the absolute path to the kickstart-tests directory, sans scripts/
 #
-# This file is used before gaining root privileges but sudo probably works if
-# you need it.
-
 # This is a regular Makefile without any automake weirdness, so just keep it
 # friendly.
 


### PR DESCRIPTION
The current runner container does not work, it fails on some "libvirt failing to talk to dbus" SNAFU. With these updates, I can build and run kickstart tests as per containers/runner/README.md.

Please run thorugh README.md, and check that you can build and use the container as advertised.

This PR should be save to land quickly, as we don't use it anywhere right now (and as mentioned above, it's broken anyway). This will  enable tricks like [running KS tests on Travis](https://travis-ci.com/github/martinpitt/kickstart-tests/builds/193409766), and more importantly, make it really easy and safe for a developer to run them locally.

This also sets up a workflow to automatically build and push the container to quay.io.