### PR TITLE
Regularly run rhel8 scenario in workflow

### DIFF
--- a/.github/workflows/scenarios.yml
+++ b/.github/workflows/scenarios.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: [self-hosted, kstest]
     strategy:
       matrix:
-        scenario: [rawhide, daily-iso]
+        scenario: [rawhide, daily-iso, rhel8]
       fail-fast: false
 
     # these settings depend on the infrastructure; on upshift ocp-master-xxl they take about 4 hours

--- a/bindtomac-bridge-2devs-httpks.sh
+++ b/bindtomac-bridge-2devs-httpks.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE="network"
+TESTTYPE="network rhbz1903061"
 
 . ${KSTESTDIR}/bridge-2devs-httpks.sh

--- a/bindtomac-bridge-2devs-pre.sh
+++ b/bindtomac-bridge-2devs-pre.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE="network"
+TESTTYPE="network rhbz1903061"
 
 . ${KSTESTDIR}/bridge-2devs-pre.sh

--- a/bindtomac-bridge-httpks.sh
+++ b/bindtomac-bridge-httpks.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE="network"
+TESTTYPE="network rhbz1903061"
 
 . ${KSTESTDIR}/bridge-httpks.sh

--- a/bindtomac-bridged-bond-httpks.sh
+++ b/bindtomac-bridged-bond-httpks.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE="network"
+TESTTYPE="network rhbz1903061"
 
 . ${KSTESTDIR}/bridged-bond-httpks.sh
 

--- a/bond-vlan-pre.sh
+++ b/bond-vlan-pre.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE="network"
+TESTTYPE="network rhbz1903061"
 
 . ${KSTESTDIR}/bond-vlan-httpks.sh

--- a/bridge-2devs-httpks.sh
+++ b/bridge-2devs-httpks.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE=${TESTTYPE:-"network"}
+TESTTYPE="network rhbz1903061"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/bridge-2devs-pre.sh
+++ b/bridge-2devs-pre.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE=${TESTTYPE:-"network"}
+TESTTYPE="network rhbz1903061"
 
 . ${KSTESTDIR}/bridge-2devs.sh

--- a/bridge-2devs.sh
+++ b/bridge-2devs.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE=${TESTTYPE:-"network"}
+TESTTYPE="network rhbz1903061"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/bridge-httpks.sh
+++ b/bridge-httpks.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE=${TESTTYPE:-"network"}
+TESTTYPE="network rhbz1903061"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/bridge-no-bootopts-net.sh
+++ b/bridge-no-bootopts-net.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE=${TESTTYPE:-"network"}
+TESTTYPE="network rhbz1903061"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/bridged-bond-httpks.sh
+++ b/bridged-bond-httpks.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE=${TESTTYPE:-"network"}
+TESTTYPE="network rhbz1903061"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/bridged-bond-pre.sh
+++ b/bridged-bond-pre.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE="network"
+TESTTYPE="network rhbz1903061"
 # This is not implemented yet for %pre (ie in anaconda, just in parse-kickstart)
 
 . ${KSTESTDIR}/functions.sh

--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -19,7 +19,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes fedora-only,knownfailure --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
+        $LAUNCH --skip-testtypes fedora-only,knownfailure,rhbz1903061 --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
         ;;
 
     # just run a single test on standard Rawhide; mostly for testing infrastructure

--- a/network-autoconnections-dhcpall-httpks.sh
+++ b/network-autoconnections-dhcpall-httpks.sh
@@ -22,7 +22,7 @@
 # The latter is causing that kickstart network commands are not applied (ifcfg
 # files created) in initramfs.
 
-TESTTYPE=${TESTTYPE:-"network"}
+TESTTYPE="network rhbz1903061"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/network-autoconnections-httpks.sh
+++ b/network-autoconnections-httpks.sh
@@ -22,7 +22,7 @@
 # The latter is causing that kickstart network commands are not applied (ifcfg
 # files created) in initramfs.
 
