### PR TITLE
Fix squid cleanup if container is stopped

### DIFF
--- a/containers/squid.sh
+++ b/containers/squid.sh
@@ -56,6 +56,8 @@ stop() {
 
 clean() {
     stop
+    # clean up in case it still exists, but is stopped
+    $CRUN rm -f squid 2>/dev/null || true
     if $CRUN volume inspect ks-squid-cache >/dev/null 2>&1; then
         $CRUN volume rm ks-squid-cache
     fi


### PR DESCRIPTION
It may happen that the squid container is not running any more, but
still exists in the "exited" state. In that case, stop() will not do
anything, but removing the cache volume fails because it's still being
used by the stopped container.

Force the removal of the container in clean() to avoid that.

----

This fixes [last night's scenario failure](https://github.com/rhinstaller/kickstart-tests/actions/runs/414165831) for the two jobs that ran on ghks1.