### PR TITLE
Add one hour to nightly kickstart tests run scenario timeout

### DIFF
--- a/.github/workflows/scenarios.yml
+++ b/.github/workflows/scenarios.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
 
     # these settings depend on the infrastructure; on upshift ocp-master-xxl they take about 4 hours
-    timeout-minutes: 360
+    timeout-minutes: 420
     env:
       TEST_JOBS: 16
       GITHUB_TOKEN: /home/github/github-token


### PR DESCRIPTION
The runs in the history so far take from 4 to 6 hours.  If raising the timeout
does not help much we might want to look if the runners degrade and consider
adding fresh provisioning of runner for each test.