### PR TITLE
Retry test failures in nightly scenarios

### DIFF
--- a/containers/runner/launch
+++ b/containers/runner/launch
@@ -31,6 +31,8 @@ Options:
  -t, --testtype TYPE                  Only run TYPE tests
  -s, --skip-testtypes TYPE[,TYPE..]   Don't run tests with given types
  -u, --updates PATH|URL               Set updates.img path or URL
+ -r, --retry                          Retry failed tests once, to guard against random
+                                      infrastructure failures
  --daily-iso TOKEN_FILE               Download and use daily boot.iso instead of rawhide's
                                       (This requires a GitHub token that can read
                                        rhinstaller/kickstart-tests workflow artifacts.)
@@ -41,7 +43,7 @@ EOF
 }
 
 # parse options
-eval set -- "$(getopt -o j:p:t:s:u:h --long jobs:,platform:,testtype:,skip-testtypes:,updates:,daily-iso:,defaults:,run-args:,help -- "$@")"
+eval set -- "$(getopt -o j:p:t:s:u:rh --long jobs:,platform:,testtype:,skip-testtypes:,updates:,retry,daily-iso:,defaults:,run-args:,help -- "$@")"
 
 while true; do
     case "${1:-}" in
@@ -50,6 +52,7 @@ while true; do
         -t|--testtype) shift; TESTTYPE="$1" ;;
         -s|--skip-testtypes) shift; SKIP_TESTTYPES="$1" ;;
         -u|--updates) shift; UPDATES_IMAGE="$1" ;;
+        -r|--retry) TEST_RETRY=1 ;;
         --daily-iso) shift; DAILY_ISO_TOKEN="$1" ;;
         --defaults) shift; DEFAULTS_SH="$1" ;;
         --run-args) shift; CONTAINER_RUN_ARGS="$1" ;;
@@ -115,6 +118,6 @@ fi
 set -x
 $CRUN run -it --rm --device=/dev/kvm --publish 127.0.0.1::16509 \
     --env KSTESTS_TEST="$KSTESTS_TEST" --env TESTTYPE="${TESTTYPE:-}" --env SKIP_TESTTYPES="${SKIP_TESTTYPES:-}" \
-    --env TEST_JOBS="$TEST_JOBS" --env PLATFORM="${PLATFORM:-}" ${UPDATES_IMG_ARGS:-} ${CONTAINER_RUN_ARGS:-} \
+    --env TEST_JOBS="$TEST_JOBS" --env PLATFORM="${PLATFORM:-}" --env TEST_RETRY="${TEST_RETRY:-}" ${UPDATES_IMG_ARGS:-} ${CONTAINER_RUN_ARGS:-} \
     ${VAR_TMP:-} -v "$PWD/data:/opt/kstest/data:z" -v "$BASEDIR:/kickstart-tests:ro,z" ${DEFAULTS_SH_ARGS:-} \
     $CONTAINER /kickstart-tests/containers/runner/run-kstest

--- a/containers/runner/run-kstest
+++ b/containers/runner/run-kstest
@@ -44,6 +44,11 @@ if [ -n "${SKIP_TESTTYPES}" ]; then
     SKIP_TESTTYPES_ARG="-s ${SKIP_TESTTYPES}"
 fi
 
+RETRY_ARG=""
+if [ -n "${TEST_RETRY}" ]; then
+    RETRY_ARG="-r"
+fi
+
 # work around virt-install TOCTOU race <https://github.com/virt-manager/virt-manager/pull/175>
 mkdir -p ~/.cache/virt-manager/boot
 
@@ -69,7 +74,7 @@ fi
 TEST_LOG=/var/tmp/kstest.log
 pushd ${KSTESTS_DIR}
 set +e
-scripts/run_kickstart_tests.sh -k ${KSTESTS_KEEP} -i ${ISO_DIR}/${BOOT_ISO} ${UPDATES_IMAGE_ARG} ${PLATFORM_ARG} ${TESTTYPE_ARG} ${SKIP_TESTTYPES_ARG} ${KSTESTS_TEST} 2>&1 | tee $TEST_LOG
+scripts/run_kickstart_tests.sh -k ${KSTESTS_KEEP} -i ${ISO_DIR}/${BOOT_ISO} ${UPDATES_IMAGE_ARG} ${PLATFORM_ARG} ${TESTTYPE_ARG} ${SKIP_TESTTYPES_ARG} ${RETRY_ARG} ${KSTESTS_TEST} 2>&1 | tee $TEST_LOG
 RC=$?
 set -e
 popd

--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -3,7 +3,8 @@
 set -eux
 
 MYDIR=$(dirname $(realpath "$0"))
