### PR TITLE
Disable harddrive-install-tree[-relative] tests temporarily (#1935004)

### DIFF
--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -10,9 +10,9 @@ SCENARIO="$1"
 shift
 
 case "$SCENARIO" in
-    rawhide) $LAUNCH --skip-testtypes rhel-only,knownfailure,rhbz1928049 "$@" all ;;
+    rawhide) $LAUNCH --skip-testtypes rhel-only,knownfailure,rhbz1928049,rhbz1935004 "$@" all ;;
     rawhide-text) $LAUNCH --skip-testtypes rhel-only,knownfailure --run-args '-eKSTEST_EXTRA_BOOTOPTS=inst.text' "$@" all ;;
-    daily-iso) $LAUNCH --skip-testtypes rhel-only,knownfailure,rhbz1928049 --testtype packaging --daily-iso="$GITHUB_TOKEN" "$@" ;;
+    daily-iso) $LAUNCH --skip-testtypes rhel-only,knownfailure,rhbz1928049,rhbz1935004 --testtype packaging --daily-iso="$GITHUB_TOKEN" "$@" ;;
 
     rhel8)
         if [ ! -e data/images/boot.iso ]; then

--- a/harddrive-install-tree-relative.sh
+++ b/harddrive-install-tree-relative.sh
@@ -19,7 +19,7 @@
 
 # FIXME: fails on RHEL 8:
 # SourceSetupError: Nothing useful found for Hard drive ISO source at partition=/dev/sdb directory=/repo/
-TESTTYPE="packaging fedora-only"
+TESTTYPE="packaging fedora-only rhbz1935004"
 
 . ${KSTESTDIR}/harddrive-install-tree.sh
 

--- a/harddrive-install-tree.sh
+++ b/harddrive-install-tree.sh
@@ -19,7 +19,7 @@
 
 # FIXME: fails on RHEL 8:
 # SourceSetupError: Nothing useful found for Hard drive ISO source at partition=/dev/sdb directory=/repo/
-TESTTYPE=${TESTTYPE:-"packaging fedora-only"}
+TESTTYPE=${TESTTYPE:-"packaging fedora-only rhbz1935004"}
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Disable harddrive-install-tree[-relative] tests until rhbz#1935004 is fixed.