### PR TITLE
Fix the proxy tests

### DIFF
--- a/lib/basic_squid_auth.py
+++ b/lib/basic_squid_auth.py
@@ -66,7 +66,7 @@ def main(user, password, debug_fd=None):
     """ Main program loop. """
     try:
         while True:
-            r_in = raw_input()
+            r_in = input()
             write_debug("Test credentials: %s -- " % r_in.rstrip(), debug_fd=debug_fd)
             (in_user, in_password) = r_in.strip().split(' ')
             if in_user == user and in_password == password:

--- a/proxy-auth.sh
+++ b/proxy-auth.sh
@@ -88,11 +88,7 @@ validate() {
 }
 
 cleanup() {
-    tmpdir=$1
-
-    if [ -f ${tmpdir}/httpd-pid ]; then
-        kill $(cat ${tmpdir}/httpd-pid)
-    fi
-
-    stop_proxy ${tmpdir}/proxy
+    local tmp_dir="${1}"
+    stop_httpd "${tmp_dir}"
+    stop_proxy "${tmp_dir}/proxy"
 }

--- a/proxy-cmdline.sh
+++ b/proxy-cmdline.sh
@@ -58,3 +58,8 @@ validate() {
         return 0
     fi
 }
+
+cleanup() {
+    local tmp_dir="${1}"
+    stop_proxy "${tmp_dir}/proxy"
+}

--- a/proxy-kickstart.sh
+++ b/proxy-kickstart.sh
@@ -84,11 +84,7 @@ validate() {
 }
 
 cleanup() {
-    tmpdir=$1
-
-    if [ -f ${tmpdir}/httpd-pid ]; then
-        kill $(cat ${tmpdir}/httpd-pid)
-    fi
-
-    stop_proxy ${tmpdir}/proxy
+    local tmp_dir="${1}"
+    stop_httpd "${tmp_dir}"
+    stop_proxy "${tmp_dir}/proxy"
 }

--- a/scripts/confs/squid-pass.conf
+++ b/scripts/confs/squid-pass.conf
@@ -17,12 +17,13 @@ acl localnet src 192.168.0.0/16		# RFC 1918 local private network (LAN)
 
 acl Safe_ports port 80			# http
 acl Safe_ports port 443			# https
+acl Safe_ports port 40000-41000	# our_http
 acl CONNECT method CONNECT
 
 # We have to use -u here. Without it, sys.stdin will behave as block buffered which
 # means we don't get input after \n.
 auth_param basic program /usr/bin/python3 -u @TMP_DIR@/basic_squid_auth.py -d @TMP_DIR@/squid_auth.pass
-auth_param basic children 5
+auth_param basic children 5 startup=5 idle=1
 
 # All users must authenticate to proxy
 acl auth proxy_auth REQUIRED
@@ -62,12 +63,16 @@ http_access deny all
 http_port 0.0.0.0:@PROXY_PORT@
 
 # Leave coredumps in the first cache dir
-coredump_dir /tmp/squid/
+coredump_dir @TMP_DIR@
 
 # Set folders to our test directory
 pid_filename @TMP_DIR@/squid.pid
 cache_access_log @TMP_DIR@/access.log
 cache_log @TMP_DIR@/cache.log
+debug_options ALL,6
 
 # Disable caching
 cache deny all
+
+# Only use IPv4.
+dns_v4_first on

--- a/scripts/confs/squid.conf
+++ b/scripts/confs/squid.conf
@@ -53,12 +53,16 @@ http_access deny all
 http_port 0.0.0.0:@PROXY_PORT@
 
 # Leave coredumps in the first cache dir
-coredump_dir /tmp/squid/
+coredump_dir @TMP_DIR@
 
 # Set folders to our test directory
 pid_filename @TMP_DIR@/squid.pid
 cache_access_log @TMP_DIR@/access.log
 cache_log @TMP_DIR@/cache.log
+debug_options ALL,6
 
 # Disable caching
 cache deny all
+
+# Only use IPv4.
+dns_v4_first on


### PR DESCRIPTION
The `proxy-kickstart` and `proxy-auth` tests are still not working. However, they seem to end with the same error now. These are the only tests that start a proxy server and a http server (using `start_httpd` and `start_proxy`).

The installer fails to load the additional repository because of `Timeout was reached for http://10.0.2.2:40000/repodata/repomd.xml [Operation too slow. Less than 1000 bytes/sec transferred the last 30 seconds]`. However, the download from `dl.fedoraproject.org` is successful, so the problem seems to be with accessing our http server.

From virt-install.log:
```
12:59:02,868 INFO anaconda:librepo: Downloading: https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/a8810e07b9ff1f25ebc9df03c2a2fbbf4dbd07701a0679cd5ea92f330157722f-primary.xml.zck
12:59:49,973 INFO anaconda:librepo: Downloading: http://10.0.2.2:40000/repodata/repomd.xml
13:00:21,832 INFO anaconda:librepo: Serious error - Curl code (28): Timeout was reached for http://10.0.2.2:40000/repodata/repomd.xml [Operation too slow. Less than 1000 bytes/sec transferred the last 30 seconds]
13:00:21,836 INFO anaconda:librepo: Error during transfer: Curl error (28): Timeout was reached for http://10.0.2.2:40000/repodata/repomd.xml [Operation too slow. Less than 1000 bytes/sec transferred the last 30 seconds]
```
From the access.log:
```
1620910739.658    368 127.0.0.1 TCP_TUNNEL/200 6855 CONNECT dl.fedoraproject.org:443 - HIER_DIRECT/38.145.60.24 -
1620910741.009   1327 127.0.0.1 TCP_TUNNEL/200 11590 CONNECT dl.fedoraproject.org:443 - HIER_DIRECT/38.145.60.24 -
1620910747.186   6164 127.0.0.1 TCP_TUNNEL/200 1762803 CONNECT dl.fedoraproject.org:443 - HIER_DIRECT/38.145.60.24 -
1620910777.308  36288 127.0.0.1 TCP_TUNNEL/200 16989120 CONNECT dl.fedoraproject.org:443 - HIER_DIRECT/38.145.60.24 -
1620910791.380  50359 127.0.0.1 TCP_TUNNEL/200 41323582 CONNECT dl.fedoraproject.org:443 - HIER_DIRECT/38.145.60.24 -
1620910821.887  30001 127.0.0.1 TCP_MISS_ABORTED/000 0 GET http://10.0.2.2:40000/repodata/repomd.xml - HIER_DIRECT/10.0.2.2 -
1620910851.897  30001 127.0.0.1 TCP_MISS_ABORTED/000 0 GET http://10.0.2.2:40000/repodata/repomd.xml - HIER_DIRECT/10.0.2.2 -
1620910881.896  29982 127.0.0.1 TCP_MISS_ABORTED/000 0 GET http://10.0.2.2:40000/repodata/repomd.xml - HIER_DIRECT/10.0.2.2 -
1620910911.842  29938 127.0.0.1 TCP_MISS_ABORTED/000 0 GET http://10.0.2.2:40000/repodata/repomd.xml - HIER_DIRECT/10.0.2.2 -
```

Link to [the cache.log](http://10.43.136.2/users/vp/cache.log).
