### PR TITLE
Static unspec

### DIFF
--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -20,7 +20,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes fedora-only,knownfailure,rhel-8-failure --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
+        $LAUNCH --skip-testtypes fedora-only,knownfailure,rhel-8-failure,rhbz1910438 --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
         ;;
 
     # just run a single test on standard Rawhide; mostly for testing infrastructure

--- a/network-bootopts-static-unspec-bootif.ks.in
+++ b/network-bootopts-static-unspec-bootif.ks.in
@@ -1,0 +1,56 @@
+#test name: network-bootopts-static-unspec-bootif
+# Multiple interfaces, no interface specified in ip= static configuration, BOOTIF is used to choose the device
+# See rhbz#1910438, rhbz#1915493
+%ksappend repos/default.ks
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+%post --nochroot
+
+@KSINCLUDE@ post-nochroot-lib-network.sh
+
+pass_autoconnections_info_to_chroot
+
+check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@
+
+%end
+
+%post
+
+@KSINCLUDE@ post-lib-network.sh
+
+check_device_connected @KSTEST_NETDEV2@ yes
+
+detect_nm_has_autoconnections_off
+nm_has_autoconnections_off=$?
+if [[ $nm_has_autoconnections_off -eq 0 ]]; then
+    check_device_connected @KSTEST_NETDEV1@ no
+else
+    check_device_connected @KSTEST_NETDEV1@ yes
+fi
+
+
+check_device_config_value @KSTEST_NETDEV1@ IPADDR __NONE ipv4 method auto
+check_device_config_value @KSTEST_NETDEV2@ IPADDR @KSTEST_STATIC_IP@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@,@KSTEST_STATIC_GATEWAY@
+check_device_config_value @KSTEST_NETDEV2@ PREFIX @KSTEST_STATIC_PREFIX@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@,@KSTEST_STATIC_GATEWAY@
+check_device_config_value @KSTEST_NETDEV2@ GATEWAY @KSTEST_STATIC_GATEWAY@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@,@KSTEST_STATIC_GATEWAY@
+check_device_config_value @KSTEST_NETDEV2@ DNS1 @KSTEST_STATIC_DNS1@ ipv4 dns "@KSTEST_STATIC_DNS1@;"
+check_device_ipv4_address @KSTEST_NETDEV2@ @KSTEST_STATIC_IP@
+
+# No error was written to /root/RESULT file, everything is OK
+if [[ ! -e /root/RESULT ]]; then
+   echo SUCCESS > /root/RESULT
+fi
+%end

--- a/network-bootopts-static-unspec-bootif.sh
+++ b/network-bootopts-static-unspec-bootif.sh
@@ -1,0 +1,53 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
+
+# This is actually testing application of kickstart network commands in
+# anaconda (which would normally be triggered by defining networking in %pre
+# and %including it into kickstart).  It is caused by network kickstart
+# commands not being applied in dracut because for ks=file:/ks.cfg (kickstart
+# injected in initrd) network devices are not found in sysfs in the time of
+# parsing the kickstart.
+
+TESTTYPE="network"
+
+. ${KSTESTDIR}/functions.sh
+
+ip_static_boot_config=""
+
+kernel_args() {
+    . ${tmpdir}/ip_static_boot_config
+    echo ${DEFAULT_BOOTOPTS} ${ip_static_boot_config} BOOTIF=52-54-00-12-34-61
+}
+
+prepare() {
+    local ks=$1
+
+    # This is a private slirp network, so we can pick any config we like
+    sed -i -e 's#@KSTEST_STATIC_IP@#10.0.2.200#g' -e 's#@KSTEST_STATIC_PREFIX@#24#g' -e 's#@KSTEST_STATIC_GATEWAY@#10.0.2.2#g' -e 's#@KSTEST_STATIC_DNS1@#10.0.2.3#g' ${ks}
+    echo "ip_static_boot_config=ip=10.0.2.200::10.0.2.2:255.255.255.0:::none:10.0.2.3" > ${tmpdir}/ip_static_boot_config
+
+
+    echo ${ks}
+}
+
+# Arguments for virt-install --network options
+prepare_network() {
+    echo "user"
+    echo "user,mac=52:54:00:12:34:61"
+}

--- a/network-bootopts-static-unspec-bootif.sh
+++ b/network-bootopts-static-unspec-bootif.sh
@@ -24,7 +24,7 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
-TESTTYPE="network"
+TESTTYPE="network rhbz1910438"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/network-bootopts-static-unspec-single.ks.in
+++ b/network-bootopts-static-unspec-single.ks.in
@@ -1,0 +1,45 @@
+#test name: network-bootopts-static-unspec-single
+# No interface specified in ip= static configuration and there is only single device available
+# (eg others can have no carrier but in this test there is just a single interface).
+# See rhbz#1915493
+%ksappend repos/default.ks
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+%post --nochroot
+
+@KSINCLUDE@ post-nochroot-lib-network.sh
+
+check_gui_configurations @KSTEST_NETDEV1@
+
+%end
+
+%post
+
+@KSINCLUDE@ post-lib-network.sh
+
+check_device_connected @KSTEST_NETDEV1@ yes
+
+check_device_config_value @KSTEST_NETDEV1@ IPADDR @KSTEST_STATIC_IP@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@,@KSTEST_STATIC_GATEWAY@
+check_device_config_value @KSTEST_NETDEV1@ PREFIX @KSTEST_STATIC_PREFIX@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@,@KSTEST_STATIC_GATEWAY@
+check_device_config_value @KSTEST_NETDEV1@ GATEWAY @KSTEST_STATIC_GATEWAY@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@,@KSTEST_STATIC_GATEWAY@
+check_device_config_value @KSTEST_NETDEV1@ DNS1 @KSTEST_STATIC_DNS1@ ipv4 dns "@KSTEST_STATIC_DNS1@;"
+check_device_ipv4_address @KSTEST_NETDEV1@ @KSTEST_STATIC_IP@
+
+# No error was written to /root/RESULT file, everything is OK
+if [[ ! -e /root/RESULT ]]; then
+   echo SUCCESS > /root/RESULT
+fi
+%end

