### PR TITLE
Add test for ks reconfig of virtual device created by boot options

### DIFF
--- a/network-bootopts-bond-ks-override.ks.in
+++ b/network-bootopts-bond-ks-override.ks.in
@@ -1,0 +1,54 @@
+#test name: network-bootopts-bond-ks-override
+# Test bond configured via boot options in a way that it does not have wired
+# setting (by leaving out ip=bond0:dhcp option) and is attempted to be
+# reconfigured via kickstart network command which would trigger #1963834.
+
+%ksappend repos/default.ks
+
+shutdown
+# This will update configuration of the first device with link found,
+# in this case bond0.
+# network
+network --onboot no --hostname myhostname
+
+# storage & bootloader
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+# l10n
+keyboard us
+lang en
+timezone America/New_York
+# user confguration
+rootpw testcase
+
+%ksappend payload/default_packages.ks
+
+%post --nochroot
+
+@KSINCLUDE@ post-nochroot-lib-network.sh
+
+check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@ @KSTEST_NETDEV3@ bond0
+
+%end
+
+%post
+
+@KSINCLUDE@ post-lib-network.sh
+
+check_device_config_value bond0 ONBOOT no connection autoconnect false
+# config files are not named bond0_slave_1 as opposed to kickstart config
+check_device_config_value @KSTEST_NETDEV2@ ONBOOT yes connection autoconnect __NONE
+check_device_config_value @KSTEST_NETDEV2@ SLAVE yes connection slave-type bond
+check_device_config_value @KSTEST_NETDEV3@ ONBOOT yes connection autoconnect __NONE
+check_device_config_value @KSTEST_NETDEV3@ SLAVE yes connection slave-type bond
+check_device_connected bond0 yes
+check_bond_has_slave bond0 @KSTEST_NETDEV2@ yes
+check_bond_has_slave bond0 @KSTEST_NETDEV3@ yes
+
+# No error was written to /root/RESULT file, everything is OK
+if [[ ! -e /root/RESULT ]]; then
+   echo SUCCESS > /root/RESULT
+fi
+%end

--- a/network-bootopts-bond-ks-override.sh
+++ b/network-bootopts-bond-ks-override.sh
@@ -1,0 +1,58 @@
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
+
+TESTTYPE=${TESTTYPE:-"network"}
+
+. ${KSTESTDIR}/functions.sh
+
+kernel_args() {
+    . ${tmpdir}/ks_url
+    echo ${DEFAULT_BOOTOPTS} ip=${KSTEST_NETDEV1}:dhcp bond=bond0:${KSTEST_NETDEV2},${KSTEST_NETDEV3}:mode=active-backup,primary=${KSTEST_NETDEV2} inst.ks=${ks_url}
+}
+
+# Arguments for virt-install --network options
+prepare_network() {
+    echo "user"
+    echo "user"
+    echo "user"
+}
+
+prepare() {
+    ks=$1
+    tmpdir=$2
+
+    # Copy the kickstart to a directory in tmpdir
+    mkdir ${tmpdir}/http
+    cp $ks ${tmpdir}/http/ks.cfg
+
+    # Start a http server to serve the included file
+    start_httpd ${tmpdir}/http $tmpdir
+
+    echo ks_url=${httpd_url}ks.cfg > ${tmpdir}/ks_url
+    echo "${ks}"
+}
+
+inject_ks_to_initrd() {
+    echo "false"
+}
+
+cleanup() {
+    local tmp_dir="${1}"
+    stop_httpd "${tmp_dir}"
+}


### PR DESCRIPTION
Related: rhbz#1963834

The test was created as modification of
network-bootopts-bond-dhcp-httpks.  See the comment in the .ks.in for
the case it covers.