### PR TITLE
Disable reboot tests temporarily (gh#527)

### DIFF
--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -12,7 +12,7 @@ shift
 case "$SCENARIO" in
     rawhide) $LAUNCH --skip-testtypes rhel-only,knownfailure "$@" all ;;
     rawhide-text) $LAUNCH --skip-testtypes rhel-only,knownfailure --run-args '-eKSTEST_EXTRA_BOOTOPTS=inst.text' "$@" all ;;
-    daily-iso) $LAUNCH --skip-testtypes rhel-only,knownfailure,rhbz1964819,rhbz1964817 --daily-iso="$GITHUB_TOKEN" "$@" all ;;
+    daily-iso) $LAUNCH --skip-testtypes rhel-only,knownfailure,rhbz1964819,rhbz1964817,gh527 --daily-iso="$GITHUB_TOKEN" "$@" all ;;
 
     rhel8)
         if [ ! -e data/images/boot.iso ]; then
@@ -20,7 +20,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes fedora-only,knownfailure,rhel-8-failure,rhel-9-only --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
+        $LAUNCH --skip-testtypes fedora-only,knownfailure,rhel-8-failure,rhel-9-only,gh527 --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
         ;;
 
     rhel9)
@@ -29,7 +29,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9-Beta/latest-RHEL-9/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes fedora-only,knownfailure,rhbz1958142,rhbz1960279 --platform rhel9 --defaults "$ROOTDIR/scripts/defaults-rhel9.sh" all
+        $LAUNCH --skip-testtypes fedora-only,knownfailure,rhbz1958142,rhbz1960279,gh527 --platform rhel9 --defaults "$ROOTDIR/scripts/defaults-rhel9.sh" all
         ;;
 
     # just run a single test on standard Rawhide; mostly for testing infrastructure

--- a/reboot-initial-setup-gui.sh
+++ b/reboot-initial-setup-gui.sh
@@ -15,7 +15,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-TESTTYPE="reboot initial-setup"
+TESTTYPE="reboot initial-setup gh527"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/reboot-initial-setup-tui.sh
+++ b/reboot-initial-setup-tui.sh
@@ -17,7 +17,7 @@
 #
 
 # FIXME: Enable the test for RHEL.
-TESTTYPE="reboot initial-setup fedora-only"
+TESTTYPE="reboot initial-setup fedora-only gh527"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/reboot.sh
+++ b/reboot.sh
@@ -15,7 +15,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-TESTTYPE="reboot"
+TESTTYPE="reboot gh527"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Disable reboot tests until
https://github.com/rhinstaller/kickstart-tests/issues/527 is fixed.