### PR TITLE
Grab GitHub notifications for periodic workflows

### DIFF
--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -1,3 +1,4 @@
+# Build our container for running kickstart tests and push that to our quay.io repository
 # We cannot fully self-validate the new container, as running all kickstart tests just takes too long.
 # So tag the containers by build date, so that in the worst case we can always reset :latest to the previously working tag.
 name: Build and push containers

--- a/.github/workflows/daily-boot-iso-rawhide.yml
+++ b/.github/workflows/daily-boot-iso-rawhide.yml
@@ -1,3 +1,4 @@
+# Build Rawhide boot.iso daily
 name: Build daily Rawhide+COPR boot.iso
 on:
   schedule:

--- a/.github/workflows/scenarios.yml
+++ b/.github/workflows/scenarios.yml
@@ -1,3 +1,4 @@
+# Run all kickstart tests for all active branches
 name: Daily run
 on:
   schedule:


### PR DESCRIPTION
Unfortunately, GitHub will sent notifications about failures for on:schedule workflows just to the last person who did some changes to the workflow. :(

Because of that it would be great to get the notifications on me so I'm going to steal them by this PR! HAHAHAHAHAHA!