### PR TITLE
Fix cleaning of squid cache in scenarios workflow

### DIFF
--- a/.github/workflows/scenarios.yml
+++ b/.github/workflows/scenarios.yml
@@ -30,12 +30,12 @@ jobs:
           sudo podman volume rm --all || true
           sudo rm -rf *
 
+      - name: Clone repository
+        uses: actions/checkout@v2
+
       # use the latest official packages for the nightly runs
       - name: Clean up squid cache
         run: sudo containers/squid.sh clean
-
-      - name: Clone repository
-        uses: actions/checkout@v2
 
       - name: Ensure http proxy is running
         run: sudo containers/squid.sh start


### PR DESCRIPTION
Call this *after* checking out the repo.

---

Fixes [last night's failed run](https://github.com/rhinstaller/kickstart-tests/runs/1520621638?check_suite_focus=true), regression from commit b6441fb838e. Sorry about that blunder!

[manual run from this branch](https://github.com/rhinstaller/kickstart-tests/actions/runs/409866459)