### PR TITLE
Use quay.io mirror of docker.io/b4tman/squid container

### DIFF
--- a/containers/squid.sh
+++ b/containers/squid.sh
@@ -17,7 +17,7 @@ if [ "${1:-}" = start ]; then
     # This image is well-maintained (auto-built) and really small
     $CRUN run --net host --name squid --detach \
         --volume "$MYDIR"/squid-cache.conf:/etc/squid/conf.d.tail/cache.conf:ro,z \
-        --volume ks-squid-cache:/var/cache/squid docker.io/b4tman/squid
+        --volume ks-squid-cache:/var/cache/squid quay.io/rhinstaller/squid
 
     # Redirect all traffic from external interfaces (like container bridges) through our local proxy
     # This does NOT re-route localhost traffic, as that does not go through PREROUTING.

--- a/scripts/run_travis.sh
+++ b/scripts/run_travis.sh
@@ -7,7 +7,7 @@ git fetch upstream
 git rebase upstream/master
 
 # list of tests that are changed by the current PR; ignore non-executable *.sh as these are helpers, not tests
-TESTS=$(git diff --name-only upstream/master..HEAD -- *.ks.in $(find -name '*.sh' -perm -u+x) | sed 's/\.ks\.in$//; s/\.sh$//' | sort -u)
+TESTS=$(git diff --name-only upstream/master..HEAD -- *.ks.in $(find -maxdepth 1 -name '*.sh' -perm -u+x) | sed 's/\.ks\.in$//; s/\.sh$//' | sort -u)
 
 # if the PR changes anything in the test runner, or does not touch any tests, pick a few representative tests
 # FIXME: Once the runner container can run groups properly, replace with a TESTTYPE="travis" group


### PR DESCRIPTION
We constantly hit the Dockerhub pull limit from inside the Red Hat VPN
now, so docker.io registry has become useless.