### PR TITLE
Remove bug tag from bridged-bond-httpks tests

### DIFF
--- a/bindtomac-bridged-bond-httpks.sh
+++ b/bindtomac-bridged-bond-httpks.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE="network rhbz1903061"
+TESTTYPE="network"
 
 . ${KSTESTDIR}/bridged-bond-httpks.sh
 

--- a/bridged-bond-httpks.sh
+++ b/bridged-bond-httpks.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE="network rhbz1903061"
+TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
The tests should be passing both on fedora and rhel.