### PR TITLE
Revert "Ignore "Call Trace:" in logs temporarily"

### DIFF
--- a/scripts/launcher/lib/log_monitor/log_handler.py
+++ b/scripts/launcher/lib/log_monitor/log_handler.py
@@ -31,8 +31,7 @@ class VirtualLogRequestHandler(LogRequestHandler):
         "CRIT mdadm:DegradedArray event detected",
 
         # Ignore a call trace during debugging.
-        # Enabled tempoarily for rhbz#1885978, rhbz#1893950
-        "Call Trace:"
+        # "Call Trace:"
     ]
 
     # Specify error lines you want to add on top


### PR DESCRIPTION
This reverts commit 58c4b426d7ac560def350cee670850b73c72f191.

The #1893950 should be fixed now.

But we will see if failing on "Call Trace:" will introduce too much noise.