### PR TITLE
Add support for modified updates images

### DIFF
--- a/anaconda-conf.ks.in
+++ b/anaconda-conf.ks.in
@@ -1,0 +1,42 @@
+#version=DEVEL
+#test name: anaconda-conf
+
+# Verify that the Anaconda configuration can be changed.
+
+# Use defaults.
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
+%ksappend payload/default_packages.ks
+
+%pre --erroronfail
+
+# Verify that the updates image is correctly applied.
+if [[ ! -f /etc/anaconda/conf.d/99-testing.conf ]]; then
+    echo "ERROR: configuration snippet doesn't exist!"
+    shutdown --now
+    exit 1
+fi
+
+%end
+
+%post --nochroot
+
+cat /tmp/anaconda.log \
+| grep "Writing a temporary configuration loaded from" \
+| grep "/etc/anaconda/conf.d/99-testing.conf"
+
+if [[ $? != 0 ]]; then
+    echo "*** the configuration file wasn't loaded:" >> /mnt/sysroot/root/RESULT
+fi
+
+cat /tmp/syslog \
+| grep "Storage check started with constraints" \
+| grep "'req_partition_sizes': {'/boot': Size (1024 MiB)}"
+
+if [[ $? != 0 ]]; then
+    echo "*** the configuration isn't correct:" >> /mnt/sysroot/root/RESULT
+fi
+
+%end
+
+%ksappend validation/success_if_result_empty_standalone.ks

--- a/anaconda-conf.sh
+++ b/anaconda-conf.sh
@@ -1,0 +1,53 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+TESTTYPE="anaconda"
+
+. ${KSTESTDIR}/functions.sh
+
+prepare_updates() {
+    local tmp_dir="${1}"
+    local updates_dir="${tmp_dir}/updates"
+    local updates_img="${tmp_dir}/updates.img"
+    local conf_dir="${updates_dir}/etc/anaconda/conf.d/"
+
+    # Define a configuration snippet.
+    mkdir -p "${conf_dir}"
+    cat > "${conf_dir}/99-testing.conf" <<EOF
+
+[Storage Constraints]
+
+# Required minimal sizes of partitions.
+req_partition_sizes =
+    /boot 1024 MiB
+
+EOF
+
+    # Apply the provided updates image if any.
+    apply_updates_image "${UPDATES}" "${updates_dir}"
+
+    # Create a new updates image.
+    create_updates_image "${updates_dir}" "${updates_img}"
+
+    # Provide the image. The function prints the URL.
+    upload_updates_image "${tmp_dir}" "${updates_img}"
+}
+
+cleanup() {
+    local tmp_dir="${1}"
+    stop_httpd "${tmp_dir}"
+}

--- a/functions.sh
+++ b/functions.sh
@@ -190,6 +190,14 @@ start_httpd() {
     echo "${httpd_url}" > ${tmpdir}/httpd_url
 }
 
