### PR TITLE
Re enable network device bootif httpks

### DIFF
--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -10,9 +10,9 @@ SCENARIO="$1"
 shift
 
 case "$SCENARIO" in
-    rawhide) $LAUNCH --skip-testtypes rhel-only,knownfailure,rhbz1949394 "$@" all ;;
-    rawhide-text) $LAUNCH --skip-testtypes rhel-only,knownfailure, --run-args '-eKSTEST_EXTRA_BOOTOPTS=inst.text' "$@" all ;;
-    daily-iso) $LAUNCH --skip-testtypes rhel-only,knownfailure,rhbz1949394 --testtype packaging --daily-iso="$GITHUB_TOKEN" "$@" ;;
+    rawhide) $LAUNCH --skip-testtypes rhel-only,knownfailure "$@" all ;;
+    rawhide-text) $LAUNCH --skip-testtypes rhel-only,knownfailure --run-args '-eKSTEST_EXTRA_BOOTOPTS=inst.text' "$@" all ;;
+    daily-iso) $LAUNCH --skip-testtypes rhel-only,knownfailure --testtype packaging --daily-iso="$GITHUB_TOKEN" "$@" ;;
 
     rhel8)
         if [ ! -e data/images/boot.iso ]; then

--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -20,7 +20,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes fedora-only,knownfailure,rhel-8-failure,rhbz1940504 --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
+        $LAUNCH --skip-testtypes fedora-only,knownfailure,rhel-8-failure --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
         ;;
 
     # just run a single test on standard Rawhide; mostly for testing infrastructure

--- a/network-device-bootif-httpks.sh
+++ b/network-device-bootif-httpks.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE="network rhbz1940504"
+TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/network-device-bootif-httpks.sh
+++ b/network-device-bootif-httpks.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE="network rhbz1940504 rhbz1949394"
+TESTTYPE="network rhbz1940504"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
"update to an early 1.32 snapshot (1.31.3)" both in rhel and fedora