### PR TITLE
Fix the proxy-cmdline test

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -236,6 +236,9 @@ start_proxy() {
 
     # Construct a URL
     proxy_url="http://${USER_NET_HOST_IP}:${proxy_port}/"
+
+    # Save the URL
+    echo "${proxy_url}" > ${tmpdir}/proxy_url
 }
 
 stop_proxy() {

--- a/proxy-cmdline.sh
+++ b/proxy-cmdline.sh
@@ -24,7 +24,8 @@ TESTTYPE="method proxy"
 . ${KSTESTDIR}/functions-proxy.sh
 
 kernel_args() {
-    echo ${DEFAULT_BOOTOPTS} inst.proxy=${proxy_url%%/*}
+    proxy_url="$(cat ${tmpdir}/proxy_url)"
+    echo ${DEFAULT_BOOTOPTS} inst.proxy=${proxy_url}
 }
 
 prepare() {


### PR DESCRIPTION
The `inst.proxy` boot option is set to an empty string without this fix.