### PR TITLE
Support local HTTP caching for running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 dist: focal
 sudo: true
 language: minimal
+addons:
+  apt:
+    packages:
+      - nftables
 script: scripts/run_travis.sh

--- a/containers/README.md
+++ b/containers/README.md
@@ -1,3 +1,4 @@
 Containers for running kickstart tests.
 
 * runner - Run a kickstart test in a container.
+* squid.sh - Start/stop a transparent HTTP proxy. See [runner README](./runner/README.md) for details.

--- a/containers/runner/README.md
+++ b/containers/runner/README.md
@@ -60,6 +60,25 @@ Environment variables for the container (`--env` option):
 
 By default, the container runs the [run-kstest](./run-kstest) script. To get an interactive shell, append `bash` to the command line.
 
+Running tests with cached package downloads
+-------------------------------------------
+
+Depending on parallelism and availabe network bandwidth, downloading the RPMs
+and package indexes takes a significant amount of time for every test. This can
+be sped up greatly with a transparent HTTP proxy. This requires root privileges
+(to configure IP routing through the proxy) and only works with system podman
+containers (which use a real bridge), not user podman containers (which use
+SLIRP networking).
+
+To use this, run
+
+    sudo containers/squid.sh start
+
+and build/run the `runner` container from above through `sudo containers/runner/launch` or `sudo podman`.
+
+This starts a container named `squid` and uses a persistent podman volume
+`ks-squid-cache`.
+
 Troubleshooting
 ---------------
 

--- a/containers/squid-cache.conf
+++ b/containers/squid-cache.conf
@@ -1,0 +1,3 @@
+http_port 3129 transparent
+cache_dir ufs /var/cache/squid 20000 16 256
+maximum_object_size 5 GB

--- a/containers/squid-cache.nft
+++ b/containers/squid-cache.nft
@@ -1,0 +1,6 @@
+table ip squid-cache {
+    chain prerouting {
+        type nat hook prerouting priority dstnat; policy accept;
+        tcp dport 80 redirect to :3129
+    }
+}

--- a/containers/squid.sh
+++ b/containers/squid.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Start/stop a transparent squid proxy in a container. System podman containers will
+# automatically use this to route plain http traffic through the cache, and thus
+# greatly speed up the kickstart tests.
+#
+# This does NOT work with user podman containers, as they don't use a bridge, but slirp.
+# Transparent content caching does NOT work with https in principle.
+
+set -eu
+
+MYDIR=$(dirname $(realpath "$0"))
+CRUN=${CRUN:-$(which podman docker 2>/dev/null | head -n1)}
+
+if [ "${1:-}" = start ]; then
+    # This image is well-maintained (auto-built) and really small
+    $CRUN run --net host --name squid --detach \
+        --volume "$MYDIR"/squid-cache.conf:/etc/squid/conf.d.tail/cache.conf:ro \
+        --volume ks-squid-cache:/var/cache/squid docker.io/b4tman/squid
+
+    # Redirect all traffic from external interfaces (like container bridges) through our local proxy
+    # This does NOT re-route localhost traffic, as that does not go through PREROUTING.
+    nft -f "$MYDIR"/squid-cache.nft
+
+elif [ "${1:-}" = stop ]; then
+    nft delete table squid-cache
+
+    $CRUN rm -f squid
+
+else
+    echo "Usage: $0 start|stop" >&2
+    exit 1
+fi

--- a/fragments/platform/fedora_rawhide/repos/default.ks
+++ b/fragments/platform/fedora_rawhide/repos/default.ks
@@ -1,3 +1,3 @@
 # Default Fedora Rawhide repositories
-url --url=https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/$basearch/os/
-repo --name=modular --baseurl https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Modular/$basearch/os/
+url --url=http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/$basearch/os/
+repo --name=modular --baseurl http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Modular/$basearch/os/

