### PR TITLE
Disable fedora-live-image-build test temporarily (#1926632)

### DIFF
--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -10,9 +10,9 @@ SCENARIO="$1"
 shift
 
 case "$SCENARIO" in
-    rawhide) $LAUNCH --skip-testtypes rhel-only,knownfailure "$@" all ;;
+    rawhide) $LAUNCH --skip-testtypes rhel-only,knownfailure,rhbz1926632 "$@" all ;;
     rawhide-text) $LAUNCH --skip-testtypes rhel-only,knownfailure --run-args '-eKSTEST_EXTRA_BOOTOPTS=inst.text' "$@" all ;;
-    daily-iso) $LAUNCH --skip-testtypes rhel-only,knownfailure --testtype packaging --daily-iso="$GITHUB_TOKEN" "$@" ;;
+    daily-iso) $LAUNCH --skip-testtypes rhel-only,knownfailure,rhbz1926632 --testtype packaging --daily-iso="$GITHUB_TOKEN" "$@" ;;
 
     rhel8)
         if [ ! -e data/images/boot.iso ]; then

--- a/fedora-live-image-build.sh
+++ b/fedora-live-image-build.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
-TESTTYPE="packaging fedora-only"
+TESTTYPE="packaging fedora-only rhbz1926632"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Disable fedora-live-image-build test until rhbz#1926632 is fixed.