### PR TITLE
Adjust tests for RHEL 8

### DIFF
--- a/container.sh
+++ b/container.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="bootloader packaging coverage"
+TESTTYPE="bootloader packaging coverage fedora-only"
 
 . ${KSTESTDIR}/functions.sh

--- a/containers/runner/launch
+++ b/containers/runner/launch
@@ -27,6 +27,7 @@ Usage:
 
 Options:
  -j, --jobs N                         Run N jobs in parallel (default: $(nproc))
+ -p, --platform NAME                  See fragments/platform/ (default: fedora_rawhide)
  -t, --testtype TYPE                  Only run TYPE tests
  -s, --skip-testtypes TYPE[,TYPE..]   Don't run tests with given types
  -u, --updates PATH|URL               Set updates.img path or URL
@@ -40,11 +41,12 @@ EOF
 }
 
 # parse options
-eval set -- "$(getopt -o j:t:s:u:h --long jobs:,testtype:,skip-testtypes:,updates:,daily-iso:,defaults:,run-args:,help -- "$@")"
+eval set -- "$(getopt -o j:p:t:s:u:h --long jobs:,platform:,testtype:,skip-testtypes:,updates:,daily-iso:,defaults:,run-args:,help -- "$@")"
 
 while true; do
     case "${1:-}" in
         -j|--jobs) shift; TEST_JOBS=$1 ;;
+        -p|--platform) shift; PLATFORM=$1 ;;
         -t|--testtype) shift; TESTTYPE="$1" ;;
         -s|--skip-testtypes) shift; SKIP_TESTTYPES="$1" ;;
         -u|--updates) shift; UPDATES_IMAGE="$1" ;;
@@ -113,6 +115,6 @@ fi
 set -x
 $CRUN run -it --rm --device=/dev/kvm --publish 127.0.0.1::16509 \
     --env KSTESTS_TEST="$KSTESTS_TEST" --env TESTTYPE="${TESTTYPE:-}" --env SKIP_TESTTYPES="${SKIP_TESTTYPES:-}" \
-    --env TEST_JOBS="$TEST_JOBS" ${UPDATES_IMG_ARGS:-} ${CONTAINER_RUN_ARGS:-} \
+    --env TEST_JOBS="$TEST_JOBS" --env PLATFORM="${PLATFORM:-}" ${UPDATES_IMG_ARGS:-} ${CONTAINER_RUN_ARGS:-} \
     ${VAR_TMP:-} -v "$PWD/data:/opt/kstest/data:z" -v "$BASEDIR:/kickstart-tests:ro,z" ${DEFAULTS_SH_ARGS:-} \
     $CONTAINER /kickstart-tests/containers/runner/run-kstest

--- a/containers/runner/run-kstest
+++ b/containers/runner/run-kstest
@@ -30,6 +30,10 @@ if [ -n "${UPDATES_IMAGE}" ]; then
   UPDATES_IMAGE_ARG="-u ${UPDATES_IMAGE}"
 fi
 
+PLATFORM_ARG=""
+if [ -n "${PLATFORM}" ]; then
+    PLATFORM_ARG="-p ${PLATFORM}"
+fi
 TESTTYPE_ARG=""
 if [ -n "${TESTTYPE}" ]; then
     TESTTYPE_ARG="-t ${TESTTYPE}"
@@ -65,7 +69,7 @@ fi
 TEST_LOG=/var/tmp/kstest.log
 pushd ${KSTESTS_DIR}
 set +e
-scripts/run_kickstart_tests.sh -k ${KSTESTS_KEEP} -i ${ISO_DIR}/${BOOT_ISO} ${UPDATES_IMAGE_ARG} ${TESTTYPE_ARG} ${SKIP_TESTTYPES_ARG} ${KSTESTS_TEST} 2>&1 | tee $TEST_LOG
+scripts/run_kickstart_tests.sh -k ${KSTESTS_KEEP} -i ${ISO_DIR}/${BOOT_ISO} ${UPDATES_IMAGE_ARG} ${PLATFORM_ARG} ${TESTTYPE_ARG} ${SKIP_TESTTYPES_ARG} ${KSTESTS_TEST} 2>&1 | tee $TEST_LOG
 RC=$?
 set -e
 popd

--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -19,7 +19,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes fedora-only,knownfailure --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
+        $LAUNCH --skip-testtypes fedora-only,knownfailure --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
         ;;
 
     # just run a single test on standard Rawhide; mostly for testing infrastructure

--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -19,7 +19,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes fedora-only,knownfailure --testtype packaging --defaults "$ROOTDIR/scripts/defaults-rhel8.sh"
+        $LAUNCH --skip-testtypes fedora-only,knownfailure --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
         ;;
 
     # just run a single test on standard Rawhide; mostly for testing infrastructure

--- a/fragments/platform/rhel8/repos/default.ks
+++ b/fragments/platform/rhel8/repos/default.ks
@@ -1,3 +1,3 @@
 # Default RHEL8 repositories - BeseOS + AppStream or unified repo can be used
