### PR TITLE
Change Fedora mirror in daily boot.iso build

### DIFF
--- a/.github/workflows/daily-boot-iso.yml
+++ b/.github/workflows/daily-boot-iso.yml
@@ -18,7 +18,8 @@ jobs:
         run: dnf install -y lorax
 
       - name: Run lorax
-        run: lorax -p Fedora -v 34 -r 34 -s http://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/ -s https://download.copr.fedorainfracloud.org/results/rpmsoftwaremanagement/dnf-nightly/fedora-rawhide-x86_64/ -s https://download.copr.fedorainfracloud.org/results/@rhinstaller/Anaconda/fedora-rawhide-x86_64/ -s https://copr-be.cloud.fedoraproject.org/results/@storage/blivet-daily/fedora-rawhide-x86_64/ /tmp/results
+        # The download.fedoraproject.org automatic redirector often selects download-ib01.f.o. for GitHub's cloud, which is too unreliable; manually select a good one that is nearby
+        run: lorax -p Fedora -v 34 -r 34 -s http://pubmirror2.math.uh.edu/fedora-buffet/fedora/linux/development/rawhide/Everything/x86_64/os/ -s https://download.copr.fedorainfracloud.org/results/rpmsoftwaremanagement/dnf-nightly/fedora-rawhide-x86_64/ -s https://download.copr.fedorainfracloud.org/results/@rhinstaller/Anaconda/fedora-rawhide-x86_64/ -s https://copr-be.cloud.fedoraproject.org/results/@storage/blivet-daily/fedora-rawhide-x86_64/ /tmp/results
 
       - name: Upload log artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
The geo-location mirror often picks download-ib01.f.o. which is very
unreliable. Use another mirror close to the Azure cloud.

----

The [last 4 runs](https://github.com/rhinstaller/kickstart-tests/actions?query=workflow%3A%22Build+daily+Rawhide%2BCOPR+boot.iso%22) failed on random mirror download errors, which is annoying. I [did a run on my fork with this mirror](https://github.com/martinpitt/kickstart-tests/runs/1416544606?check_suite_focus=true), and it went well. It downloaded the entire package set in just 20s (!) Let's try this for a bit?