### PR TITLE
Fix squid container proxy for firewalld and SELinux

### DIFF
--- a/containers/squid.sh
+++ b/containers/squid.sh
@@ -14,7 +14,7 @@ CRUN=${CRUN:-$(which podman docker 2>/dev/null | head -n1)}
 if [ "${1:-}" = start ]; then
     # This image is well-maintained (auto-built) and really small
     $CRUN run --net host --name squid --detach \
-        --volume "$MYDIR"/squid-cache.conf:/etc/squid/conf.d.tail/cache.conf:ro \
+        --volume "$MYDIR"/squid-cache.conf:/etc/squid/conf.d.tail/cache.conf:ro,z \
         --volume ks-squid-cache:/var/cache/squid docker.io/b4tman/squid
 
     # Redirect all traffic from external interfaces (like container bridges) through our local proxy

--- a/containers/squid.sh
+++ b/containers/squid.sh
@@ -21,11 +21,17 @@ if [ "${1:-}" = start ]; then
     # This does NOT re-route localhost traffic, as that does not go through PREROUTING.
     nft -f "$MYDIR"/squid-cache.nft
 
+    if firewall-cmd --state; then
+        firewall-cmd --add-port=3129/tcp
+    fi
 elif [ "${1:-}" = stop ]; then
     nft delete table squid-cache
 
     $CRUN rm -f squid
 
+    if firewall-cmd --state; then
+        firewall-cmd --remove-port=3129/tcp
+    fi
 else
     echo "Usage: $0 start|stop" >&2
     exit 1


### PR DESCRIPTION
With these patches I can successfully run kickstart-tests with the local http proxy on our RHEL 7 e2e machines:
```
# containers/squid.sh start
# containers/runner/launch --skip-testtypes rhel-only,knownfailure --jobs 27 all
```
Last time I tried that was with 25 parallel jobs and no proxy, which took about 2:54 hours. (The machine does not have enough RAM/storage to run 32 tests in parallel).

This time it took just 2:20 hours, so a noticeable speedup. Of these 34 minutes, 14 can be explained due to the higher parallelism, and 20 due to the download caching.