-url RHEL8_BASE_OS_REPO_URL_GOES_HERE
-repo --name=appstream RHEL8_APPSTREAM_REPO_URL_GOES_HERE
+url @KSTEST_URL@
+repo --name=appstream --baseurl @KSTEST_MODULAR_URL@

--- a/groups-and-envs-1.sh
+++ b/groups-and-envs-1.sh
@@ -17,6 +17,7 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="packaging"
+# FIXME: times out on rhel8
+TESTTYPE="packaging fedora-only"
 
 . ${KSTESTDIR}/functions.sh

--- a/groups-and-envs-2.sh
+++ b/groups-and-envs-2.sh
@@ -17,6 +17,7 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="packaging"
+# FIXME: times out on rhel8
+TESTTYPE="packaging fedora-only"
 
 . ${KSTESTDIR}/functions.sh

--- a/groups-and-envs-3.sh
+++ b/groups-and-envs-3.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="packaging"
+# FIXME: Fails on RHEL due to nonexisting @domain-client; when dropped, fails validation on
+# "Fedora Server default environment was not installed"
+TESTTYPE="packaging fedora-only"
 
 . ${KSTESTDIR}/functions.sh

--- a/harddrive-install-tree-relative.sh
+++ b/harddrive-install-tree-relative.sh
@@ -17,7 +17,9 @@
 #
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 
-TESTTYPE=${TESTTYPE:-"packaging"}
+# FIXME: fails on RHEL 8:
+# SourceSetupError: Nothing useful found for Hard drive ISO source at partition=/dev/sdb directory=/repo/
+TESTTYPE="packaging fedora-only"
 
 . ${KSTESTDIR}/harddrive-install-tree.sh
 

--- a/harddrive-install-tree.sh
+++ b/harddrive-install-tree.sh
@@ -17,7 +17,9 @@
 #
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 
-TESTTYPE=${TESTTYPE:-"packaging"}
+# FIXME: fails on RHEL 8:
+# SourceSetupError: Nothing useful found for Hard drive ISO source at partition=/dev/sdb directory=/repo/
+TESTTYPE="packaging fedora-only"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/hello-world.sh
+++ b/hello-world.sh
@@ -17,6 +17,7 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
-TESTTYPE="addon coverage"
+# FIXME: %pre script uses python3, which does not exist in RHEL8 env; times out there
+TESTTYPE="addon coverage fedora-only"
 
 . ${KSTESTDIR}/functions.sh

--- a/https-repo.sh
+++ b/https-repo.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Pitt <mpitt@redhat.com>
 
-TESTTYPE="method"
+# FIXME: https://download.devel.redhat.com does not have a recognized certificate
+# once there is a solution, create fragments/platform/rhel8/repos/https.ks
+TESTTYPE="method fedora-only"
 
 . ${KSTESTDIR}/functions.sh

--- a/lvm-2.ks.in
+++ b/lvm-2.ks.in
@@ -20,7 +20,7 @@ rootpw testcase
 shutdown
 
 %packages
-python
+python3
 %end
 
 %post
@@ -28,8 +28,8 @@ python
 vg_size=$(vgs --noheadings -o size --unit=m --nosuffix fedora)
 root_lv_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/root)
 swap_lv_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/swap)
-root_percentage=$(python -c "print int(round(($root_lv_size*100)/$vg_size))")
-swap_percentage=$(python -c "print int(round(($swap_lv_size*100)/$vg_size))")
+root_percentage=$(python3 -c "print(int(round(($root_lv_size*100)/$vg_size)))")
+swap_percentage=$(python3 -c "print(int(round(($swap_lv_size*100)/$vg_size)))")
 if [ $swap_percentage != "10" ]; then
     echo "*** swap lv size is incorrect ($swap_lv_size MiB, or ${swap_percentage}%)" >> /root/RESULT
 fi

--- a/ntp-pools.sh
+++ b/ntp-pools.sh
@@ -17,6 +17,7 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="time coverage"
+# Fails in rhel8 with "Unknown command: timesource"
+TESTTYPE="time coverage fedora-only"
 
 . ${KSTESTDIR}/functions.sh

--- a/unified.sh
+++ b/unified.sh
@@ -17,6 +17,7 @@
 #
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 
-TESTTYPE="packaging rhel-only"
+# times out
+TESTTYPE="packaging rhel-only knownfailure"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
I went through the [first rhel8 run](https://github.com/rhinstaller/kickstart-tests/actions/runs/385441891) on the new infra, compared it with the results from cobra02. This addresses all tests which have consistently failed on both infrastructures. Mostly by skipping them on RHEL with a FIXME comment, and in one case actually fixing it. I'd really like to start the new infra runs from a clean slate, keep the tests generally succeeding, and then putting back the tests one by one with PRs that fix them.

This also adds some necessary fixes/improvements to the runner container scripts. They should not affect Fedora (tests will tell us), but they are already useful to have in master for  running RHEL 8 tests locally, until PR #421 lands.