### PR TITLE
Additional RPM repository support

### DIFF
--- a/reboot-initial-setup-gui.sh
+++ b/reboot-initial-setup-gui.sh
@@ -22,3 +22,13 @@ TESTTYPE="reboot initial-setup"
 additional_runner_args() {
     echo "--wait"
 }
+
+kernel_args() {
+    export_additional_repo $tmpdir
+    echo $(append_additional_repo_to_kernel_args $DEFAULT_BOOTOPTS)
+}
+
+cleanup() {
+    local tmp_dir="${1}"
+    stop_httpd "${tmp_dir}"
+}

--- a/reboot-initial-setup-tui.sh
+++ b/reboot-initial-setup-tui.sh
@@ -24,3 +24,13 @@ TESTTYPE="reboot initial-setup fedora-only"
 additional_runner_args() {
     echo "--wait"
 }
+
+kernel_args() {
+    export_additional_repo $tmpdir
+    echo $(append_additional_repo_to_kernel_args $DEFAULT_BOOTOPTS)
+}
+
+cleanup() {
+    local tmp_dir="${1}"
+    stop_httpd "${tmp_dir}"
+}


### PR DESCRIPTION
The first commit adds two library functions for working with additional RPM repositories for kickstart tests.

The second commit uses these library functions in the new Initial Setup reboot tests that need a latest Aanconda scratchbuild to work effectively.