### PR TITLE
Ignore "Call Trace:" in logs temporarily

### DIFF
--- a/scripts/launcher/lib/log_monitor/log_handler.py
+++ b/scripts/launcher/lib/log_monitor/log_handler.py
@@ -31,7 +31,8 @@ class VirtualLogRequestHandler(LogRequestHandler):
         "CRIT mdadm:DegradedArray event detected",
 
         # Ignore a call trace during debugging.
-        # "Call Trace:"
+        # Enabled tempoarily for rhbz#1885978, rhbz#1893950
+        "Call Trace:"
     ]
 
     # Specify error lines you want to add on top


### PR DESCRIPTION
Ignore Call Traces so that rhbz#1885978 and rhbz#1893950 don't block Anaconda
testing and development of testing tools.