### PR TITLE
Test a rebooted system with the enabled initial setup 

### DIFF
--- a/fragments/shared/users/user.ks
+++ b/fragments/shared/users/user.ks
@@ -1,0 +1,2 @@
+# Simple user configuration
+user --name=user1 --homedir=/home/user1 --password="user1_password" --plaintext

--- a/fragments/shared/validation/success_on_first_boot.ks
+++ b/fragments/shared/validation/success_on_first_boot.ks
@@ -1,0 +1,62 @@
+# Report success if no errors have been reported on the first boot.
+# Additional tests can be implemented in /usr/libexec/kickstart-test.sh
+# by the kickstart test that includes this fragment. This file is empty
+# by default.
+
+%post
+
+# Create a systemd service.
+cat > /etc/systemd/system/kickstart-test.service << EOF
+
+[Unit]
+Description=The kickstart test service
+After=initial-setup.service
+After=multi-user.target
+After=graphical.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh /usr/libexec/kickstart-service.sh
+
+[Install]
+WantedBy=graphical.target
+WantedBy=multi-user.target
+
+EOF
+
+# Create a script with the actual test. Print errors to stdout.
+# IMPORTANT: This file should be rewritten in tests!
+touch /usr/libexec/kickstart-test.sh
+
+# Create a script for the service
+cat > /usr/libexec/kickstart-service.sh << 'EOF'
+
+# Check error messages in the syslog.
+error_messages="$(/bin/sh /usr/libexec/kickstart-test.sh)"
+
+if [[ ! -z "${error_messages}" ]]; then
+    echo "*** System has started with errors:" >> /root/RESULT
+    echo "${error_messages}" >> /root/RESULT
+fi
+
+# Validate the results.
+if [ ! -f /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+
+# Print the results.
+cat /root/RESULT
+
+# Make the syslog accessible after the test.
+# FIXME: Find a better way to do this.
+journalctl >> /var/log/anaconda/syslog
+
+# Stop the virtual machine.
+shutdown now
+
+EOF
+
+# Enable the systemd service.
+systemctl enable kickstart-test.service
+
+%end

--- a/ibft.sh
+++ b/ibft.sh
@@ -60,13 +60,6 @@ prepare_disks() {
     echo ""
 }
 
-additional_runner_args() {
-#--boot 'kernel=/usr/share/ipxe/ipxe.lkrn,kernel_args=ifconf -c dhcp net0 && chain http://10.34.39.2/trees/rv/ibft-tests/test2-m2/install.ipxe
-    . ${tmpdir}/httpd_url
-    ipxe_script_url="${httpd_url}${ipxe_script}"
-    echo "--boot kernel=${ipxe_image},kernel_args='ifconf -c dhcp net0 && chain ${ipxe_script_url}'"
-}
-
 boot_args() {
     . ${tmpdir}/httpd_url
     ipxe_script_url="${httpd_url}${ipxe_script}"

--- a/reboot-initial-setup-gui.ks.in
+++ b/reboot-initial-setup-gui.ks.in
@@ -1,0 +1,49 @@
+#version=DEVEL
+#test name: reboot-initial-setup-gui
+
+# Make sure that there is nothing else to configure.
+%ksappend users/user.ks
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
+
+# Reboot the installed system.
+reboot
+
+# Enable the initial setup.
+firstboot --enable
+
+# Run in the graphical mode.
+graphical
+
+%packages
+
+# Install the initial setup.
+initial-setup-gui
+
+# Install something that provides service(graphical-login).
+gdm
+
+# Don't install the initial setup addons.
+-subscription-manager-initial-setup-addon
+
+%end
+
+# Validate on the first boot.
+%ksappend validation/success_on_first_boot.ks
+
+%post
+
+# Remove EULA if any.
+rm /usr/share/redhat-release/EULA
+
+# Create a script with the first boot test.
+# Print errors to stdout.
+cat > /usr/libexec/kickstart-test.sh << EOF
+
+journalctl -g "Starting Initial Setup GUI" >/dev/null \
+|| echo "Failed to start Initial Setup GUI."
+
+journalctl -u initial-setup -g "Traceback" --quiet
+EOF
+
+%end

--- a/reboot-initial-setup-gui.sh
+++ b/reboot-initial-setup-gui.sh
@@ -1,0 +1,24 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+TESTTYPE="reboot initial-setup"
+
+. ${KSTESTDIR}/functions.sh
+
+additional_runner_args() {
+    echo "--wait"
+}

--- a/reboot-initial-setup-tui.ks.in
+++ b/reboot-initial-setup-tui.ks.in
@@ -1,0 +1,41 @@
+#version=DEVEL
+#test name: reboot-initial-setup-tui
+
+# Make sure that there is nothing else to configure.
+%ksappend users/user.ks
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
+
+# Reboot the installed system.
+reboot
+
+# Enable the initial setup.
+firstboot --enable
+
+%packages
+
+# Install the initial setup.
+initial-setup
+
+%end
+
+# Validate on the first boot.
+%ksappend validation/success_on_first_boot.ks
+
+%post
+
+# Remove EULA if any.
+rm /usr/share/redhat-release/EULA
+
+# Create a script with the first boot test.
+# Print errors to stdout.
+cat > /usr/libexec/kickstart-test.sh << EOF
+
+journalctl -g "Starting Initial Setup TUI" >/dev/null \
+|| echo "Failed to start Initial Setup TUI."
+
+journalctl -u initial-setup -g "Traceback" --quiet
+
+EOF
+
+%end

--- a/reboot-initial-setup-tui.sh
+++ b/reboot-initial-setup-tui.sh
@@ -1,0 +1,26 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+# FIXME: Enable the test for RHEL.
+TESTTYPE="reboot initial-setup fedora-only"
+
+. ${KSTESTDIR}/functions.sh
+
+additional_runner_args() {
+    echo "--wait"
+}

--- a/reboot.ks.in
+++ b/reboot.ks.in
@@ -1,0 +1,13 @@
+#version=DEVEL
+#test name: reboot
+
+# Use defaults.
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
+%ksappend payload/default_packages.ks
+
+# Reboot the installed system.
+reboot
+
+# Validate on the first boot.
+%ksappend validation/success_on_first_boot.ks

--- a/reboot.sh
+++ b/reboot.sh
@@ -1,0 +1,24 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+TESTTYPE="reboot"
+
+. ${KSTESTDIR}/functions.sh
+
+additional_runner_args() {
+    echo "--wait"
+}

--- a/scripts/launcher/lib/conf/configuration.py
+++ b/scripts/launcher/lib/conf/configuration.py
@@ -182,6 +182,7 @@ class VirtualConfiguration(BaseConfiguration):
         self._vnc = None
         self._kernel_args = None
         self._timeout = None
+        self._runner_args = []
 
     @property
     def test_name(self):
@@ -359,3 +360,13 @@ class VirtualConfiguration(BaseConfiguration):
     def timeout(self, value: int):
         """Set cancel installer after X minutes"""
         self._timeout = value
+
+    @property
+    def runner_args(self) -> list:
+        """Additional arguments to pass to virt-install"""
+        return self._runner_args
+
+    @runner_args.setter
+    def runner_args(self, value: list):
+        """Set additional arguments to pass to virt-install"""
+        self._runner_args = value

--- a/scripts/launcher/run_one_test.py
+++ b/scripts/launcher/run_one_test.py
@@ -160,6 +160,7 @@ class Runner(object):
         v_conf.timeout = 60
         v_conf.disk_paths = disk_args
         v_conf.networks = nics_args
+        v_conf.runner_args = self._shell.additional_runner_args()
 
         return v_conf
 

--- a/scripts/run_travis.sh
+++ b/scripts/run_travis.sh
@@ -31,8 +31,10 @@ network-static
 "
 fi
 
-# weed out duplicates, convert to space separated list, and limit to 6 tests (we can't run a lot of tests on Travis)
-TESTS=$(echo "$TESTS" | sort -u | head -n6 | xargs)
+# Limit to 6 tests (we can't run a lot of tests on Travis), weed out duplicates
+# and convert to space separated list. The changed tests should have precedence
+# over the representative tests.
+TESTS=$(echo "$TESTS" | head -n6 | sort -u | xargs)
 
 echo "Running tests: $TESTS"
 


### PR DESCRIPTION
It doesn't have to be pretty, it just needs to work.

Process the `additional_runner_args` bash function again to allow to specify
additional arguments for the `virt-install` tool. Remove the deprecated usage
of this function from the `ibft` test.

Test the reboot of the installed system with and without the initial setup.
Verify that the installed system boots without any errors or tracebacks.

Next steps:
* Optimize the initial setup tests for RHEL.
* Install the same version of anaconda as on the boot.iso.
* Apply the same updates image as on the boot.iso.
