### PR TITLE
Add a kickstart test that checks the Anaconda DBus modules

### DIFF
--- a/anaconda-modules.ks.in
+++ b/anaconda-modules.ks.in
@@ -1,0 +1,51 @@
+#version=DEVEL
+#test name: anaconda-modules
+
+# Verify that only the enabled Anaconda DBus modules are started.
+
+# Use defaults.
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
+%ksappend payload/default_packages.ks
+
+%post --nochroot
+
+# Get the activated Anaconda DBus modules.
+cat /tmp/syslog | grep "Activating service name" | \
+grep "org.fedoraproject.Anaconda.Modules" | cut -d"'" -f2 \
+| sort > /tmp/generated.out
+
+# Generate the expected output.
+cat > /tmp/expected.out << EOF
+org.fedoraproject.Anaconda.Modules.Localization
+org.fedoraproject.Anaconda.Modules.Network
+org.fedoraproject.Anaconda.Modules.Payloads
+org.fedoraproject.Anaconda.Modules.Security
+org.fedoraproject.Anaconda.Modules.Services
+org.fedoraproject.Anaconda.Modules.Storage
+org.fedoraproject.Anaconda.Modules.Subscription
+org.fedoraproject.Anaconda.Modules.Timezone
+org.fedoraproject.Anaconda.Modules.Users
+EOF
+
+# Drop the Subscription module if this is not RHEL.
+if [[ "@KSTEST_OS_NAME@" != "rhel" ]]; then
+    sed -i '/Subscription/d' /tmp/expected.out
+fi
+
+# Check the output
+diff /tmp/expected.out /tmp/generated.out
+
+if [[ $? != 0 ]]; then
+    echo "*** List of activated modules differs!" >> /mnt/sysroot/root/RESULT
+
+    echo "*** The following modules were expected:" >> /mnt/sysroot/root/RESULT
+    cat /tmp/expected.out >> /mnt/sysroot/root/RESULT
+
+    echo "*** The following modules were generated:" >> /mnt/sysroot/root/RESULT
+    cat /tmp/generated.out >> /mnt/sysroot/root/RESULT
+fi
+
+%end
+
+%ksappend validation/success_if_result_empty_standalone.ks

--- a/anaconda-modules.sh
+++ b/anaconda-modules.sh
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+TESTTYPE="anaconda"
+
+. ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Check modules that should (not) run in the current configuration.

**Related to:** https://github.com/rhinstaller/kickstart-tests/pull/462