### PR TITLE
Fix unpacking of daily boot.iso artifact

### DIFF
--- a/containers/runner/launch
+++ b/containers/runner/launch
@@ -75,7 +75,7 @@ if ! [ -e data/images/boot.iso ]; then
         echo "INFO: Downloading $ZIP ..."
         $CURL -L -o data/images.zip "$ZIP"
         # there is on unzip on RHEL 7, so fall back to 7za (p7zip package)
-        (cd data && if type unzip >/dev/null 2>&1; then unzip images.zip images/boot.iso; else 7za x images.zip images/boot.iso; fi)
+        (cd data/images && if type unzip >/dev/null 2>&1; then unzip ../images.zip; else 7za x ../images.zip; fi)
     else
         echo "INFO: data/images/boot.iso does not exist, downloading current Fedora Rawhide Server image..."
         curl -L https://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Server/x86_64/os/images/boot.iso --output data/images/boot.iso


### PR DESCRIPTION
Commit 929b3f1617ea2 changed the artifact to only contain boot.iso. That
had the side effect that the .zip does not contain an images/
subdirectory any more. Adjust the unpacking to follow suit -- it's
actually nicer that way to not make assumptions about the zip's
structure.

----

I noticed that bug while trying to set up the daily boot.iso run on my fork. I included this commit into my fork, and the test  [happily runs now](https://github.com/martinpitt/kickstart-tests/runs/1424649220?check_suite_focus=true) -- at least it's past the "unpack zip" stage that failed before.