### PR TITLE
Mark fedora-live-image-build as knownfailure (#1926632)

### DIFF
--- a/fedora-live-image-build.sh
+++ b/fedora-live-image-build.sh
@@ -17,6 +17,7 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
-TESTTYPE="packaging fedora-only"
+# https://bugzilla.redhat.com/show_bug.cgi?id=1926632#c7
+TESTTYPE="packaging fedora-only knownfailure"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
The test runs too long (~10 mins more then 1h timeout).
See https://bugzilla.redhat.com/show_bug.cgi?id=1926632#c7

We might reenable it with higher timeout set if we add support for per-test
timout setting in the future.