### PR TITLE
Add tests for deprecated commands in RHEL-9

### DIFF
--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -20,7 +20,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes fedora-only,knownfailure,rhel-8-failure --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
+        $LAUNCH --skip-testtypes fedora-only,knownfailure,rhel-8-failure,rhel-9-only --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
         ;;
 
     rhel9)

--- a/deprecated-rhel9-part1.ks.in
+++ b/deprecated-rhel9-part1.ks.in
@@ -1,0 +1,77 @@
+#version=DEVEL
+#test name: deprecated-logging-level
+%ksappend repos/default.ks
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+autopart
+
+keyboard us
+lang en_US.UTF-8
+timezone --nontp Europe/Prague
+rootpw testcase
+shutdown
+
+repo --ignoregroups 1 --name=epel8 --install --baseurl=https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/
+
+%packages --instLangs cs --excludeWeakdeps --timeout 42
+%end
+
+logging --level debug --host thisdoesntexist.example.com
+
+%anaconda
+pwpolicy root --minlen=6 --notempty
+%end
+
+%post --nochroot
+# Check logging --level
+if ! $(grep -q "KickstartDeprecationWarning: Ignoring deprecated option on line [0-9]*: The --level option has been deprecated" /tmp/anaconda.log); then
+    echo 'Deprecation warning is missing for logging --level' > /mnt/sysroot/root/RESULT
+fi
+if ! $(grep -q thisdoesntexist.example.com /etc/rsyslog.conf); then
+    echo 'Command logging ignored not deprecated option "host"' > /mnt/sysroot/root/RESULT
+fi
+# Check %packages --instLangs --excludeWeakdeps
+if ! $(grep -q "KickstartParseWarning: The --instLangs option on line [0-9]* will be deprecated in future releases" /tmp/anaconda.log); then
+    echo 'Deprecation warning is missing for %packages --instLangs' > /mnt/sysroot/root/RESULT
+fi
+if ! $(grep -q "KickstartParseWarning: The --excludeWeakdeps option on line [0-9]* will be deprecated in future releases" /tmp/anaconda.log); then
+    echo 'Deprecation warning is missing for %packages --excludeWeakdeps' > /mnt/sysroot/root/RESULT
+fi
+if ! $(awk '/DNF configuration:/,/^$/' /tmp/anaconda.log | grep -q "timeout = 42"); then
+    echo 'Command %packages ignored not deprecated option "timeout"' > /mnt/sysroot/root/RESULT
+fi
+# Check %anaconda pwpolicy
+if ! $(grep -q "KickstartDeprecationWarning: The %%anaconda section has been deprecated" /tmp/anaconda.log); then
+    echo 'Deprecation warning is missing for %anaconda' > /mnt/sysroot/root/RESULT
+fi
+if ! $(grep -q "KickstartDeprecationWarning: The pwpolicy command has been deprecated" /tmp/anaconda.log); then
+    echo 'Deprecation warning is missing for pwpolicy' > /mnt/sysroot/root/RESULT
+fi
+# Check repo --ignoregroups
+if ! $(grep -q "KickstartDeprecationWarning: Ignoring deprecated option on line [0-9]*: The --ignoregroups option has been deprecated" /tmp/anaconda.log); then
+    echo 'Deprecation warning is missing for repo --ignoregroups' > /mnt/sysroot/root/RESULT
+fi
+# Check timezone --nontp
+if ! $(grep -q "KickstartParseWarning: The option --nontp will be deprecated in future releases." /tmp/anaconda.log); then
+    echo 'Deprecation warning is missing for timezone --nontp' > /mnt/sysroot/root/RESULT
+fi
+%end
+
+%post
+# Check repo --ignoregroups
+if [ ! -e /etc/yum.repos.d/epel8.repo ]; then
+    echo 'Command repo ignored not deprecated options' > /root/RESULT
+fi
+# Check timezone --nontp
+if ! $(ls -l /etc/localtime | grep -q "Europe/Prague"); then
+    echo 'Command timezone ignored not deprecated options' > /root/RESULT
+fi
+
+# No error was written to /root/RESULT file, everything is OK
+if [[ ! -e /root/RESULT ]]; then
+    echo SUCCESS > /root/RESULT
+fi
+%end

--- a/deprecated-rhel9-part1.sh
+++ b/deprecated-rhel9-part1.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Zdenek Veleba <zveleba@redhat.com>
+
+TESTTYPE="deprecated rhel-only rhel-9-only"
+
+. ${KSTESTDIR}/functions.sh

--- a/deprecated-rhel9-part2.ks.in
+++ b/deprecated-rhel9-part2.ks.in
@@ -1,0 +1,35 @@
+#version=DEVEL
+#test name: deprecated-timezone-ntpservers
+%ksappend repos/default.ks
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+autopart
+
+keyboard us
+lang en_US.UTF-8
+timezone --ntpservers ntp.example.com Europe/Prague
+rootpw testcase
+shutdown
+
+%packages
+%end
+
+%post --nochroot
+if ! $(grep -q "KickstartParseWarning: The option --ntpservers will be deprecated in future releases." /tmp/anaconda.log); then
+    echo 'Deprecation warning is missing for timezone --ntpservers' > /mnt/sysroot/root/RESULT
+fi
+%end
+
+%post
+if ! $(ls -l /etc/localtime | grep -q "Europe/Prague"); then
+    echo 'Command timezone ignored not deprecated options' > /root/RESULT
+fi
+
+# No error was written to /root/RESULT file, everything is OK
+if [[ ! -e /root/RESULT ]]; then
+    echo SUCCESS > /root/RESULT
+fi
+%end

--- a/deprecated-rhel9-part2.sh
+++ b/deprecated-rhel9-part2.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Zdenek Veleba <zveleba@redhat.com>
+
+TESTTYPE="deprecated rhel-only rhel-9-only"
+
+. ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
These new tests check that correct warning message is shown when deprecated command/option is used and rest of the command still works.

There is a potential issue that should be cleared up before merging: https://bugzilla.redhat.com/show_bug.cgi?id=1959486