### PR TITLE
Per test timeout support

### DIFF
--- a/fedora-live-image-build.sh
+++ b/fedora-live-image-build.sh
@@ -21,3 +21,11 @@
 TESTTYPE="packaging fedora-only knownfailure"
 
 . ${KSTESTDIR}/functions.sh
+
+# This rest effectively builds a Fedora live image, which
+# among other things installs 1600+ packages and does various
+# fairly resource intensive tasks. So bump the timeout
+# to give it more time to do what's needed.
+get_timeout() {
+    echo "120"
+}

--- a/functions.sh
+++ b/functions.sh
@@ -382,3 +382,7 @@ append_additional_repo_to_kernel_args() {
         echo $bootopts
     fi
 }
+
+get_timeout() {
+    echo "60"
+}

--- a/scripts/launcher/lib/launcher_interface.sh
+++ b/scripts/launcher/lib/launcher_interface.sh
@@ -120,6 +120,10 @@ case $1 in
         msg="$(additional_runner_args)"
         ret=$?
         ;;
+    get_timeout)
+        msg="$(get_timeout)"
+        ret=$?
+        ;;
     validate)
         msg="$(validate ${tmpdir})"
         ret=$?

--- a/scripts/launcher/lib/shell_launcher.py
+++ b/scripts/launcher/lib/shell_launcher.py
@@ -175,6 +175,18 @@ class ShellLauncher(ProcessLauncher):
         out.check_ret_code_with_exception()
         return out.stdout_as_array
 
+    def get_timeout(self):
+        """Per test timeout override.
+
+        The value returned by the get_timeout() function should be
+        a string representing an integer value that sets how long
+        should we wait for a test to finish in minutes.
+        """
+        out = self._run_shell_func("get_timeout")
+
+        out.check_ret_code_with_exception()
+        return out.stdout
+
     def validate(self):
         return self._run_shell_func("validate")
 

--- a/scripts/launcher/run_one_test.py
+++ b/scripts/launcher/run_one_test.py
@@ -135,6 +135,9 @@ class Runner(object):
 
         kernel_args = self._shell.kernel_args()
 
+        timeout_string = self._shell.get_timeout()
+        timeout = int(timeout_string)
+
         if self._conf.updates_img_path:
             kernel_args += " inst.updates={}".format(self._conf.updates_img_path)
 
@@ -160,7 +163,7 @@ class Runner(object):
         v_conf.log_path = log_path
         v_conf.vnc = "vnc,listen=0.0.0.0"
         v_conf.boot_image = boot_args
-        v_conf.timeout = 60
+        v_conf.timeout = timeout
         v_conf.disk_paths = disk_args
         v_conf.networks = nics_args
         v_conf.runner_args = self._shell.additional_runner_args()


### PR DESCRIPTION
The first commit adds support for defining a per-test timeout override.

The second commit uses this new feature to set a 120 minute timeout for the Fedora live image build kickstart test.

A couple notes about thing's I'm not 100% sure about with this:
- what do you think about calling the bash function used for this `timeout()` ? any other suggestions ?
- what about input validation (so far we only split output from the bash functions in lists at most) ?
  - should we put the integer parsing into a try/except block and report issues or is this too niche for us to care ?
  - is the parsing to integers in the right place or would it be better to have it as a generic method in the `ShellOutput` class ?
