### PR TITLE
Update a network test for rhel 8 that does not process ks in stage 2

### DIFF
--- a/bridge-no-bootopts-net.ks.in
+++ b/bridge-no-bootopts-net.ks.in
@@ -38,10 +38,17 @@ check_gui_configurations @KSTEST_NETDEV1@ bridge0
 check_device_connected bridge0 yes
 check_device_connected @KSTEST_NETDEV1@ yes
 
-# The bridge is created in initramfs so the slave connection is named @KSTEST_NETDEV1@
-# connection.master is identified by connection uuid so check __ANY
-check_device_config_value @KSTEST_NETDEV1@ BRIDGE bridge0 connection master __ANY
-check_device_config_value @KSTEST_NETDEV1@ BRIDGE bridge0 connection slave-type bridge
+if [ "@KSTEST_OS_NAME@" == "rhel" ] ; then
+    # RHEL-8-FAILURE: in rhel 8 the ifcfg is generated in initramfs by Anaconda
+    check_device_config_value bridge0_slave_1 BRIDGE bridge0 connection master bridge0
+    check_device_config_value bridge0_slave_1 BRIDGE bridge0 connection slave-type bridge
+else
+    # The bridge is created in initramfs so the slave connection is named @KSTEST_NETDEV1@
+    # connection.master is identified by connection uuid so check __ANY
+    check_device_config_value @KSTEST_NETDEV1@ BRIDGE bridge0 connection master __ANY
+    check_device_config_value @KSTEST_NETDEV1@ BRIDGE bridge0 connection slave-type bridge
+fi
+
 
 check_device_has_ipv4_address bridge0 yes
 check_device_has_ipv4_address @KSTEST_NETDEV1@ no

--- a/bridge-no-bootopts-net.sh
+++ b/bridge-no-bootopts-net.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE="network rhbz1903061"
+TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Update of
commit 593bdfd5db3e0bb31f14e27f188d7c8f607a3f39
for rhel 8.