-TESTTYPE=${TESTTYPE:-"network"}
+TESTTYPE="network rhbz1903061"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/network-device-mac.sh
+++ b/network-device-mac.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
-TESTTYPE="network"
+TESTTYPE="network rhbz1903061"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/network-noipv4-httpks.sh
+++ b/network-noipv4-httpks.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE="network"
+TESTTYPE="network rhbz1903061"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/network-noipv4-pre.sh
+++ b/network-noipv4-pre.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE="network"
+TESTTYPE="network rhbz1903061"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/post-lib-network.sh
+++ b/post-lib-network.sh
@@ -215,7 +215,10 @@ function check_connection_device() {
     local con=$1
     local dev=$2
 
-    nmcli -t -f NAME,DEVICE con | egrep -q ^${con}:${dev}$
+    # show this in the logs for easier debugging
+    nmcli con
+
+    nmcli -t -f NAME,DEVICE con | egrep -q '^(System )?'"${con}:${dev}$"
     if [[ $? -ne 0 ]]; then
         echo "*** Failed check: connection ${con} exists and is active on ${dev}" >> /root/RESULT
     fi

--- a/scripts/run_travis.sh
+++ b/scripts/run_travis.sh
@@ -14,7 +14,8 @@ for t in $CHANGED_TESTS; do
     if grep -q 'TESTTYPE.*knownfailure' ${t}.sh; then
         echo "Not running $t as it is a known failure"
     else
-        TESTS="$TESTS $t"
+        TESTS="$TESTS
+$t"
     fi
 done
 


### PR DESCRIPTION
## Blockers
 - [x] PR #422
 - [x] Skip tests broken by the  [NM regression](https://bugzilla.redhat.com/show_bug.cgi?id=1903061)
 - [x] fix travis timeout, limit the number of tests that run

## [sixth run](https://github.com/rhinstaller/kickstart-tests/actions/runs/394342600)

Just one random flake, otherwise ok. (We really need PR #424!)

[Re-run without changes](https://github.com/rhinstaller/kickstart-tests/actions/runs/395577906) -- different flake, so overall every test succeeded.

## [fifth run](https://github.com/rhinstaller/kickstart-tests/actions/runs/394032530)

 - Just one ks test failure, `bridged-bond-httpks` -- forgot that in the current "skip affected tests" commit
 - Travis timed out as it tried to run too many tests (fixed in separate commit)

## [fourth run](https://github.com/rhinstaller/kickstart-tests/actions/runs/393673757)

Even more networking test failures, they just fail later on. This takes too long to fix all of them, and apparently the workaround was detrimental. Plan B: Skip these 15 tests on rhel8 and mark them in an useful way.

## [third run](https://github.com/rhinstaller/kickstart-tests/actions/runs/386618493)
- lots of networking tests fail on validation
- firewall-use-system-defaults failure, random flake

## [second run](https://github.com/rhinstaller/kickstart-tests/actions/runs/385441891)

 - lots of networking tests fail on validation

Failing Test | Failing on old cobra infra | Fails how | Fixed 
-------------|----------------|-----------------|-----------------
hello-world | Y | timed out; No such file or directory: '/usr/bin/python3' | fedora-only
https-repo | Y | no https repo defined; download.devel does not have valid cert | fedora-only
lvm-2 | Y | missing packages: python | move to python3
ntp-pools | Y | Unknown command: timesource | fedora-only| 

## [first run, for "packages" tests only](https://github.com/rhinstaller/kickstart-tests/actions/runs/385064239)

Failing Test | Failing on old cobra infra | Fails how | Fixed 
-------------|----------------|-----------------|-----------------
| container |  Y | impossible in principle with RHEL | move to fedora-only |
| unified | Y |  timeout | knownfailure
| groups-and-envs-1 | Y | timeout | move to fedora-only
| groups-and-envs-2 | Y | timeout | move to fedora-only
| groups-and-envs-3 | Y | Module or Group 'domain-client' is not available; when dropping that, fails validatinon | not easy to fix, fedora-only for now
| harddrive-install-tree{,-relative} | Y | SourceSetupError: Nothing useful found for Hard drive ISO source at partition=/dev/sdb directory=/repo/ | move to fedora-only