### PR TITLE
Run scenario workflow after daily-boot-iso

### DIFF
--- a/.github/workflows/scenarios.yml
+++ b/.github/workflows/scenarios.yml
@@ -1,7 +1,8 @@
 name: Daily run
 on:
   schedule:
-    - cron: 0 22 * * *
+    # run after daily-boot-iso.yml
+    - cron: 0 23 * * *
   # be able to start this action manually from a actions tab when needed
   workflow_dispatch:
 


### PR DESCRIPTION
So far the nightly run was testing the previous day's daily iso, as both
jobs ran at the same time.