### PR TITLE
Fix reqpart for Fedora Server

### DIFF
--- a/reqpart.ks.in
+++ b/reqpart.ks.in
@@ -23,10 +23,14 @@ shutdown
 %packages
 %end
 
+%post --nochroot
+cp /.buildstamp /mnt/sysroot
+%end
+
 %post
 
 expected_fstype="ext4"
-if [ "@KSTEST_OS_NAME@" == "rhel" ]; then
+if [ "@KSTEST_OS_NAME@" == "rhel" ] || grep -qi '^variant=server' /.buildstamp; then
     expected_fstype="xfs"
 fi
 


### PR DESCRIPTION
Fedora Server uses xfs by default (that's the boot.iso that our
README.md tells you to download).

Use the boot.iso's .buildstamp file to determine the variant.