### PR TITLE
Run daily test for rawhide with daily built iso

### DIFF
--- a/.github/workflows/scenarios.yml
+++ b/.github/workflows/scenarios.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: [self-hosted, kstest]
     strategy:
       matrix:
-        scenario: [rawhide, daily-iso, rhel8, rhel9]
+        scenario: [daily-iso, rhel8, rhel9]
       fail-fast: false
 
     # these settings depend on the infrastructure; on upshift ocp-master-xxl they take about 4 hours

--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -12,7 +12,7 @@ shift
 case "$SCENARIO" in
     rawhide) $LAUNCH --skip-testtypes rhel-only,knownfailure "$@" all ;;
     rawhide-text) $LAUNCH --skip-testtypes rhel-only,knownfailure --run-args '-eKSTEST_EXTRA_BOOTOPTS=inst.text' "$@" all ;;
-    daily-iso) $LAUNCH --skip-testtypes rhel-only,knownfailure --testtype packaging --daily-iso="$GITHUB_TOKEN" "$@" ;;
+    daily-iso) $LAUNCH --skip-testtypes rhel-only,knownfailure --daily-iso="$GITHUB_TOKEN" "$@" all ;;
 
     rhel8)
         if [ ! -e data/images/boot.iso ]; then


### PR DESCRIPTION
We could also remove copr build of dnf from the built iso, this line:
https://github.com/rhinstaller/kickstart-tests/blob/f2f7d20d13a653d73ccf49039d8fd02a8203fbaf/.github/workflows/daily-boot-iso-rawhide.yml#L62
but it showed up to be pretty stable last few months so I'd keep it there until we see some failures caused by too unstable dnf.
Or if you like I'll remove it from 'daily-iso' and create a special scenario for dnf, eg 'daily-iso-dnf'.