### PR TITLE
Revert "Disable network-prefixdevname test temporarily on rhel9 (#195…

### DIFF
--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -29,7 +29,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9-Beta/latest-RHEL-9/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes fedora-only,knownfailure,rhbz1958142,rhbz1958173,rhbz1960279 --platform rhel9 --defaults "$ROOTDIR/scripts/defaults-rhel9.sh" all
+        $LAUNCH --skip-testtypes fedora-only,knownfailure,rhbz1958142,rhbz1960279 --platform rhel9 --defaults "$ROOTDIR/scripts/defaults-rhel9.sh" all
         ;;
 
     # just run a single test on standard Rawhide; mostly for testing infrastructure

--- a/network-prefixdevname.sh
+++ b/network-prefixdevname.sh
@@ -24,7 +24,7 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
-TESTTYPE=${TESTTYPE:-"network rhel-only rhbz1958173"}
+TESTTYPE=${TESTTYPE:-"network rhel-only"}
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
…8173)"

This reverts commit 68db6c5801c0d35e1af4ff5cd582414ded2fffcb.