### PR TITLE
Use local container image if is exists

### DIFF
--- a/containers/runner/README.md
+++ b/containers/runner/README.md
@@ -14,12 +14,6 @@ kickstart-tests directory in the runner container:
 
 Call `launch all` to run all tests. This can be controlled further through `--testtype` and/or `--skip-testtypes`, see `--help`.
 
-This will download the [automatically built](.github/workflows/container-autoupdate.yml) [official container image](https://quay.io/repository/rhinstaller/kstest-runner).
-
-You can also build the container yourself to test modifications to it:
-
-    podman build -t rhinstaller/kstest-runner .
-
 The `launch` script creates a `./data/` directory for passing of data between
 the container and the system (via volume).  By default it downloads the current
 Fedora Rawhide boot.iso, but to test some other image you can put it into
@@ -137,3 +131,16 @@ the graphical console for a virtual machine with a command:
 
 To change of the boot options for the tests (for example to add `inst.text`), please use
 `--run-args="--env KSTEST_EXTRA_BOOTOPTS=inst.text"` parameter for the `launch` script.
+
+## Building the runner container locally
+
+The `launch` script downloads the [automatically built](.github/workflows/container-autoupdate.yml) [official container image](https://quay.io/repository/rhinstaller/kstest-runner) by default.
+
+You can also build the container yourself to test modifications to it:
+
+    podman build -t rhinstaller/kstest-runner .
+
+The `launch` script prefers the locally built container image to the officially built one.
+Remove the locally built image to switch back to using the official container image:
+
+    podman image rm localhost/rhinstaller/kstest-runner

--- a/containers/runner/launch
+++ b/containers/runner/launch
@@ -9,7 +9,16 @@ set -eu
 BASEDIR=$(dirname $(dirname $(dirname $(realpath $0))))
 TEST_JOBS=${TEST_JOBS:-$(nproc)}
 CRUN=${CRUN:-$(which podman docker 2>/dev/null | head -n1)}
+
+# Set the container image to use.
+# If the rhinstaller/kstest-runner container image exists in the local registry, prefer it.
 CONTAINER=quay.io/rhinstaller/kstest-runner
+LOCAL_CONTAINER=localhost/rhinstaller/kstest-runner
+if $CRUN image inspect "$LOCAL_CONTAINER" &> /dev/null; then
+    CONTAINER="$LOCAL_CONTAINER"
+fi
+echo "INFO: Using container image: $CONTAINER"
+
 # Podman in rootless mode does not have access to /dev/kvm socket https://bugzilla.redhat.com/show_bug.cgi?id=1901462
 # disable selinux container separation when podman is executed as user
 PODMAN_SELINUX_FIX=


### PR DESCRIPTION
The container image created as descibed at the following page should be preferred to the official image:
https://github.com/rhinstaller/kickstart-tests/blob/master/containers/runner/README.md