### PR TITLE
Run the checks of the geolocation test in nochroot

### DIFF
--- a/geolocation-off-by-default-with-ks.ks.in
+++ b/geolocation-off-by-default-with-ks.ks.in
@@ -18,7 +18,10 @@ shutdown
 %packages
 %end
 
-%post
+%post --nochroot
+# Specify the result file.
+SYSROOT=${ANA_INSTALL_PATH:-/mnt/sysimage}
+RESULT_FILE=${SYSROOT}/root/RESULT
 
 # Geolocation should be off by default during a kickstart installation.
 # This can be tested by checking if the sensitive-info log contains
@@ -27,25 +30,23 @@ shutdown
 
 # first check the anaconda log
 if grep -q "Geolocation started:" /tmp/anaconda.log; then
-  echo "error: geolocation started during default kickstart installation" >> /root/RESULT
+  echo "error: geolocation started during default kickstart installation" >> ${RESULT_FILE}
 fi
 if grep -q "got results from geolocation" /tmp/anaconda.log; then
-  echo "error: got results from geolocation during default kickstart installation" >> /root/RESULT
+  echo "error: got results from geolocation during default kickstart installation" >> ${RESULT_FILE}
 fi
 
 # then the sensitive-info log where geolocation record lookup results
 if grep -q "geolocation result:" /tmp/sensitive-info.log; then
-  echo "error: geolocation result found during default kickstart installation" >> /root/RESULT
+  echo "error: geolocation result found during default kickstart installation" >> ${RESULT_FILE}
 fi
 if grep -q "territory:" /tmp/sensitive-info.log; then
-  echo "error: geolocated territory found during default kickstart installation" >> /root/RESULT
+  echo "error: geolocated territory found during default kickstart installation" >> ${RESULT_FILE}
 fi
 if grep -q "timezone:" /tmp/sensitive-info.log; then
-  echo "error: geolocated timezone found during default kickstart installation" >> /root/RESULT
+  echo "error: geolocated timezone found during default kickstart installation" >> ${RESULT_FILE}
 fi
 
-# No error was written to /root/RESULT file, everything is OK
-if [[ ! -e /root/RESULT ]]; then
-    echo SUCCESS > /root/RESULT
-fi
 %end
+
+%ksappend validation/success_if_result_empty_standalone.ks


### PR DESCRIPTION
The checks have to run in nochroot post scripts to have access /tmp/anaconda.log
and other files.