--- a/network-bootopts-static-unspec-single.sh
+++ b/network-bootopts-static-unspec-single.sh
@@ -1,0 +1,52 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
+
+# This is actually testing application of kickstart network commands in
+# anaconda (which would normally be triggered by defining networking in %pre
+# and %including it into kickstart).  It is caused by network kickstart
+# commands not being applied in dracut because for ks=file:/ks.cfg (kickstart
+# injected in initrd) network devices are not found in sysfs in the time of
+# parsing the kickstart.
+
+TESTTYPE="network"
+
+. ${KSTESTDIR}/functions.sh
+
+ip_static_boot_config=""
+
+kernel_args() {
+    . ${tmpdir}/ip_static_boot_config
+    echo ${DEFAULT_BOOTOPTS} ${ip_static_boot_config}
+}
+
+prepare() {
+    local ks=$1
+
+    # This is a private slirp network, so we can pick any config we like
+    sed -i -e 's#@KSTEST_STATIC_IP@#10.0.2.200#g' -e 's#@KSTEST_STATIC_PREFIX@#24#g' -e 's#@KSTEST_STATIC_GATEWAY@#10.0.2.2#g' -e 's#@KSTEST_STATIC_DNS1@#10.0.2.3#g' ${ks}
+    echo "ip_static_boot_config=ip=10.0.2.200::10.0.2.2:255.255.255.0:::none:10.0.2.3" > ${tmpdir}/ip_static_boot_config
+
+
+    echo ${ks}
+}
+
+# Arguments for virt-install --network options
+prepare_network() {
+    echo "user"
+}

--- a/network-bootopts-static-unspec-single.sh
+++ b/network-bootopts-static-unspec-single.sh
@@ -24,7 +24,7 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
-TESTTYPE="network"
+TESTTYPE="network rhbz1910438"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/network-bootopts-static.ks.in
+++ b/network-bootopts-static.ks.in
@@ -1,0 +1,43 @@
+#test name: network-bootopts-static
+# Static configuration of single interface via boot options
+%ksappend repos/default.ks
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+%post --nochroot
+
+@KSINCLUDE@ post-nochroot-lib-network.sh
+
+check_gui_configurations @KSTEST_NETDEV1@
+
+%end
+
+%post
+
+@KSINCLUDE@ post-lib-network.sh
+
+check_device_connected @KSTEST_NETDEV1@ yes
+
+check_device_config_value @KSTEST_NETDEV1@ IPADDR @KSTEST_STATIC_IP@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@,@KSTEST_STATIC_GATEWAY@
+check_device_config_value @KSTEST_NETDEV1@ PREFIX @KSTEST_STATIC_PREFIX@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@,@KSTEST_STATIC_GATEWAY@
+check_device_config_value @KSTEST_NETDEV1@ GATEWAY @KSTEST_STATIC_GATEWAY@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@,@KSTEST_STATIC_GATEWAY@
+check_device_config_value @KSTEST_NETDEV1@ DNS1 @KSTEST_STATIC_DNS1@ ipv4 dns "@KSTEST_STATIC_DNS1@;"
+check_device_ipv4_address @KSTEST_NETDEV1@ @KSTEST_STATIC_IP@
+
+# No error was written to /root/RESULT file, everything is OK
+if [[ ! -e /root/RESULT ]]; then
+   echo SUCCESS > /root/RESULT
+fi
+%end

--- a/network-bootopts-static.sh
+++ b/network-bootopts-static.sh
@@ -1,0 +1,51 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
+
+# This is actually testing application of kickstart network commands in
+# anaconda (which would normally be triggered by defining networking in %pre
+# and %including it into kickstart).  It is caused by network kickstart
+# commands not being applied in dracut because for ks=file:/ks.cfg (kickstart
+# injected in initrd) network devices are not found in sysfs in the time of
+# parsing the kickstart.
+
+TESTTYPE="network"
+
+. ${KSTESTDIR}/functions.sh
+
+ip_static_boot_config=""
+
+kernel_args() {
+    . ${tmpdir}/ip_static_boot_config
+    echo ${DEFAULT_BOOTOPTS} ${ip_static_boot_config}
+}
+
+prepare() {
+    local ks=$1
+
+    # This is a private slirp network, so we can pick any config we like
+    sed -i -e 's#@KSTEST_STATIC_IP@#10.0.2.200#g' -e 's#@KSTEST_STATIC_PREFIX@#24#g' -e 's#@KSTEST_STATIC_GATEWAY@#10.0.2.2#g' -e 's#@KSTEST_STATIC_DNS1@#10.0.2.3#g' ${ks}
+    echo "ip_static_boot_config=ip=10.0.2.200::10.0.2.2:255.255.255.0::${KSTEST_NETDEV1}:none:10.0.2.3" > ${tmpdir}/ip_static_boot_config
+
+    echo ${ks}
+}
+
+# Arguments for virt-install --network options
+prepare_network() {
+    echo "user"
+}


### PR DESCRIPTION
I am using rhel-8-failure instead of rhbz#BZNUM tag for tests disabling because the related BZ is assigned to NetworkManager and on Anaconda side the cases from the BZ are fixed upstream.