### PR TITLE
Simplify daily-boot-iso workflow

### DIFF
--- a/.github/workflows/daily-boot-iso.yml
+++ b/.github/workflows/daily-boot-iso.yml
@@ -9,34 +9,28 @@ jobs:
   boot_iso:
     name: Build boot.iso
     runs-on: ubuntu-latest
-    steps:
-      # lorax and its dependencies do not exist in Ubuntu, and we want to test the latest Fedora version anyway
+    container:
+      image: fedora:latest
       # lorax does mounts and uses loop devices, thus needs to be privileged
-      - name: Start fedora container
-        run: |
-          mkdir data
-          docker run --name fedora -d --privileged --network host -v $PWD/data:/data fedora:latest sleep infinity
-
+      options: --privileged
+    steps:
       - name: Install lorax
-        run: docker exec fedora dnf install -y lorax
+        run: dnf install -y lorax
 
       - name: Run lorax
-        run: docker exec -w /data fedora lorax -p Fedora -v 34 -r 34 -s http://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/ -s https://download.copr.fedorainfracloud.org/results/rpmsoftwaremanagement/dnf-nightly/fedora-rawhide-x86_64/ -s https://download.copr.fedorainfracloud.org/results/@rhinstaller/Anaconda/fedora-rawhide-x86_64/ -s https://copr-be.cloud.fedoraproject.org/results/@storage/blivet-daily/fedora-rawhide-x86_64/ /data/results
-
-      - name: Make generated files accessible
-        run: docker exec fedora chmod -R a+rX /data/
+        run: lorax -p Fedora -v 34 -r 34 -s http://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/ -s https://download.copr.fedorainfracloud.org/results/rpmsoftwaremanagement/dnf-nightly/fedora-rawhide-x86_64/ -s https://download.copr.fedorainfracloud.org/results/@rhinstaller/Anaconda/fedora-rawhide-x86_64/ -s https://copr-be.cloud.fedoraproject.org/results/@storage/blivet-daily/fedora-rawhide-x86_64/ /tmp/results
 
       - name: Upload log artifacts
         uses: actions/upload-artifact@v2
         with:
           name: logs
           path: |
-            data/*.log
-            data/*.txt
+            *.log
+            *.txt
 
       - name: Upload image artifacts
         uses: actions/upload-artifact@v2
         with:
           name: images
           path: |
-            data/results/**
+            /tmp/results/**

--- a/.github/workflows/daily-boot-iso.yml
+++ b/.github/workflows/daily-boot-iso.yml
@@ -33,4 +33,4 @@ jobs:
         with:
           name: images
           path: |
-            /tmp/results/**
+            /tmp/results/images/boot.iso


### PR DESCRIPTION
It's possible to specify options (in particular, `--privileged`) for the launched container. So use the declarative syntax instead of launching the container manually, and entirely avoid the /data volume. [successful run on my fork](https://github.com/martinpitt/kickstart-tests/actions/runs/360185931)

The second commit greatly reduces the size of the artifact, see commit message for details. [successful run on my fork](https://github.com/martinpitt/kickstart-tests/actions/runs/360231363)