--- a/fragments/platform/fedora_rawhide/repos/https.ks
+++ b/fragments/platform/fedora_rawhide/repos/https.ks
@@ -1,0 +1,3 @@
+# Default Fedora Rawhide repositories with https
+url --url=https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/$basearch/os/
+repo --name=modular --baseurl https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Modular/$basearch/os/

--- a/https-repo.ks.in
+++ b/https-repo.ks.in
@@ -1,0 +1,49 @@
+#version=DEVEL
+#test name: https-repo
+#
+# Test that https:// repositories work as expected. Most tests run with http to
+# be able to squid-cache the downloads.
+# Only install a minimal system to save time, similar to the "container" test.
+
+%ksappend repos/https.ks
+%ksappend common/common.ks
+%ksappend users/default.ks
+%ksappend network/default.ks
+
+# Disable the boot loader.
+bootloader --disabled
+
+# Disable the NTP service.
+keyboard us
+lang en_US.UTF-8
+timezone Etc/UTC --utc --nontp
+
+# Create only / with the ext4 filesystem type.
+autopart --type=plain --fstype=ext4 --nohome --noboot --noswap
+zerombr
+clearpart --all
+
+# Don't install kernel and systemd.
+%packages --nocore
+-kernel
+-systemd
+bash
+rpm
+%end
+
+%post
+# (1) No http:// Fedora repo sources
+if out=$(grep -r 'http://.*\.fedoraproject' /etc/yum.repos.d/); then
+    echo "*** Found Fedora http repo: $out" > /root/RESULT
+    exit 1
+fi
+
+# (2) Should have at least the default https:// repo source
+if ! grep -r 'https://.*\.fedoraproject' /etc/yum.repos.d/; then
+    echo '*** Did not find https default Fedora repo' > /root/RESULT
+    exit 1
+fi
+
+%ksappend validation/success_if_result_empty.ks
+
+%end

--- a/https-repo.sh
+++ b/https-repo.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Pitt <mpitt@redhat.com>
+
+TESTTYPE="method"
+
+. ${KSTESTDIR}/functions.sh

--- a/scripts/defaults.sh
+++ b/scripts/defaults.sh
@@ -7,6 +7,6 @@
 # CAUTION: the sed expression we currently use does not like white-space in the strings
 
 source network-device-names.cfg
-export KSTEST_URL='--url=https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/$basearch/os/'
-export KSTEST_MODULAR_URL='https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Modular/$basearch/os/'
+export KSTEST_URL='--url=http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/$basearch/os/'
+export KSTEST_MODULAR_URL='http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Modular/$basearch/os/'
 export KSTEST_FTP_URL='ftp://ftp.tu-chemnitz.de/pub/linux/fedora/linux/development/rawhide/Everything/$basearch/os/'

--- a/scripts/run_travis.sh
+++ b/scripts/run_travis.sh
@@ -29,6 +29,8 @@ echo "Running tests: $TESTS"
 # HACK: /dev/kvm is root:kvm 0660 in Travis by default
 sudo -n chmod 666 /dev/kvm
 
+sudo -n containers/squid.sh start
+
 # With parallel jobs, each test takes a little longer than 10 minutes, which makes Travis abort
 # <https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received>
 # Avoid this by printing a keep-alive '.' line every minute


### PR DESCRIPTION
This greatly speeds up tests locally and avoids bandwidth bottlenecks when running tests in parallel.

Also enable squid in Travis. As that has huge bandwidth, it does not help too much with the test runtime, but it validates the caching implementation.

Caching https isn't possible, and the cert hacks for explicit `CONNECT` are too intrusive for proper testing, so this requires running most tests against a http:// source (and relying on GPG signature verification). I added a single https test to make sure that https still works as well.

I'm aware that this may be controversial -- it's a trade-off. If you don't like this as-is, I can also look into making the default repo more dynamic, and provide a knob to the test to switch to plain http by default. I appreciate some guidance here.