### PR TITLE
Support downloading and testing against rawhide+COPR iso

### DIFF
--- a/containers/runner/README.md
+++ b/containers/runner/README.md
@@ -36,6 +36,12 @@ podman build -t rhinstaller/kstest-runner .
 
 The `launch` script creates a `./data/` directory for passing of data between the container and the system (via volume). By default it downloads the current Fedora Rawhide boot.iso, but to test some other image you can put it into `data/images/boot.iso` before running `launch`.
 
+There is also a [daily boot.iso](.github/workflows/daily-boot-iso.yml) built
+from Rawhide and various COPRs (e.g. Anaconda and DNF) for regression testing,
+which you can test against with the `--daily-iso` option. When given, `launch`
+downloads/unpacks that instead of the the official Rawhide boot.iso. This
+requires authentication, so the option expects a GitHub token file as value.
+
 The result logs get written into `./data/logs/`:
 ```
 tree -L 3 data/logs

--- a/containers/runner/launch
+++ b/containers/runner/launch
@@ -29,18 +29,22 @@ Options:
  -j, --jobs N                         Run N jobs in parallel (default: $(nproc))
  -t, --testtype TYPE                  Only run TYPE tests
  -s, --skip-testtypes TYPE[,TYPE..]   Don't run tests with given types
+ --daily-iso TOKEN_FILE               Download and use daily boot.iso instead of rawhide's
+                                      (This requires a GitHub token that can read
+                                       rhinstaller/kickstart-tests workflow artifacts.)
  -h, --help                           Show this help
 EOF
 }
 
 # parse options
-eval set -- "$(getopt -o j:t:s:h --long jobs:,testtype:,skip-testtypes:,help -- "$@")"
+eval set -- "$(getopt -o j:t:s:h --long jobs:,testtype:,skip-testtypes:,daily-iso:,help -- "$@")"
 
 while true; do
     case "${1:-}" in
         -j|--jobs) shift; TEST_JOBS=$1 ;;
         -t|--testtype) shift; TESTTYPE=$1 ;;
         -s|--skip-testtypes) shift; SKIP_TESTTYPES=$1 ;;
+        --daily-iso) shift; DAILY_ISO_TOKEN="$1" ;;
         -h|--help) usage; exit 0 ;;
         --) shift; break ;;
     esac
@@ -61,8 +65,19 @@ fi
 mkdir -p data/images
 mkdir -p -m 777 data/logs
 if ! [ -e data/images/boot.iso ]; then
-    echo "INFO: data/images/boot.iso does not exist, downloading current Fedora Rawhide Server image..."
-    curl -L https://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Server/x86_64/os/images/boot.iso --output data/images/boot.iso
+    if [ -n "${DAILY_ISO_TOKEN:-}" ]; then
+        echo "INFO: data/images/boot.iso does not exist, downloading daily iso..."
+        CURL="curl -u token:$(cat $DAILY_ISO_TOKEN) --show-error --fail"
+        RESPONSE=$($CURL --silent https://api.github.com/repos/rhinstaller/kickstart-tests/actions/artifacts)
+        ZIP=$(echo "$RESPONSE" | jq --raw-output '.artifacts | map(select(.name == "images"))[0].archive_download_url')
+        echo "INFO: Downloading $ZIP ..."
+        $CURL -L -o data/images.zip "$ZIP"
+        # there is on unzip on RHEL 7, so fall back to 7za (p7zip package)
+        (cd data && if type unzip >/dev/null 2>&1; then unzip images.zip images/boot.iso; else 7za x images.zip images/boot.iso; fi)
+    else
+        echo "INFO: data/images/boot.iso does not exist, downloading current Fedora Rawhide Server image..."
+        curl -L https://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Server/x86_64/os/images/boot.iso --output data/images/boot.iso
+    fi
 fi
 
 VAR_TMP=""


### PR DESCRIPTION
PR #403 introduced a GitHub workflow for building a boot.iso from Fedora Rawhide and the anaconda/blivet/dnf COPRs. This provides an easy external regression test for these projects before they land in Fedora.

The boot.iso (plus some other files) are exported as an artifact.
Downloading them requires authentication, require a GitHub token file as
value of the new `--daily-copr` option. When given, download/unpack that
instead of the official Rawhide boot.iso.

---

This is mostly a PoC for now, to demonstrate that this can provide a full end-to-end workflow (without requiring any internal infrastructure). The `launch` script may not be the final place for this, but it's easy enough to move the code someplace else.

I tested this with my personal GitHub access token and also with the "rhel8-runner" one in our internal secrets repository.

 - [x] Land PR #402
 - [x] Adjust the repository API URL afterwards
 - [x] Land PR #404 
 - [x] Turn env var into a CLI option