### PR TITLE
More configuration options for launch script

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -221,6 +221,10 @@ The following environment variables are currently supported:
   KSTEST_OS_VERSION = 26, Fedora rawhide has "Rawhide", and RHEL 7.3 has
   KSTEST_OS_VERSION = 7.3 .
 
+- KSTEST_EXTRA_BOOTOPTS - This variable is used in functions.sh to pass
+  additional kernel command line options. For example, setting this to `inst.text`
+  enables Anaconda's text mode (instead of the default GUI).
+
 Chapter 3. Sharing common code in kickstart (.ks.in) files
 ==========================================================
 

--- a/containers/runner/launch
+++ b/containers/runner/launch
@@ -33,12 +33,13 @@ Options:
  --daily-iso TOKEN_FILE               Download and use daily boot.iso instead of rawhide's
                                       (This requires a GitHub token that can read
                                        rhinstaller/kickstart-tests workflow artifacts.)
+ --defaults DEFAULTS_SH_FILE          Path to file with overrides to scripts/defaults.sh
  -h, --help                           Show this help
 EOF
 }
 
 # parse options
-eval set -- "$(getopt -o j:t:s:u:h --long jobs:,testtype:,skip-testtypes:,updates:,daily-iso:,help -- "$@")"
+eval set -- "$(getopt -o j:t:s:u:h --long jobs:,testtype:,skip-testtypes:,updates:,daily-iso:,defaults:,help -- "$@")"
 
 while true; do
     case "${1:-}" in
@@ -47,6 +48,7 @@ while true; do
         -s|--skip-testtypes) shift; SKIP_TESTTYPES="$1" ;;
         -u|--updates) shift; UPDATES_IMAGE="$1" ;;
         --daily-iso) shift; DAILY_ISO_TOKEN="$1" ;;
+        --defaults) shift; DEFAULTS_SH="$1" ;;
         -h|--help) usage; exit 0 ;;
         --) shift; break ;;
     esac
@@ -91,7 +93,9 @@ elif [ -n "${UPDATES_IMAGE:-}" ]; then
     UPDATES_IMG_ARGS="--env UPDATES_IMAGE=$UPDATES_IMAGE"
 fi
 
-VAR_TMP=""
+if [ -n "${DEFAULTS_SH:-}" ]; then
+    DEFAULTS_SH_ARGS="-v $DEFAULTS_SH:/home/kstest/.kstests.defaults.sh:ro,z"
+fi
 
 # if there is enough RAM (2 GB per test with 2x safety margin), and we don't keep VM images, put the VMs on tmpfs for faster tests
 if awk "/MemAvailable:/ { exit (\$2 > 4000000*${TEST_JOBS}) ? 0 : 1  }" /proc/meminfo; then
@@ -106,5 +110,5 @@ set -x
 $CRUN run -it --rm --device=/dev/kvm \
     --env KSTESTS_TEST="$KSTESTS_TEST" --env TESTTYPE="${TESTTYPE:-}" --env SKIP_TESTTYPES="${SKIP_TESTTYPES:-}" \
     --env TEST_JOBS="$TEST_JOBS"  ${UPDATES_IMG_ARGS:-} \
-    $VAR_TMP -v "$PWD/data:/opt/kstest/data:z" -v "$BASEDIR:/kickstart-tests:ro,z" \
+    ${VAR_TMP:-} -v "$PWD/data:/opt/kstest/data:z" -v "$BASEDIR:/kickstart-tests:ro,z" ${DEFAULTS_SH_ARGS:-} \
     $CONTAINER /kickstart-tests/containers/runner/run-kstest

--- a/containers/runner/launch
+++ b/containers/runner/launch
@@ -34,12 +34,13 @@ Options:
                                       (This requires a GitHub token that can read
                                        rhinstaller/kickstart-tests workflow artifacts.)
  --defaults DEFAULTS_SH_FILE          Path to file with overrides to scripts/defaults.sh
+ --run-args ARGUMENTS                 Extra $CRUN options/arguments (space separated)
  -h, --help                           Show this help
 EOF
 }
 
 # parse options
-eval set -- "$(getopt -o j:t:s:u:h --long jobs:,testtype:,skip-testtypes:,updates:,daily-iso:,defaults:,help -- "$@")"
+eval set -- "$(getopt -o j:t:s:u:h --long jobs:,testtype:,skip-testtypes:,updates:,daily-iso:,defaults:,run-args:,help -- "$@")"
 
 while true; do
     case "${1:-}" in
@@ -49,6 +50,7 @@ while true; do
         -u|--updates) shift; UPDATES_IMAGE="$1" ;;
         --daily-iso) shift; DAILY_ISO_TOKEN="$1" ;;
         --defaults) shift; DEFAULTS_SH="$1" ;;
+        --run-args) shift; CONTAINER_RUN_ARGS="$1" ;;
         -h|--help) usage; exit 0 ;;
         --) shift; break ;;
     esac
@@ -109,6 +111,6 @@ fi
 set -x
 $CRUN run -it --rm --device=/dev/kvm \
     --env KSTESTS_TEST="$KSTESTS_TEST" --env TESTTYPE="${TESTTYPE:-}" --env SKIP_TESTTYPES="${SKIP_TESTTYPES:-}" \
-    --env TEST_JOBS="$TEST_JOBS"  ${UPDATES_IMG_ARGS:-} \
+    --env TEST_JOBS="$TEST_JOBS" ${UPDATES_IMG_ARGS:-} ${CONTAINER_RUN_ARGS:-} \
     ${VAR_TMP:-} -v "$PWD/data:/opt/kstest/data:z" -v "$BASEDIR:/kickstart-tests:ro,z" ${DEFAULTS_SH_ARGS:-} \
     $CONTAINER /kickstart-tests/containers/runner/run-kstest

--- a/functions.sh
+++ b/functions.sh
@@ -31,7 +31,7 @@ inject_ks_to_initrd() {
     echo "true"
 }
 
-DEFAULT_BASIC_BOOTOPTS="debug=1 inst.debug"
+DEFAULT_BASIC_BOOTOPTS="debug=1 inst.debug ${KSTEST_EXTRA_BOOTOPTS}"
 
 DEFAULT_DRACUT_BOOTOPTS="rd.shell=0 rd.emergency=poweroff"
 

--- a/scripts/run_travis.sh
+++ b/scripts/run_travis.sh
@@ -6,8 +6,8 @@ git remote get-url upstream >/dev/null 2>&1 || git remote add upstream https://g
 git fetch upstream
 git rebase upstream/master
 
-# list of tests that are changed by the current PR
-TESTS=$(git diff --name-only upstream/master..HEAD -- *.ks.in *.sh | sed 's/\.ks\.in$//; s/\.sh$//' | sort -u)
+# list of tests that are changed by the current PR; ignore non-executable *.sh as these are helpers, not tests
+TESTS=$(git diff --name-only upstream/master..HEAD -- *.ks.in $(find -name '*.sh' -perm -u+x) | sed 's/\.ks\.in$//; s/\.sh$//' | sort -u)
 
 # if the PR changes anything in the test runner, or does not touch any tests, pick a few representative tests
 # FIXME: Once the runner container can run groups properly, replace with a TESTTYPE="travis" group


### PR DESCRIPTION
Also slightly simplify handling an undefined `$VAR_TMP`.

----

We use this for running tests in upshift (PR #412)