-LAUNCH="$MYDIR/launch"
+# tests often fail due to random infrastructure flakes; enable auto-retry
+LAUNCH="$MYDIR/launch --retry"
 ROOTDIR=$(dirname $(dirname "$MYDIR"))
 SCENARIO="$1"
 shift

--- a/scripts/launcher/lib/conf/runner_parser.py
+++ b/scripts/launcher/lib/conf/runner_parser.py
@@ -88,6 +88,8 @@ class RunnerParser(BaseParser):
         self._parser.add_argument("--append-host-id", default=False, action="store_true",
                                   dest="append_host_id",
                                   help="append an id of the host running the test to the result")
+        self._parser.add_argument("--retry", default=False, action="store_true",
+                                  help="retry a failed test once, to guard against random infrastructure failures")
 
     def get_configuration(self):
         """Parse arguments and return configuration object.
@@ -115,6 +117,8 @@ class RunnerParser(BaseParser):
 
         if ns.append_host_id:
             conf.append_host_id = ns.append_host_id
+
+        conf.retry = ns.retry
 
         self._check_arguments(conf)
 

--- a/scripts/launcher/run_one_test.py
+++ b/scripts/launcher/run_one_test.py
@@ -47,6 +47,9 @@ from lib.test_logging import setup_logger, close_logger, get_logger
 
 log = get_logger()
 
+# return values for which a test gets retried with --retry
+# don't retry skips, panics, etc., just the unspecific failures
+RETRY_CODES = [1]
 
 class Runner(object):
 
@@ -203,5 +206,9 @@ if __name__ == '__main__':
 
     print("================================================================")
     ret_code = run_test_in_temp(config)
+
+    if config.retry and ret_code in RETRY_CODES:
+        print("\nRetrying failed test once")
+        ret_code = run_test_in_temp(config)
 
     exit(ret_code)

--- a/scripts/run_kickstart_tests.sh
+++ b/scripts/run_kickstart_tests.sh
@@ -64,7 +64,7 @@ UPDATES_IMG=""
 TESTTYPE=""
 SKIP_TESTTYPES=""
 
-while getopts ":i:k:t:s:u:b:p:o:" opt; do
+while getopts ":i:k:t:s:u:b:p:o:r" opt; do
     case $opt in
        i)
            # If this wasn't set from the environment, set it from the command line
@@ -111,6 +111,11 @@ while getopts ":i:k:t:s:u:b:p:o:" opt; do
            #
            # -o "path/to/overrides1 path/to/overrides2"
            KSAPPEND_OVERRIDES=$OPTARG
+           ;;
+       r)
+           # Retry tests once which failed for an unspecific reason (code 1), to avoid random
+           # infrastructure failures when running lots of tests
+           RETRY=--retry
            ;;
        *)
            echo "Usage: run_kickstart_tests.sh [-i boot.iso] [-k 0|1|2] [-t test_type_to_run] [-s test_types_to_ignore] [-u link_to_updates.img] [-b additional_boot_options] [-p platform_name] [-o ksappend_overrides] [tests]"
@@ -411,7 +416,7 @@ if [[ "$TEST_REMOTES" != "" ]]; then
                                                                -i ../install_images/${_IMAGE} \
                                                                -k ${KEEPIT} \
                                                                --append-host-id \
-                                                               ${UPDATES_ARG} ${BOOT_ARG} {} ::: ${tests}
+                                                               ${RETRY} ${UPDATES_ARG} ${BOOT_ARG} {} ::: ${tests}
     rc=$?
     cd -
 
@@ -443,7 +448,7 @@ else
                                                       -i ${IMAGE} \
                                                       -k ${KEEPIT} \
                                                       --append-host-id \
-                                                      ${UPDATES_ARG} ${BOOT_ARG} {} ::: ${tests}
+                                                      ${RETRY} ${UPDATES_ARG} ${BOOT_ARG} {} ::: ${tests}
     rc=$?
 fi
 


### PR DESCRIPTION
During the large nightly scenarios, tests sometimes fail on random
infrastructure flakes, which makes just about every run fail. This makes
the failure notifications useless for spotting actual problems, and just
wastes human time for checking the results.

Avoid that by retrying tests once if they fail for an unspecific reason
(i.e. do *not* retry kernel panics, timeouts, or skips). But do *not*
enable this for PR runs (in Travis), as we don't want to introduce flaky
tests -- there they must succeed on first try. Usually a PR does not
change many tests, so if we occasionally get unlucky there, a developer
can retry them manually.

Add a retry option to run_one_test, plumb it through
run_kickstart_tests.sh → run-kstest → launch, and enable it for the
"scenario" script that is being run every night.

 - [x] Builds on top of PR #423 

[manual run with these commits](https://github.com/rhinstaller/kickstart-tests/actions/runs/393761586)