### PR TITLE
Revert "Mark fedora-live-image-build as knownfailure (#1926632)"

### DIFF
--- a/fedora-live-image-build.sh
+++ b/fedora-live-image-build.sh
@@ -17,8 +17,7 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
-# https://bugzilla.redhat.com/show_bug.cgi?id=1926632#c7
-TESTTYPE="packaging fedora-only knownfailure"
+TESTTYPE="packaging fedora-only"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
This reverts commit 36868ec54d81a32b4b6915bcabf8ec7e2d0181c5.

The test should be no more knownfailure with
https://github.com/rhinstaller/kickstart-tests/pull/504