### PR TITLE
Master fix loop devices

### DIFF
--- a/.github/workflows/daily-boot-iso-rhel8.yml
+++ b/.github/workflows/daily-boot-iso-rhel8.yml
@@ -24,8 +24,15 @@ jobs:
       - name: Build boot.iso with lorax
         run: |
           mkdir build
+
+          # We have to pre-create loop devices because they are not namespaced in kernel so
+          # podman can't access newly created ones. That caused failures of tests when runners
+          # were rebooted.
+          sudo mknod -m 0660 /dev/loop0 b 7 0  2> /dev/null || true
+          sudo mknod -m 0660 /dev/loop1 b 7 1  2> /dev/null || true
+
           # /var/tmp tmpfs speeds up lorax and avoids https://bugzilla.redhat.com/show_bug.cgi?id=1906364
-          sudo podman run --rm -i --privileged --device /dev/loop0 --device /dev/loop-control --tmpfs /var/tmp:rw,mode=1777 --network host -v $PWD/build:/data registry.access.redhat.com/ubi8 <<EOF
+          sudo podman run --rm -i --privileged --tmpfs /var/tmp:rw,mode=1777 --network host -v $PWD/build:/data registry.access.redhat.com/ubi8 <<EOF
           set -eux
 
           # lorax must run on RHEL host to produce RHEL guest images :-(
@@ -102,4 +109,5 @@ jobs:
         run: |
           # just in case it leaves some behind
           sudo losetup -d /dev/loop0 2>/dev/null || true
+          sudo losetup -d /dev/loop1 2>/dev/null || true
           sudo rm -rf build

--- a/.github/workflows/daily-boot-iso-rhel8.yml
+++ b/.github/workflows/daily-boot-iso-rhel8.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: run
     runs-on: [self-hosted, kstest]
+    env:
+       LORAX_BUILD_CONTAINER: registry.access.redhat.com/ubi8
     steps:
       # self-hosted runners don't do this automatically; also useful to keep stuff around for debugging
       # need to run sudo as the launch script and the container create root/other user owned files
@@ -17,6 +19,11 @@ jobs:
           sudo podman ps -q --all --filter='ancestor=kstest-runner' | xargs -tr sudo podman rm -f
           sudo podman volume rm --all || true
           sudo rm -rf *
+
+      - name: Update container images used here
+        run: |
+          sudo podman pull ${{ env.LORAX_BUILD_CONTAINER }}
+          sudo podman pull quay.io/rhinstaller/kstest-runner:latest
 
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -32,7 +39,7 @@ jobs:
           sudo mknod -m 0660 /dev/loop1 b 7 1  2> /dev/null || true
 
           # /var/tmp tmpfs speeds up lorax and avoids https://bugzilla.redhat.com/show_bug.cgi?id=1906364
-          sudo podman run --rm -i --privileged --tmpfs /var/tmp:rw,mode=1777 --network host -v $PWD/build:/data registry.access.redhat.com/ubi8 <<EOF
+          sudo podman run --rm -i --privileged --tmpfs /var/tmp:rw,mode=1777 --network host -v $PWD/build:/data ${{ env.LORAX_BUILD_CONTAINER }} <<EOF
           set -eux
 
           # lorax must run on RHEL host to produce RHEL guest images :-(


### PR DESCRIPTION
Solve problems with loop devices during the Lorax builds.

Container is not able to create new loop devices so we need to pre-create them before the container with lorax is started.

Tested [here](https://github.com/Test-anaconda-org/kickstart-tests/runs/1669275525?check_suite_focus=true). It's failing but later during the workflow because 15 GiB of memory (xlarge host) is not enough for our workflow with 16 parallel test runs. Next time I should use the ocp xxl host we normally using. 