### PR TITLE
Run daily kickstart test scenarios in GitHub workflow

### DIFF
--- a/.github/defaults.sh
+++ b/.github/defaults.sh
@@ -1,0 +1,3 @@
+# The download.fedoraproject.org automatic redirector often selects download-ib01.f.o. for GitHub's cloud, which is too unreliable; manually select a good one that is nearby
+export KSTEST_URL='--url=http://pubmirror2.math.uh.edu/fedora-buffet/fedora/linux/development/rawhide/Everything/$basearch/os/'
+export KSTEST_MODULAR_URL='http://pubmirror2.math.uh.edu/fedora-buffet/fedora/linux/development/rawhide/Modular/$basearch/os/'

--- a/.github/workflows/scenarios.yml
+++ b/.github/workflows/scenarios.yml
@@ -1,0 +1,50 @@
+name: Daily run
+on:
+  schedule:
+    - cron: 0 22 * * *
+  # be able to start this action manually from a actions tab when needed
+  workflow_dispatch:
+
+jobs:
+  scenario:
+    name: Scenario
+    runs-on: [self-hosted, kstest]
+    strategy:
+      matrix:
+        scenario: [rawhide, daily-iso]
+      fail-fast: false
+
+    # these settings depend on the infrastructure; on upshift ocp-master-xxl they take about 4 hours
+    timeout-minutes: 360
+    env:
+      TEST_JOBS: 16
+      GITHUB_TOKEN: /home/github/github-token
+
+    steps:
+      # self-hosted runners don't do this automatically; also useful to keep stuff around for debugging
+      # need to run sudo as the launch script and the container create root/other user owned files
+      - name: Clean up previous run
+        run: |
+          sudo podman ps -q --all --filter='ancestor=kstest-runner' | xargs -tr sudo podman rm -f
+          sudo podman volume rm --all || true
+          sudo rm -rf *
+
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Ensure http proxy is running
+        run: |
+          [ -n "$(sudo podman ps -q -f 'name=^squid$')" ] || sudo containers/squid.sh start
+
+      - name: Run scenario ${{ matrix.scenario }} in container
+        run: sudo --preserve-env=TEST_JOBS,GITHUB_TOKEN containers/runner/scenario ${{ matrix.scenario }} --defaults .github/defaults.sh
+
+      - name: Collect logs
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: 'logs-${{ matrix.scenario }}'
+          # skip the /anaconda subdirectories, too large
+          path: |
+            data/logs/kstest.log
+            data/logs/kstest-*/*.log

--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Launch a scenario for the daily run.
+set -eux
+
+LAUNCH=$(dirname "$0")/launch
+SCENARIO="$1"
+shift
+
+case "$SCENARIO" in
+    rawhide) $LAUNCH --skip-testtypes rhel-only,knownfailure "$@" all ;;
+    rawhide-text) $LAUNCH --skip-testtypes rhel-only,knownfailure --run-args '-eKSTEST_EXTRA_BOOTOPTS=inst.text' "$@" all ;;
+    daily-iso) $LAUNCH --skip-testtypes rhel-only,knownfailure --testtype packaging --daily-iso="$GITHUB_TOKEN" "$@" ;;
+    # just run a single test on standard Rawhide; mostly for testing infrastructure
+    minimal) $LAUNCH "$@" container ;;
+
+    *) echo "ERROR: unknown scenario $1" >&2; exit 1 ;;
+esac

--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -2,7 +2,9 @@
 # Launch a scenario for the daily run.
 set -eux
 
-LAUNCH=$(dirname "$0")/launch
+MYDIR=$(dirname $(realpath "$0"))
+LAUNCH="$MYDIR/launch"
+ROOTDIR=$(dirname $(dirname "$MYDIR"))
 SCENARIO="$1"
 shift
 
@@ -10,6 +12,16 @@ case "$SCENARIO" in
     rawhide) $LAUNCH --skip-testtypes rhel-only,knownfailure "$@" all ;;
     rawhide-text) $LAUNCH --skip-testtypes rhel-only,knownfailure --run-args '-eKSTEST_EXTRA_BOOTOPTS=inst.text' "$@" all ;;
     daily-iso) $LAUNCH --skip-testtypes rhel-only,knownfailure --testtype packaging --daily-iso="$GITHUB_TOKEN" "$@" ;;
+
+    rhel8)
+        if [ ! -e data/images/boot.iso ]; then
+            echo "INFO: data/images/boot.iso does not exist, downloading current RHEL 8 boot iso..."
+            mkdir -p data/images
+            curl -L http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
+        fi
+        $LAUNCH --skip-testtypes fedora-only,knownfailure --testtype packaging --defaults "$ROOTDIR/scripts/defaults-rhel8.sh"
+        ;;
+
     # just run a single test on standard Rawhide; mostly for testing infrastructure
     minimal) $LAUNCH "$@" container ;;
 

--- a/scripts/defaults-rhel8.sh
+++ b/scripts/defaults-rhel8.sh
@@ -1,0 +1,5 @@
+# Default settings for testing RHEL 8. This requires being inside the Red Hat VPN.
+
+source scripts/defaults.sh
+export KSTEST_URL='--url=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8/compose/BaseOS/x86_64/os/'
+export KSTEST_MODULAR_URL='http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8/compose/AppStream/x86_64/os/'


### PR DESCRIPTION
[Latest run on my fork for rawhide+daily](https://github.com/martinpitt/kickstart-tests/actions/runs/382599422) - just one random failure

Older runs:
 - [rawhide+minimal](https://github.com/martinpitt/kickstart-tests/actions/runs/371938555), [second run](https://github.com/martinpitt/kickstart-tests/actions/runs/378675867)
 - [rawhide-text + minimal](https://github.com/martinpitt/kickstart-tests/actions/runs/378769793)
 - ~[old daily+minimal](https://github.com/martinpitt/kickstart-tests/actions/runs/372434207) - that  run looks rather sorry, need to investigate more closely; the networking failures reproduce and are consistent, and most likely an actual regression on anaconda master; the timeouts looks like a regression in dnf copr? they happen on the official results as well.~
- [current daily boot.iso](https://github.com/martinpitt/kickstart-tests/runs/1447171006?check_suite_focus=true) -- tests succeeded, but the script failed overall -- fixed
 - [rawhide + r-text + daily](https://github.com/martinpitt/kickstart-tests/actions/runs/380457486)
 - [rawhide + daily](https://github.com/martinpitt/kickstart-tests/actions/runs/381259209) -- first daily success, rawhide timed out

 - [x] Builds on top of PR  #410 
 - [x] Requires fix in PR #411 and container refresh to  make tests run reliably
 - [x] daily boot.iso scenario requires fix in PR #413
 - [x] add option to override defaults.sh and kernel boot args: PR #415 
 - [x] Infra for creating the workers (builder PR 30)
 - [x] Restrict daily-iso scenario to `packaging` tests only, to mirror what the current tests do and make the scenario more reliable (it's mostly for the benefit of the dnf team)
 - [x] Fix [daily-iso test failure](https://github.com/martinpitt/kickstart-tests/runs/1447171006?check_suite_focus=true) (all tests passed) -- due to nfs-repo-and-addon failure
 - [x] Mark all long-standing failures as `knownfailure` for now, so that tests have a chance to get green: PR #418
 - [ ] ~Fix `network-noipv4-pre` failure, this doesn't happen on cobra02~ **update**: this is a race condition, sometimes it succeeds; depends on picking ens4 vs. enp1s0 style network names
 - [x] Fix [virt-install TOCTOU](https://bugzilla.redhat.com/show_bug.cgi?id=1901081), apply [fix](https://github.com/virt-manager/virt-manager/pull/194) once it gets approved upstream: PR #417