### PR TITLE
Don't use the modular repo for the module-ignoremissing test

### DIFF
--- a/module-ignoremissing.ks.in
+++ b/module-ignoremissing.ks.in
@@ -6,7 +6,6 @@
 # - that such an installation finishes successfully
 
 %ksappend repos/default.ks
-%ksappend repos/modular.ks
 %ksappend common/common_no_payload.ks
 
 %packages --ignoremissing


### PR DESCRIPTION
The test doesn't really need this repo and it should be able work on Fedora and RHEL without it.