### PR TITLE
Support KSTEST_* substitution in fragments

### DIFF
--- a/fragments/platform/fedora_rawhide/repos/default.ks
+++ b/fragments/platform/fedora_rawhide/repos/default.ks
@@ -1,3 +1,3 @@
 # Default Fedora Rawhide repositories
-url --url=http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/$basearch/os/
-repo --name=modular --baseurl http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Modular/$basearch/os/
+url @KSTEST_URL@
+repo --name=modular --baseurl @KSTEST_MODULAR_URL@

--- a/scripts/run_kickstart_tests.sh
+++ b/scripts/run_kickstart_tests.sh
@@ -286,7 +286,6 @@ export KSTESTDIR=$(pwd)
 # The name of input kickstart (ks.in) file is
 # 1) either defined in the test (.sh) file by KICKSTART_NAME variable
 # 2) or the same as the test (.sh) file name .sh if the variable is not found
-tests_ks=""
 for t in ${tests}; do
     ksname_line=$(grep KICKSTART_NAME= ${t})
     if [[ -n "$ksname_line" ]]; then
@@ -295,12 +294,10 @@ for t in ${tests}; do
     else
         ks=${t/.sh/.ks.in}
     fi
-    tests_ks+="${ks/.ks.in/.ks} "
-    sed ${sed_args} ${ks} > ${t/.sh/.ks}
-done
 
-# do %ksappend substition on all the files as well
-./scripts/apply-ksappend.py -p ${PLATFORM_NAME} -o ${KSAPPEND_OVERRIDES} -t ${tests_ks}
+    # do %ksappend substition on all the files as well
+    ./scripts/apply-ksappend.py -o ${KSAPPEND_OVERRIDES} -p ${PLATFORM_NAME} ${ks} | sed ${sed_args} > ${t/.sh/.ks}
+done
 
 # And now, include common stuff with @KSINCLUDE@ <FILE>
 # For example libraries for post scripts gathering the result


### PR DESCRIPTION
Avoid duplicating the default Fedora rawhide repositories in the
default.ks fragment and scripts/default.sh. This makes it much easier to
set a local mirror in a test environment.

To implement this, run the %ksappend substitution before the
`@KSTEST_*@` sedding, so that the sed will catch the substitutions in
the fragments.

To make that work nicely, simplify apply-ksappend.py to only process one
file at a time (specified as positional command line argument, as it's
not really optional and thus should not be an option), avoid all the
file copying, and write the result to stdout, so that it can be
pipelined efficiently.

Also make any errors in apply-ksappend.py fatal. We don't want to hide
substitution errors or missing files in our tests, let's just fix them
instead.

Replace the ArgumentParser class in apply-ksappend.py with a simple
function. The class did not add any new functionality, and was just
unnecessary glue.