+stop_httpd() {
+    local tmpdir=$1
+
+    if [ -f ${tmpdir}/httpd-pid ]; then
+        kill $(cat ${tmpdir}/httpd-pid)
+    fi
+}
+
 start_proxy() {
     local proxy_root=$1
     local config="squid.conf"

--- a/functions.sh
+++ b/functions.sh
@@ -49,6 +49,11 @@ prepare() {
     echo ${ks}
 }
 
+prepare_updates() {
+    local tmp_dir=$1
+    echo "${UPDATES}"
+}
+
 prepare_disks() {
     tmpdir=$1
 
@@ -259,4 +264,42 @@ remove_iscsi_target() {
     if [[ ${KEEPIT} == 1 ]]; then
         rm ${imgfile}
     fi
+}
+
+apply_updates_image() {
+    local image_url="${1}"
+    local updates_dir="${2}"
+
+    # Create the updates directory.
+    mkdir -p "${updates_dir}"
+
+    # Check the updates image.
+    if [[ -z "${image_url}" ]]; then
+        return
+    fi
+
+    # Download and extract the updates image.
+    ( cd "${updates_dir}" ; curl -f "${image_url}" | gzip -dc  | cpio -idu )
+}
+
+create_updates_image() {
+    local updates_dir="${1}"
+    local updates_img="${2}"
+
+    ( cd "${updates_dir}" ; find . | cpio -co | gzip -9 ) >"${updates_img}"
+}
+
+upload_updates_image() {
+    local tmp_dir="${1}"
+    local updates_img="${2}"
+
+    # Copy the updates image.
+    mkdir ${tmpdir}/http
+    cp "${updates_img}" ${tmpdir}/http/updates.img
+
+    # Start the http server.
+    start_httpd ${tmpdir}/http ${tmpdir}
+
+    # Provide the URL of the updates image.
+    echo "${httpd_url}updates.img"
 }

--- a/scripts/launcher/lib/launcher_interface.sh
+++ b/scripts/launcher/lib/launcher_interface.sh
@@ -96,6 +96,10 @@ case $1 in
         msg="$(prepare ${ks} ${tmpdir})"
         ret=$?
         ;;
+    prepare_updates)
+        msg="$(prepare_updates ${tmpdir})"
+        ret=$?
+        ;;
     prepare_disks)
         msg="$(prepare_disks ${tmpdir})"
         ret=$?

--- a/scripts/launcher/lib/shell_launcher.py
+++ b/scripts/launcher/lib/shell_launcher.py
@@ -79,13 +79,20 @@ class ProcessLauncher(object):
 
     def _report_result(self, subprocess_out):
         if not subprocess_out.check_ret_code():
-            msg = self._format_result(subprocess_out)
-            log.debug(msg)
+            msg = "Failed to run subprocess: '{}'\n".format(self._cmd)
+            msg += self._format_result(subprocess_out)
+
             if self._print_errors:
                 print(msg)
 
+            log.debug(msg)
+        else:
+            msg = self._format_result(subprocess_out)
+            log.debug(msg)
+
     def _format_result(self, subprocess_out):
-        msg = "Failed to run subprocess: '{}'\n".format(self._cmd)
+        msg = ""
+
         if subprocess_out.stderr:
             msg += "stderr:\n"
             msg += subprocess_out.stderr + "\n"
@@ -119,6 +126,11 @@ class ShellLauncher(ProcessLauncher):
 
     def cleanup(self):
         return self._run_shell_func("cleanup")
+
+    def prepare_updates(self):
+        out = self._run_shell_func("prepare_updates")
+        out.check_ret_code_with_exception()
+        return out.stdout
 
     def prepare_disks(self):
         out = self._run_shell_func("prepare_disks")

--- a/scripts/launcher/run_one_test.py
+++ b/scripts/launcher/run_one_test.py
@@ -130,6 +130,9 @@ class Runner(object):
         self._shell.cleanup()
 
     def _create_virtual_conf(self, log_path) -> VirtualConfiguration:
+        img_path = self._shell.prepare_updates()
+        self._conf.updates_img_path = img_path
+
         kernel_args = self._shell.kernel_args()
 
         if self._conf.updates_img_path:

--- a/scripts/run_travis.sh
+++ b/scripts/run_travis.sh
@@ -31,8 +31,10 @@ network-static
 "
 fi
 
-# weed out duplicates, convert to space separated list, and limit to 6 tests (we can't run a lot of tests on Travis)
-TESTS=$(echo "$TESTS" | sort -u | head -n6 | xargs)
+# Limit to 6 tests (we can't run a lot of tests on Travis), weed out duplicates
+# and convert to space separated list. The changed tests should have precedence
+# over the representative tests.
+TESTS=$(echo "$TESTS" | head -n6 | sort -u | xargs)
 
 echo "Running tests: $TESTS"
 


### PR DESCRIPTION
Allow kickstart tests to modify provided updates images.
Check that the installer loads the provided Anaconda configuration files.

**Related to:** https://github.com/rhinstaller/kickstart-tests/pull/462