### PR TITLE
Pull in libvirt domain TOCTOU fix

### DIFF
--- a/containers/runner/Dockerfile
+++ b/containers/runner/Dockerfile
@@ -20,10 +20,13 @@ RUN dnf -y update && \
     openssh-clients && \
     dnf -y clean all
 
-# HACK: Pull in the libvirt fix from https://github.com/virt-manager/virt-manager/pull/179 to fix parallel runs
+# HACK: Pull in the libvirt fixes from
+# https://github.com/virt-manager/virt-manager/pull/179 and
+# https://github.com/virt-manager/virt-manager/pull/194 to fix parallel runs
 # This will fail once a fixed libvirt lands, remove this when that happens
-COPY libvirt-pool-toctou.patch /tmp
-RUN patch --batch /usr/share/virt-manager/virtinst/connection.py /tmp/libvirt-pool-toctou.patch
+COPY ["libvirt-pool-toctou.patch", "libvirt-domain-toctou.patch", "/tmp"]
+RUN patch --batch /usr/share/virt-manager/virtinst/connection.py /tmp/libvirt-pool-toctou.patch && \
+    patch --batch /usr/share/virt-manager/virtinst/connection.py /tmp/libvirt-domain-toctou.patch
 
 ENV APP_ROOT=/opt/kstest
 ENV PATH=${APP_ROOT}/bin:${PATH} \

--- a/containers/runner/libvirt-domain-toctou.patch
+++ b/containers/runner/libvirt-domain-toctou.patch
@@ -1,0 +1,37 @@
+commit cdb3cd4f258e0db209efd69763af2f7987c06bae
+Author: Martin Pitt <martin@piware.de>
+Date:   Tue Nov 24 14:24:06 2020 +0100
+
+    virtinst: Fix TOCTOU in domain enumeration
+    
+    Similar to commit 49a01b5482, _fetch_all_domains_raw() has a race
+    condition where a domain may disappear (from parallel libvirt
+    operations) in between enumerating and inspecting the objects.
+    
+    Ignore these missing domains instead of crashing.
+    
+    https://bugzilla.redhat.com/show_bug.cgi?id=1901081
+
+diff --git virtinst/connection.py virtinst/connection.py
+index fec273b7..06bc60ad 100644
+--- virtinst/connection.py
++++ virtinst/connection.py
+@@ -182,8 +182,16 @@ class VirtinstConnection(object):
+     def _fetch_all_domains_raw(self):
+         dummy1, dummy2, ret = pollhelpers.fetch_vms(
+             self, {}, lambda obj, ignore: obj)
+-        return [Guest(weakref.proxy(self), parsexml=obj.XMLDesc(0))
+-                for obj in ret]
++        domains = []
++        for obj in ret:
++            # TOCTOU race: a domain may go away in between enumeration and inspection
++            try:
++                xml = obj.XMLDesc(0)
++            except libvirt.libvirtError as e:  # pragma: no cover
++                log.debug("Fetching domain XML failed: %s", e)
++                continue
++            domains.append(Guest(weakref.proxy(self), parsexml=xml))
++        return domains
+ 
+     def _build_pool_raw(self, poolobj):
+         return StoragePool(weakref.proxy(self),


### PR DESCRIPTION
Similarly to commit 2ba1875471f, this often breaks our tests with
non-trivial parallelism. Grab the fix from GitHub as a patch and
hot-apply it in the container.