### PR TITLE
Remove obsolete rhbz tag from module tests

### DIFF
--- a/groups-and-envs-1.sh
+++ b/groups-and-envs-1.sh
@@ -18,6 +18,6 @@
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
 # FIXME: times out on rhel8
-TESTTYPE="packaging fedora-only rhbz1928049"
+TESTTYPE="packaging fedora-only"
 
 . ${KSTESTDIR}/functions.sh

--- a/groups-and-envs-2.sh
+++ b/groups-and-envs-2.sh
@@ -18,6 +18,6 @@
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
 # FIXME: times out on rhel8
-TESTTYPE="packaging fedora-only rhbz1928049"
+TESTTYPE="packaging fedora-only"
 
 . ${KSTESTDIR}/functions.sh

--- a/module-1.sh
+++ b/module-1.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
-TESTTYPE="packaging modularity fedora-only rhbz1928049"
+TESTTYPE="packaging modularity fedora-only"
 
 . ${KSTESTDIR}/functions.sh

--- a/module-2.sh
+++ b/module-2.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
-TESTTYPE="packaging modularity fedora-only rhbz1928049"
+TESTTYPE="packaging modularity fedora-only"
 
 . ${KSTESTDIR}/functions.sh

--- a/module-3.sh
+++ b/module-3.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
-TESTTYPE="packaging modularity fedora-only rhbz1928049"
+TESTTYPE="packaging modularity fedora-only"
 
 . ${KSTESTDIR}/functions.sh

--- a/module-4.sh
+++ b/module-4.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="packaging modularity fedora-only rhbz1928049"
+TESTTYPE="packaging modularity fedora-only"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Follow-up of
commit 36041a22b98842be6e3cc04f47743e9e7b3facf2