### PR TITLE
Update network config for built iso

### DIFF
--- a/.github/defaults.sh
+++ b/.github/defaults.sh
@@ -1,3 +1,0 @@
-# The download.fedoraproject.org automatic redirector often selects download-ib01.f.o. for GitHub's cloud, which is too unreliable; use mirror from default scripts/defaults.sh configuration
-#export KSTEST_URL='--url=http://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/$basearch/os/'
-#export KSTEST_MODULAR_URL='http://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Modular/$basearch/os/'

--- a/.github/workflows/scenarios.yml
+++ b/.github/workflows/scenarios.yml
@@ -42,7 +42,7 @@ jobs:
         run: sudo containers/squid.sh start
 
       - name: Run scenario ${{ matrix.scenario }} in container
-        run: sudo --preserve-env=TEST_JOBS,GITHUB_TOKEN containers/runner/scenario ${{ matrix.scenario }} --defaults .github/defaults.sh
+        run: sudo --preserve-env=TEST_JOBS,GITHUB_TOKEN containers/runner/scenario ${{ matrix.scenario }}
 
       - name: Collect logs
         if: always()

--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -12,7 +12,7 @@ shift
 case "$SCENARIO" in
     rawhide) $LAUNCH --skip-testtypes rhel-only,knownfailure,rhbz1926632 "$@" all ;;
     rawhide-text) $LAUNCH --skip-testtypes rhel-only,knownfailure --run-args '-eKSTEST_EXTRA_BOOTOPTS=inst.text' "$@" all ;;
-    daily-iso) $LAUNCH --skip-testtypes rhel-only,knownfailure,rhbz1926632 --testtype packaging --daily-iso="$GITHUB_TOKEN" "$@" ;;
+    daily-iso) $LAUNCH --skip-testtypes rhel-only,knownfailure,rhbz1926632 --testtype packaging --daily-iso="$GITHUB_TOKEN" --defaults "$ROOTDIR/scripts/defaults-built-iso.sh" "$@" ;;
 
     rhel8)
         if [ ! -e data/images/boot.iso ]; then

--- a/scripts/defaults-built-iso.sh
+++ b/scripts/defaults-built-iso.sh
@@ -1,0 +1,15 @@
+# FIXME: Defaults for our custom built iso - the network device naming differs
+# from latest rawhide isos but seems to have other cause then
+# https://github.com/rhinstaller/kickstart-tests/issues/448
+# See https://github.com/rhinstaller/kickstart-tests/issues/482
+
+source scripts/defaults.sh
+# network device names
+NETDEV_PREFIX="ens"
+NETDEV_SUFFIX=""
+export KSTEST_NETDEV1=${NETDEV_PREFIX}3${NETDEV_SUFFIX}
+export KSTEST_NETDEV2=${NETDEV_PREFIX}4${NETDEV_SUFFIX}
+export KSTEST_NETDEV3=${NETDEV_PREFIX}5${NETDEV_SUFFIX}
+export KSTEST_NETDEV4=${NETDEV_PREFIX}6${NETDEV_SUFFIX}
+export KSTEST_NETDEV5=${NETDEV_PREFIX}7${NETDEV_SUFFIX}
+export KSTEST_NETDEV6=${NETDEV_PREFIX}8${NETDEV_SUFFIX}


### PR DESCRIPTION
A workaround addressing https://github.com/rhinstaller/kickstart-tests/issues/482 temporarily.
 - [ ] Needs testing.