### PR TITLE
Run fixed tests failing for kickstart in stage2 changes on rhel8 again

### DIFF
--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -20,7 +20,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.devel.redhat.com/nightly/rhel-8/RHEL-8/latest-RHEL-8/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes fedora-only,knownfailure,rhbz1903061 --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
+        $LAUNCH --skip-testtypes fedora-only,knownfailure --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
         ;;
 
     # just run a single test on standard Rawhide; mostly for testing infrastructure

--- a/network-device-mac.sh
+++ b/network-device-mac.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
-TESTTYPE="network rhbz1903061"
+TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
The tests marked with the tag are fixed in these PRs:
* [x] https://github.com/rhinstaller/kickstart-tests/pull/434
* [x] https://github.com/rhinstaller/kickstart-tests/pull/433
* [x] https://github.com/rhinstaller/kickstart-tests/pull/432
* [x] https://github.com/rhinstaller/kickstart-tests/pull/441
* [x] https://github.com/rhinstaller/kickstart-tests/pull/440
* [x] https://github.com/rhinstaller/kickstart-tests/pull/438
* [x] https://github.com/rhinstaller/kickstart-tests/pull/437
* [x] https://github.com/rhinstaller/kickstart-tests/pull/442