### PR TITLE
Support testing local updates.img file, support updates image in runner container launch script

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ About the parameters:
  - 1 = keep log files
  - 2 = keep log files and disk images (will take up a lot of space)
 
-  -u   use updates image given by URL
+  -u   use updates image given by URL or local file path
   -b   use additional installer boot options
 
 And at the end name of the kickstart test script to run.

--- a/containers/runner/README.md
+++ b/containers/runner/README.md
@@ -59,7 +59,7 @@ Instead of keeping named container you can remove it after the test by replacing
 
 Environment variables for the container (`--env` option):
 * KSTESTS_TEST - name of the test to be run
-* UPDATES_IMAGE - HTTP URL of updates image to be used
+* UPDATES_IMAGE - HTTP URL or path (inside the container) of updates image to be used
 * KSTESTS_REPOSITORY - kickstart-tests git repository to be used
 * KSTESTS_BRANCH - kickstart-tests git branch to be used
 * BOOT_ISO - name of the installer boot iso from `data/images` to be tested (default is "boot.iso")

--- a/containers/runner/launch
+++ b/containers/runner/launch
@@ -29,6 +29,7 @@ Options:
  -j, --jobs N                         Run N jobs in parallel (default: $(nproc))
  -t, --testtype TYPE                  Only run TYPE tests
  -s, --skip-testtypes TYPE[,TYPE..]   Don't run tests with given types
+ -u, --updates URL                    Set updates.img URL
  --daily-iso TOKEN_FILE               Download and use daily boot.iso instead of rawhide's
                                       (This requires a GitHub token that can read
                                        rhinstaller/kickstart-tests workflow artifacts.)
@@ -37,13 +38,14 @@ EOF
 }
 
 # parse options
-eval set -- "$(getopt -o j:t:s:h --long jobs:,testtype:,skip-testtypes:,daily-iso:,help -- "$@")"
+eval set -- "$(getopt -o j:t:s:u:h --long jobs:,testtype:,skip-testtypes:,updates:,daily-iso:,help -- "$@")"
 
 while true; do
     case "${1:-}" in
         -j|--jobs) shift; TEST_JOBS=$1 ;;
-        -t|--testtype) shift; TESTTYPE=$1 ;;
-        -s|--skip-testtypes) shift; SKIP_TESTTYPES=$1 ;;
+        -t|--testtype) shift; TESTTYPE="$1" ;;
+        -s|--skip-testtypes) shift; SKIP_TESTTYPES="$1" ;;
+        -u|--updates) shift; UPDATES_IMAGE="$1" ;;
         --daily-iso) shift; DAILY_ISO_TOKEN="$1" ;;
         -h|--help) usage; exit 0 ;;
         --) shift; break ;;
@@ -92,6 +94,8 @@ fi
 
 # Run container against the local repository, to test changes easily
 set -x
-$CRUN run -it --rm --device=/dev/kvm --env KSTESTS_TEST="$KSTESTS_TEST" --env TESTTYPE="${TESTTYPE:-}" --env SKIP_TESTTYPES="${SKIP_TESTTYPES:-}" \
-    --env TEST_JOBS="$TEST_JOBS" $VAR_TMP -v "$PWD/data:/opt/kstest/data:z" -v "$BASEDIR:/kickstart-tests:ro,z" \
+$CRUN run -it --rm --device=/dev/kvm \
+    --env KSTESTS_TEST="$KSTESTS_TEST" --env TESTTYPE="${TESTTYPE:-}" --env SKIP_TESTTYPES="${SKIP_TESTTYPES:-}" \
+    --env UPDATES_IMAGE="${UPDATES_IMAGE:-}" --env TEST_JOBS="$TEST_JOBS" \
+    $VAR_TMP -v "$PWD/data:/opt/kstest/data:z" -v "$BASEDIR:/kickstart-tests:ro,z" \
     $CONTAINER /kickstart-tests/containers/runner/run-kstest

--- a/containers/runner/launch
+++ b/containers/runner/launch
@@ -29,7 +29,7 @@ Options:
  -j, --jobs N                         Run N jobs in parallel (default: $(nproc))
  -t, --testtype TYPE                  Only run TYPE tests
  -s, --skip-testtypes TYPE[,TYPE..]   Don't run tests with given types
- -u, --updates URL                    Set updates.img URL
+ -u, --updates PATH|URL               Set updates.img path or URL
  --daily-iso TOKEN_FILE               Download and use daily boot.iso instead of rawhide's
                                       (This requires a GitHub token that can read
                                        rhinstaller/kickstart-tests workflow artifacts.)
@@ -82,6 +82,15 @@ if ! [ -e data/images/boot.iso ]; then
     fi
 fi
 
+# support both path and URL for --updates
+if [ -e "${UPDATES_IMAGE:-}" ]; then
+    # local file; bind mount into container
+    UPDATES_IMG_ARGS="-v $UPDATES_IMAGE:/updates.img:ro,Z --env UPDATES_IMAGE=/updates.img"
+elif [ -n "${UPDATES_IMAGE:-}" ]; then
+    # URL, pass through
+    UPDATES_IMG_ARGS="--env UPDATES_IMAGE=$UPDATES_IMAGE"
+fi
+
 VAR_TMP=""
 
 # if there is enough RAM (2 GB per test with 2x safety margin), and we don't keep VM images, put the VMs on tmpfs for faster tests
@@ -96,6 +105,6 @@ fi
 set -x
 $CRUN run -it --rm --device=/dev/kvm \
     --env KSTESTS_TEST="$KSTESTS_TEST" --env TESTTYPE="${TESTTYPE:-}" --env SKIP_TESTTYPES="${SKIP_TESTTYPES:-}" \
-    --env UPDATES_IMAGE="${UPDATES_IMAGE:-}" --env TEST_JOBS="$TEST_JOBS" \
+    --env TEST_JOBS="$TEST_JOBS"  ${UPDATES_IMG_ARGS:-} \
     $VAR_TMP -v "$PWD/data:/opt/kstest/data:z" -v "$BASEDIR:/kickstart-tests:ro,z" \
     $CONTAINER /kickstart-tests/containers/runner/run-kstest


### PR DESCRIPTION
This makes the validation of local anaconda changes really easy for a developer or CI.

I tested this without an updates.img (Travis does that as well), with an URL, and with a local file:

    containers/runner/launch ../anaconda/updates.img keyboard