### PR TITLE
Switch bond= and ip= order in network-bootopts-bond-dhcp-httpks

### DIFF
--- a/network-bootopts-bond-dhcp-httpks.sh
+++ b/network-bootopts-bond-dhcp-httpks.sh
@@ -23,7 +23,7 @@ TESTTYPE=${TESTTYPE:-"network"}
 
 kernel_args() {
     . ${tmpdir}/ks_url
-    echo ${DEFAULT_BOOTOPTS} ip=${KSTEST_NETDEV1}:dhcp ip=bond0:dhcp bond=bond0:${KSTEST_NETDEV2},${KSTEST_NETDEV3}:mode=active-backup,primary=${KSTEST_NETDEV2} inst.ks=${ks_url}
+    echo ${DEFAULT_BOOTOPTS} ip=${KSTEST_NETDEV1}:dhcp bond=bond0:${KSTEST_NETDEV2},${KSTEST_NETDEV3}:mode=active-backup,primary=${KSTEST_NETDEV2} ip=bond0:dhcp inst.ks=${ks_url}
 }
 
 # Arguments for virt-install --network options


### PR DESCRIPTION
There is an anaconda traceback in RHEL-8.3 (bug [1912898](https://bugzilla.redhat.com/show_bug.cgi?id=1912898)) when the bond= boot argument is placed before ip= on the kernel command line.
Switch the boot arguments order to cover the linked bug.

Related: rhbz#1912898

Q: do we want to change the original test or create a new test with switched arguments?