### PR TITLE
Change rawhide boot.iso job to run safely

### DIFF
--- a/.github/workflows/daily-boot-iso-rawhide.yml
+++ b/.github/workflows/daily-boot-iso-rawhide.yml
@@ -9,33 +9,83 @@ on:
 jobs:
   boot_iso:
     name: Build boot.iso
-    runs-on: ubuntu-latest
-    container:
-      image: fedora:rawhide
-      # lorax does mounts and uses loop devices, thus needs to be privileged
-      options: --privileged
-    steps:
-      - name: Install lorax
-        run: dnf install -y lorax
+    runs-on: [self-hosted, kstest]
+    env:
+      LORAX_BUILD_CONTAINER: fedora:rawhide
 
-      - name: Run lorax
+    steps:
+      - name: Clean up previous run
         run: |
+          sudo podman ps -q --all --filter='ancestor=kstest-runner' | xargs -tr sudo podman rm -f
+          sudo podman volume rm --all || true
+          sudo rm -rf * .git
+
+      - name: Check out kickstart-tests
+        uses: actions/checkout@v2
+        with:
+          repository: rhinstaller/kickstart-tests
+          path: kickstart-tests
+          fetch-depth: 0
+
+      - name: Ensure http proxy is running
+        run: sudo kickstart-tests/containers/squid.sh start
+
+      - name: Update container image used here
+        run: |
+          sudo podman pull ${{ env.LORAX_BUILD_CONTAINER }}
+
+      - name: Set up host loop devices
+        run: |
+          # We have to pre-create loop devices because they are not namespaced in kernel so
+          # podman can't access newly created ones. That caused failures of tests when runners
+          # were rebooted.
+          sudo mknod -m 0660 /dev/loop0 b 7 0  2> /dev/null || true
+          sudo mknod -m 0660 /dev/loop1 b 7 1  2> /dev/null || true
+
+      - name: Build boot.iso
+        run: |
+          mkdir -p /tmp/lorax-images
+          # /var/tmp tmpfs speeds up lorax and avoids https://bugzilla.redhat.com/show_bug.cgi?id=1906364
+          sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v /tmp/lorax-images:/images:z ${{ env.LORAX_BUILD_CONTAINER }} <<EOF
+          set -eux
+          echo "::group::Install lorax"
+          dnf install -y lorax
+          echo "::endgroup::"
+
+          # build boot.iso with our rpms
+          echo "::group::Build boot.iso with the RPMs"
           . /etc/os-release
           # The download.fedoraproject.org automatic redirector often selects download-ib01.f.o. for GitHub's cloud, which is too unreliable; use a mirror
           # The --volid argument can cause different network interface naming: https://github.com/rhinstaller/kickstart-tests/issues/448
-          lorax -p Fedora -v $VERSION_ID -r $VERSION_ID --volid Fedora-S-dvd-x86_64-rawh -s http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/ -s https://download.copr.fedorainfracloud.org/results/rpmsoftwaremanagement/dnf-nightly/fedora-rawhide-x86_64/ -s https://download.copr.fedorainfracloud.org/results/@rhinstaller/Anaconda/fedora-rawhide-x86_64/ -s https://copr-be.cloud.fedoraproject.org/results/@storage/blivet-daily/fedora-rawhide-x86_64/ /tmp/results
+          lorax -p Fedora -v \$VERSION_ID -r \$VERSION_ID --volid Fedora-S-dvd-x86_64-rawh \
+            -s http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/ \
+            -s https://download.copr.fedorainfracloud.org/results/rpmsoftwaremanagement/dnf-nightly/fedora-rawhide-x86_64/ \
+            -s https://download.copr.fedorainfracloud.org/results/@rhinstaller/Anaconda/fedora-rawhide-x86_64/ \
+            -s https://copr-be.cloud.fedoraproject.org/results/@storage/blivet-daily/fedora-rawhide-x86_64/ \
+            lorax
+          cp lorax/images/boot.iso /images/
+          cp *.txt /images/
+          cp *.log /images/
+          echo "::endgroup::"
+          EOF
+
+      - name: Tear down loop devices
+        if: always()
+        run: |
+          sudo losetup -d /dev/loop0 2> /dev/null || true
+          sudo losetup -d /dev/loop1 2> /dev/null || true
 
       - name: Upload log artifacts
         uses: actions/upload-artifact@v2
         with:
           name: logs
           path: |
-            *.log
-            *.txt
+            /tmp/lorax-images/*.log
+            /tmp/lorax-images/*.txt
 
       - name: Upload image artifacts
         uses: actions/upload-artifact@v2
         with:
           name: images
           path: |
-            /tmp/results/images/boot.iso
+            /tmp/lorax-images/boot.iso


### PR DESCRIPTION
This copies how boot.iso is built for kickstart tests in the anaconda repository.

Not tested yet.