### PR TITLE
Add runner container launch script, add Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+dist: focal
+sudo: true
+language: minimal
+script: scripts/run_travis.sh

--- a/containers/runner/launch
+++ b/containers/runner/launch
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Run a set of tests (positional command line arguments) in the runner container in podman or docker.
+# Tests are taken from the current kickstart-tests checkout
+# If data/images/boot.iso exists, that is tested, otherwise it downloads the current Fedora Rawhide version.
+# This runs `nproc` parallel tests by default; this can be changed by setting $TEST_JOBS.
+
+set -eu
+
+BASEDIR=$(dirname $(dirname $(dirname $(realpath $0))))
+TEST_JOBS=${TEST_JOBS:-$(nproc)}
+CRUN=${CRUN:-$(which podman docker 2>/dev/null | head -n1)}
+CONTAINER=quay.io/rhinstaller/kstest-runner
+
+if ! test -w /dev/kvm; then
+    echo "FATAL: /dev/kvm not accessible" >&2
+    exit 1
+fi
+
+if [ -z "${1:-}" ]; then
+    echo "Usage: $0 test1 test2 ..."
+    exit 1
+fi
+
+# prepare data directory
+mkdir -p data/images
+mkdir -p -m 777 data/logs
+if ! [ -e data/images/boot.iso ]; then
+    echo "INFO: data/images/boot.iso does not exist, downloading current Fedora Rawhide Server image..."
+    curl -L https://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Server/x86_64/os/images/boot.iso --output data/images/boot.iso
+fi
+
+EXTRA_OPTS=""
+
+# if there is enough RAM (1 GB per test with 2x safety margin), and we don't keep VM images, put the VMs on tmpfs for faster tests
+# FIXME: This runs ENOSPC after a while, as .qcow and .iso images pile up; clean them up properly
+#if awk "/MemAvailable:/ { exit (\$2 > 2000000*${TEST_JOBS}) ? 0 : 1  }" /proc/meminfo; then
+#    EXTRA_OPTS="--tmpfs /var/tmp/"
+#fi
+
+# Run container against the local repository, to test changes easily
+set -x
+$CRUN run -it --rm --device=/dev/kvm --env KSTESTS_TEST="$*" --env TEST_JOBS="$TEST_JOBS" $EXTRA_OPTS \
+    -v "$PWD/data:/opt/kstest/data:z" -v "$BASEDIR:/kickstart-tests:ro,z" $CONTAINER /kickstart-tests/containers/runner/run-kstest

--- a/scripts/run_travis.sh
+++ b/scripts/run_travis.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -eu
+
+# rebase on current upstream master, so that we run current tests
+git remote get-url upstream >/dev/null 2>&1 || git remote add upstream https://github.com/rhinstaller/kickstart-tests
+git fetch upstream
+git rebase upstream/master
+
+# list of tests that are changed by the current PR
+TESTS=$(git diff --name-only upstream/master..HEAD -- *.ks.in *.sh | sed 's/\.ks\.in$//; s/\.sh$//' | sort -u)
+
+# if the PR changes anything in the test runner, or does not touch any tests, pick a few representative tests
+# FIXME: Once the runner container can run groups properly, replace with a TESTTYPE="travis" group
+if [ -z "$TESTS" ] || [ -n "$(git diff --name-only upstream/master..HEAD -- containers scripts)" ]; then
+    TESTS="$TESTS
+bindtomac-network-device-default-httpks
+container
+lvm-1
+network-device-mac-httpks
+network-static
+"
+fi
+
+# weed out duplicates, convert to space separated list, and limit to 6 tests (we can't run a lot of tests on Travis)
+TESTS=$(echo "$TESTS" | sort -u | head -n6 | xargs)
+
+echo "Running tests: $TESTS"
+
+# HACK: /dev/kvm is root:kvm 0660 in Travis by default
+sudo -n chmod 666 /dev/kvm
+
+# With parallel jobs, each test takes a little longer than 10 minutes, which makes Travis abort
+# <https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received>
+# Avoid this by printing a keep-alive '.' line every minute
+while true; do echo '.'; sleep 60; done &
+trap "kill $!" EXIT INT QUIT PIPE
+
+containers/runner/launch $TESTS


### PR DESCRIPTION
This significantly simplifies the necessary setup steps to just one command. From a fresh checkout you can run
    
    containers/runner/launch keyboard [... other tests]
    
It has sensible defaults, and works both as user and through sudo (for user podman or and system podman/docker containers).

Travis now offers /dev/kvm, and its machines are powerful enough to run at least a handful of tests. This is useful for PRs that change a few tests only, to self-validate them. We can't run all tests on Travis, it would take too long. But at least for gating PRs that add/change tests, it is enough to only run these.

Travis is most likely *not* the final place where we run these, but rather we'd adjust our upshift nodes (or perhaps TMT or whatever). But it's a very cheap and easy (for us) way to get *some* initial gating into kickstart-tests. It's easy enough to remove again in the future if we want to.