### PR TITLE
Use lorax from rawhide for building daily boot.iso

### DIFF
--- a/.github/workflows/daily-boot-iso.yml
+++ b/.github/workflows/daily-boot-iso.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build boot.iso
     runs-on: ubuntu-latest
     container:
-      image: fedora:latest
+      image: fedora:rawhide
       # lorax does mounts and uses loop devices, thus needs to be privileged
       options: --privileged
     steps:


### PR DESCRIPTION
Fedora 33's version is missing a fix [1] that causes lots of programs to
fail on a missing libldap_r-2.4.so.2.

It's probably better to let lorax co-evolve with rawhide changes, so use
the same release on the host and the built guest.

[1] https://github.com/weldr/lorax/commit/bd37cd5b87
[2] https://bugzilla.redhat.com/show_bug.cgi?id=1905811

----

This fixes the [build failures](https://github.com/rhinstaller/kickstart-tests/actions?query=workflow%3A%22Build+daily+Rawhide%2BCOPR+boot.iso%22) that we had for a few days. I [successfully tested this on my fork](https://github.com/martinpitt/kickstart-tests/runs/1522807678?check_suite_focus=true)