### PR TITLE
Use a better workaround for lorax/podman bug

### DIFF
--- a/.github/workflows/daily-boot-iso-rhel8.yml
+++ b/.github/workflows/daily-boot-iso-rhel8.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Build boot.iso with lorax
         run: |
           mkdir build
-          # HACK: lorax and podman overlayfs really hate each other: https://bugzilla.redhat.com/show_bug.cgi?id=1906364
-          sudo podman run --rm -i --storage-driver=vfs --root /tmp/podman-vfs --privileged --device /dev/loop0 --device /dev/loop-control --network host -v $PWD/build:/data registry.access.redhat.com/ubi8 <<EOF
+          # /var/tmp tmpfs speeds up lorax and avoids https://bugzilla.redhat.com/show_bug.cgi?id=1906364
+          sudo podman run --rm -i --privileged --device /dev/loop0 --device /dev/loop-control --tmpfs /var/tmp:rw,mode=1777 --network host -v $PWD/build:/data registry.access.redhat.com/ubi8 <<EOF
           set -eux
 
           # lorax must run on RHEL host to produce RHEL guest images :-(


### PR DESCRIPTION
Use a tmpfs volume as /var/tmp inside the container, to avoid it being
on overlayfs. This is much better than the inefficient vfs driver, and
avoids building up a parallel podman image and container store.

Thanks to Brian Lane for this!

-----

[Tested on manual run on this branch](https://github.com/rhinstaller/kickstart-tests/runs/1538955496?check_suite_focus=true). 
There are a few failures, but they already occurred [on a previous run](https://github.com/rhinstaller/kickstart-tests/runs/1532875634?check_suite_focus=true), so are not related to the broken boot.iso build (which makes *every* test fail quickly)