### PR TITLE
Mark currently failing tests as knownfailures

### DIFF
--- a/basic-ftp.sh
+++ b/basic-ftp.sh
@@ -18,6 +18,7 @@
 #
 # Red Hat Author(s): David Shea <dshea@redhat.com>
 
-TESTTYPE="method"
+# dnf crashes with zchunk errors on ftp:// repos: https://bugzilla.redhat.com/show_bug.cgi?id=1886706
+TESTTYPE="method knownfailure"
 
 . ${KSTESTDIR}/functions.sh

--- a/lvm-cache-1.sh
+++ b/lvm-cache-1.sh
@@ -17,7 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="lvm storage"
+# blivet crashes with BlockDev.LVMError: https://bugzilla.redhat.com/show_bug.cgi?id=1886767
+TESTTYPE="lvm storage knownfailure"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/lvm-cache-2.sh
+++ b/lvm-cache-2.sh
@@ -17,7 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="lvm storage"
+# blivet crashes with BlockDev.LVMError: https://bugzilla.redhat.com/show_bug.cgi?id=1886767
+TESTTYPE="lvm storage knownfailure"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/nfs-repo-and-addon.sh
+++ b/nfs-repo-and-addon.sh
@@ -17,7 +17,8 @@
 #
 # Red Hat Author(s): David Shea <dshea@redhat.com>
 
-TESTTYPE="method packaging"
+# requires special setup (NFS server) which we don't have in our test environments
+TESTTYPE="method packaging knownfailure"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/proxy-auth.sh
+++ b/proxy-auth.sh
@@ -17,7 +17,8 @@
 #
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 
-TESTTYPE="method proxy"
+# FIXME: Anaconda crashes with "InvalidValueError: Proxy URL does not have valid format: malformed URL, cannot parse it."
+TESTTYPE="method proxy knownfailure"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/functions-proxy.sh

--- a/proxy-kickstart.sh
+++ b/proxy-kickstart.sh
@@ -18,7 +18,8 @@
 # Red Hat Author(s): David Shea <dshea@redhat.com>
 #                    Jiri Konecny <jkonecny@redhat.com>
 
-TESTTYPE="method proxy"
+# FIXME: Anaconda crashes with "InvalidValueError: Proxy URL does not have valid format: malformed URL, cannot parse it."
+TESTTYPE="method proxy knownfailure"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/functions-proxy.sh

--- a/scripts/launcher/run_one_test.py
+++ b/scripts/launcher/run_one_test.py
@@ -148,7 +148,7 @@ class Runner(object):
         v_conf.log_path = os.path.join(self._tmp_dir, "livemedia.log")
         v_conf.vnc = "vnc"
         v_conf.boot_image = boot_args
-        v_conf.timeout = 30
+        v_conf.timeout = 60
         v_conf.disk_paths = disk_args
         v_conf.networks = nics_args
 

--- a/scripts/run_travis.sh
+++ b/scripts/run_travis.sh
@@ -7,7 +7,16 @@ git fetch upstream
 git rebase upstream/master
 
 # list of tests that are changed by the current PR; ignore non-executable *.sh as these are helpers, not tests
-TESTS=$(git diff --name-only upstream/master..HEAD -- *.ks.in $(find -maxdepth 1 -name '*.sh' -perm -u+x) | sed 's/\.ks\.in$//; s/\.sh$//' | sort -u)
+CHANGED_TESTS=$(git diff --name-only upstream/master..HEAD -- *.ks.in $(find -maxdepth 1 -name '*.sh' -perm -u+x) | sed 's/\.ks\.in$//; s/\.sh$//' | sort -u)
+# weed out known failures
+TESTS=""
+for t in $CHANGED_TESTS; do
+    if grep -q 'TESTTYPE.*knownfailure' ${t}.sh; then
+        echo "Not running $t as it is a known failure"
+    else
+        TESTS="$TESTS $t"
+    fi
+done
 
 # if the PR changes anything in the test runner, or does not touch any tests, pick a few representative tests
 # FIXME: Once the runner container can run groups properly, replace with a TESTTYPE="travis" group

--- a/snapshot-post.sh
+++ b/snapshot-post.sh
@@ -17,6 +17,7 @@
 #
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 
-TESTTYPE="snapshot lvm storage coverage"
+# FIXME: Anaconda crashes with "Logical volume testvg/testLV contains a filesystem in use"
+TESTTYPE="snapshot lvm storage coverage knownfailure"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Let's do a clean break and mark the currently failing tests as such. Then our daily runs should ordinarily succeed, and any failure will point out an actual regression. This PR covers the tests which fail *both* on the old cobra02 infra and the containers/runner based infra.

The only remaining exception is `network-noipv4-pre`, which succeeds on cobra02 and fails *only* in the container. I am still investigating this, but will handle it as part of PR#412 or separately.