### PR TITLE
Fix runner Dockerfile syntax for docker

### DIFF
--- a/containers/runner/Dockerfile
+++ b/containers/runner/Dockerfile
@@ -24,7 +24,7 @@ RUN dnf -y update && \
 # https://github.com/virt-manager/virt-manager/pull/179 and
 # https://github.com/virt-manager/virt-manager/pull/194 to fix parallel runs
 # This will fail once a fixed libvirt lands, remove this when that happens
-COPY ["libvirt-pool-toctou.patch", "libvirt-domain-toctou.patch", "/tmp"]
+COPY ["libvirt-pool-toctou.patch", "libvirt-domain-toctou.patch", "/tmp/"]
 RUN patch --batch /usr/share/virt-manager/virtinst/connection.py /tmp/libvirt-pool-toctou.patch && \
     patch --batch /usr/share/virt-manager/virtinst/connection.py /tmp/libvirt-domain-toctou.patch
 


### PR DESCRIPTION
This file works fine with podman, but docker fails with

   When using COPY with more than one source file, the destination must be a directory and end with a /

So, do what it says.

----

See the [failed run from master branch](https://github.com/cockpit-project/cockpit/runs/1455235685?check_suite_focus=true). I ran this branch and [it succeeded](https://github.com/rhinstaller/kickstart-tests/actions/runs/384633508) and [pushed a new image](https://quay.io/repository/rhinstaller/kstest-runner?tab=tags). That's why I didn't submit this PR from my fork, but pushed the branch to origin, so that it could use the quay secrets.