### PR TITLE
Fix rootless podman SELinux issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ fragments/runtime
 *.log
 *.retry
 __pycache__
+
+# these are temp directories for downloaded images and logs
+data/

--- a/containers/runner/README.md
+++ b/containers/runner/README.md
@@ -52,7 +52,7 @@ Configuration of the test
 -------------------------
 For more control, you can run the container manually:
 ```
-podman run -it --name last-kstest --env KSTESTS_TEST=keyboard -v ./data:/opt/kstest/data:z -v .:/kickstart-tests:ro --device=/dev/kvm rhinstaller/kstest-runner
+podman run -it --name last-kstest [--security-opt label=disable] --env KSTESTS_TEST=keyboard -v ./data:/opt/kstest/data:z -v .:/kickstart-tests:ro --device=/dev/kvm rhinstaller/kstest-runner
 ```
 
 Instead of keeping named container you can remove it after the test by replacing `--name last-kstest` option with `--rm`.
@@ -65,6 +65,10 @@ Environment variables for the container (`--env` option):
 * BOOT_ISO - name of the installer boot iso from `data/images` to be tested (default is "boot.iso")
 
 By default, the container runs the [run-kstest](./run-kstest) script. To get an interactive shell, append `bash` to the command line.
+
+**Beware** of the [issue](https://bugzilla.redhat.com/show_bug.cgi?id=1901462#c12) that podman
+is not able to get access to kvm socket in rootless mode. This issue will result in awfully
+slow execution of the tests. In that case please add `--security-opt label=disable`.
 
 Running tests with cached package downloads
 -------------------------------------------

--- a/containers/runner/launch
+++ b/containers/runner/launch
@@ -10,6 +10,9 @@ BASEDIR=$(dirname $(dirname $(dirname $(realpath $0))))
 TEST_JOBS=${TEST_JOBS:-$(nproc)}
 CRUN=${CRUN:-$(which podman docker 2>/dev/null | head -n1)}
 CONTAINER=quay.io/rhinstaller/kstest-runner
+# Podman in rootless mode does not have access to /dev/kvm socket https://bugzilla.redhat.com/show_bug.cgi?id=1901462
+# disable selinux container separation when podman is executed as user
+PODMAN_SELINUX_FIX=
 
 if ! test -w /dev/kvm; then
     echo "FATAL: /dev/kvm not accessible" >&2
@@ -112,11 +115,16 @@ elif [ ${TEST_JOBS} -gt 4 ]; then
     VAR_TMP="-v /var/tmp"
 fi
 
+if [ "${CRUN%podman*}" != "$CRUN" ] && [ $(id -u) -ne 0 ]; then
+    echo "Disabling SELinux container separation to enable /dev/kvm socket access."
+    PODMAN_SELINUX_FIX="--security-opt label=disable"
+fi
+
 # Run container against the local repository, to test changes easily
 # Expose the container's libvirt to the host; check "podman ps" for the port, and use e.g.:
 # virsh -c qemu+tcp://localhost:<port>/session list
 set -x
-$CRUN run -it --rm --device=/dev/kvm --publish 127.0.0.1::16509 \
+$CRUN run -it --rm --device=/dev/kvm --publish 127.0.0.1::16509 $PODMAN_SELINUX_FIX \
     --env KSTESTS_TEST="$KSTESTS_TEST" --env TESTTYPE="${TESTTYPE:-}" --env SKIP_TESTTYPES="${SKIP_TESTTYPES:-}" \
     --env TEST_JOBS="$TEST_JOBS" --env PLATFORM="${PLATFORM:-}" --env TEST_RETRY="${TEST_RETRY:-}" ${UPDATES_IMG_ARGS:-} ${CONTAINER_RUN_ARGS:-} \
     ${VAR_TMP:-} -v "$PWD/data:/opt/kstest/data:z" -v "$BASEDIR:/kickstart-tests:ro,z" ${DEFAULTS_SH_ARGS:-} \


### PR DESCRIPTION
This is happening when podman is started in rootless mode. In that case /dev/kvm socket has wrong SELinux label because it just bind-mounted inside of the container. For more info see here:

https://bugzilla.redhat.com/show_bug.cgi?id=1901462

To solve this issue we need to add '--security-opt label=disabled' which will disable container SELinux separation. This will be used only if we are runnig podman in a rootless mode (use 'sudo podman' to avoid that).