### PR TITLE
Add kickstart tests for all user interface modes

### DIFF
--- a/post-nochroot-lib-ui.sh
+++ b/post-nochroot-lib-ui.sh
@@ -1,0 +1,26 @@
+# The library for nochroot post scripts of the UI kickstart tests.
+
+# Specify the result file.
+SYSROOT=${ANA_INSTALL_PATH:-/mnt/sysimage}
+RESULT_FILE=${SYSROOT}/root/RESULT
+
+# Check that the current display mode is set to the expected value.
+function check_display_mode() {
+    local expected_mode="$1"
+    local display_mode
+
+    display_mode="$(grep 'Display mode is set to ' /tmp/anaconda.log | cut -d \' -f2)"
+
+    if [ "$display_mode" != "$expected_mode" ]; then
+        echo "*** incorrect display mode (got $display_mode; expected $expected_mode)" >> ${RESULT_FILE}
+    fi
+}
+
+# Check that the VNC server is running.
+function check_vnc_server_is_running() {
+    grep -q "The VNC server is now running." /tmp/anaconda.log
+
+    if [[ $? -ne 0 ]]; then
+        echo "*** the VNC server is not running" >> ${RESULT_FILE}
+    fi
+}

--- a/ui_cmdline.ks.in
+++ b/ui_cmdline.ks.in
@@ -1,0 +1,19 @@
+#version=DEVEL
+#test name: ui_cmdline
+
+# Use defaults.
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
+%ksappend payload/default_packages.ks
+
+# Run the installation in the cmdline mode.
+cmdline
+
+%post --nochroot
+@KSINCLUDE@ post-nochroot-lib-ui.sh
+
+# Check the installation mode.
+check_display_mode "noninteractive text mode"
+%end
+
+%ksappend validation/success_if_result_empty_standalone.ks

--- a/ui_cmdline.sh
+++ b/ui_cmdline.sh
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+TESTTYPE="ui"
+
+. ${KSTESTDIR}/functions.sh

--- a/ui_graphical_interactive.ks.in
+++ b/ui_graphical_interactive.ks.in
@@ -1,0 +1,19 @@
+#version=DEVEL
+#test name: ui_graphical_interactive
+
+# Use defaults.
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
+%ksappend payload/default_packages.ks
+
+# Run the installation in the graphical mode.
+graphical
+
+%post --nochroot
+@KSINCLUDE@ post-nochroot-lib-ui.sh
+
+# Check the installation mode.
+check_display_mode "interactive graphical mode"
+%end
+
+%ksappend validation/success_if_result_empty_standalone.ks

--- a/ui_graphical_interactive.sh
+++ b/ui_graphical_interactive.sh
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+TESTTYPE="ui"
+
+. ${KSTESTDIR}/functions.sh

--- a/ui_graphical_interactive.sh
+++ b/ui_graphical_interactive.sh
@@ -15,6 +15,6 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-TESTTYPE="ui"
+TESTTYPE="ui smoke"
 
 . ${KSTESTDIR}/functions.sh

--- a/ui_graphical_noninteractive.ks.in
+++ b/ui_graphical_noninteractive.ks.in
@@ -1,0 +1,19 @@
+#version=DEVEL
+#test name: ui_graphical_noninteractive
+
+# Use defaults.
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
+%ksappend payload/default_packages.ks
+
+# Run the installation in the graphical mode.
+graphical --non-interactive
+
+%post --nochroot
+@KSINCLUDE@ post-nochroot-lib-ui.sh
+
+# Check the installation mode.
+check_display_mode "noninteractive graphical mode"
+%end
+
+%ksappend validation/success_if_result_empty_standalone.ks

--- a/ui_graphical_noninteractive.sh
+++ b/ui_graphical_noninteractive.sh
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+TESTTYPE="ui"
+
+. ${KSTESTDIR}/functions.sh

--- a/ui_graphical_noninteractive.sh
+++ b/ui_graphical_noninteractive.sh
@@ -15,6 +15,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-TESTTYPE="ui"
+
+# Anaconda raises the noninteractive error for the progress spoke.
+TESTTYPE="ui knownfailure"
 
 . ${KSTESTDIR}/functions.sh

--- a/ui_text_interactive.ks.in
+++ b/ui_text_interactive.ks.in
@@ -1,0 +1,19 @@
+#version=DEVEL
+#test name: ui_text_interactive
+
+# Use defaults.
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
+%ksappend payload/default_packages.ks
+
+# Run the installation in the text mode.
+text
+
+%post --nochroot
+@KSINCLUDE@ post-nochroot-lib-ui.sh
+
+# Check the installation mode.
+check_display_mode "interactive text mode"
+%end
+
+%ksappend validation/success_if_result_empty_standalone.ks

--- a/ui_text_interactive.sh
+++ b/ui_text_interactive.sh
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+TESTTYPE="ui"
+
+. ${KSTESTDIR}/functions.sh

--- a/ui_text_interactive.sh
+++ b/ui_text_interactive.sh
@@ -15,6 +15,6 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-TESTTYPE="ui"
+TESTTYPE="ui smoke"
 
 . ${KSTESTDIR}/functions.sh

--- a/ui_text_noninteractive.ks.in
+++ b/ui_text_noninteractive.ks.in
@@ -1,0 +1,19 @@
+#version=DEVEL
+#test name: ui_text_noninteractive
+
+# Use defaults.
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
+%ksappend payload/default_packages.ks
+
+# Run the installation in the text mode.
+text --non-interactive
+
+%post --nochroot
+@KSINCLUDE@ post-nochroot-lib-ui.sh
+
+# Check the installation mode.
+check_display_mode "noninteractive text mode"
+%end
+
+%ksappend validation/success_if_result_empty_standalone.ks

--- a/ui_text_noninteractive.sh
+++ b/ui_text_noninteractive.sh
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+TESTTYPE="ui"
+
+. ${KSTESTDIR}/functions.sh

--- a/ui_vnc.ks.in
+++ b/ui_vnc.ks.in
@@ -1,0 +1,22 @@
+#version=DEVEL
+#test name: ui_vnc
+
+# Use defaults.
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
+%ksappend payload/default_packages.ks
+
+# Run the installation in the VNC mode.
+vnc --password anaconda
+
+%post --nochroot
+@KSINCLUDE@ post-nochroot-lib-ui.sh
+
+# Check the installation mode.
+check_display_mode "interactive graphical mode"
+
+# Check the VNC server.
+check_vnc_server_is_running
+%end
+
+%ksappend validation/success_if_result_empty_standalone.ks

--- a/ui_vnc.sh
+++ b/ui_vnc.sh
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+TESTTYPE="ui"
+
+. ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Create new tests for the text, graphical, cmdline and vnc mode.

Add a new test type for smoke tests. The smoke tests consists
of two minimal installations. One runs in the text mode and one
runs the graphical mode.
