### PR TITLE
Disable network-bootoopts-bond-ks-override test temporarily on rhel8 …

### DIFF
--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -20,7 +20,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes fedora-only,knownfailure,rhel-8-failure,rhel-9-only,gh527 --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
+        $LAUNCH --skip-testtypes fedora-only,knownfailure,rhel-8-failure,rhel-9-only,gh527,rhbz1963834 --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
         ;;
 
     rhel9)

--- a/network-bootopts-bond-ks-override.sh
+++ b/network-bootopts-bond-ks-override.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE=${TESTTYPE:-"network"}
+TESTTYPE=${TESTTYPE:-"network rhbz1963834"}
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
…(#1963834)

Disable network-bootoopts-bond-ks-override test on rhel8 until
rhbz#1963834 is fixed.