### PR TITLE
Expose runner container's libvirt and VNC

### DIFF
--- a/containers/runner/launch
+++ b/containers/runner/launch
@@ -108,8 +108,10 @@ elif [ ${TEST_JOBS} -gt 4 ]; then
 fi
 
 # Run container against the local repository, to test changes easily
+# Expose the container's libvirt to the host; check "podman ps" for the port, and use e.g.:
+# virsh -c qemu+tcp://localhost:<port>/session list
 set -x
-$CRUN run -it --rm --device=/dev/kvm \
+$CRUN run -it --rm --device=/dev/kvm --publish 127.0.0.1::16509 \
     --env KSTESTS_TEST="$KSTESTS_TEST" --env TESTTYPE="${TESTTYPE:-}" --env SKIP_TESTTYPES="${SKIP_TESTTYPES:-}" \
     --env TEST_JOBS="$TEST_JOBS" ${UPDATES_IMG_ARGS:-} ${CONTAINER_RUN_ARGS:-} \
     ${VAR_TMP:-} -v "$PWD/data:/opt/kstest/data:z" -v "$BASEDIR:/kickstart-tests:ro,z" ${DEFAULTS_SH_ARGS:-} \

--- a/containers/runner/run-kstest
+++ b/containers/runner/run-kstest
@@ -43,6 +43,24 @@ fi
 # work around virt-install TOCTOU race <https://github.com/virt-manager/virt-manager/pull/175>
 mkdir -p ~/.cache/virt-manager/boot
 
+# Expose libvirt to the outside, so that one can attach virt-viewer easily for debugging
+# Disable TLS; we don't have a certificate setup, and this is all local anyway
+mkdir -p ~/.config/libvirt
+printf 'listen_tls = 0\nlisten_tcp = 1\nauth_tcp = "none"\n' > ~/.config/libvirt/libvirtd.conf
+libvirtd --listen > ~/libvirtd.log 2>&1 &
+
+# this only works with a bridged network; user containers use SLIRP and only have a tun0 interface
+if MY_IP=$(ip -4 -c a show dev eth0 2>/dev/null | grep -Eo '[0-9.]+\.[0-9]+' | grep -v '\.255'); then
+    set +x
+    echo "************************************************************************"
+    echo "You can connect to this container's libvirt with this connection string:"
+    echo
+    echo "   qemu+tcp://${MY_IP}/session"
+    echo
+    echo "************************************************************************"
+    set -x
+fi
+
 # Run the test, capture the output for run_report.sh
 TEST_LOG=/var/tmp/kstest.log
 pushd ${KSTESTS_DIR}

--- a/scripts/launcher/run_one_test.py
+++ b/scripts/launcher/run_one_test.py
@@ -146,7 +146,7 @@ class Runner(object):
         v_conf.test_name = self._conf.ks_test_name
         v_conf.temp_dir = self._tmp_dir
         v_conf.log_path = os.path.join(self._tmp_dir, "livemedia.log")
-        v_conf.vnc = "vnc"
+        v_conf.vnc = "vnc,listen=0.0.0.0"
         v_conf.boot_image = boot_args
         v_conf.timeout = 30
         v_conf.disk_paths = disk_args


### PR DESCRIPTION
Start the user libvirt instance manually with `--listen`, so that it
listens to the TCP port. Disable TLS mode, as that requires setting up a
CA/certs; and all of this happens locally only anyway, so we don't need
authentication really.

Show a libvirt connection string to the user, so that it's easy to
control the container's libvirt on the host with `virsh -c`, or connect
to the running VMs with `virt-viewer -c` and visually follow the test
progress.

For now this only fully works with with system podman instances as they
use proper bridges.

For user podman instances we expose the port to the host, so that you
can find it in "podman ps". But this only works for controlling libvirt
itself, not for VNC.

But running as system instance is nicer anyway due to being able to use
the squid proxy, so that's not a priority for now.
