### PR TITLE
Kill reboot tests after the timeout

### DIFF
--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -12,7 +12,7 @@ shift
 case "$SCENARIO" in
     rawhide) $LAUNCH --skip-testtypes rhel-only,knownfailure "$@" all ;;
     rawhide-text) $LAUNCH --skip-testtypes rhel-only,knownfailure --run-args '-eKSTEST_EXTRA_BOOTOPTS=inst.text' "$@" all ;;
-    daily-iso) $LAUNCH --skip-testtypes rhel-only,knownfailure,rhbz1964819,rhbz1964817,gh527,rhbz1973078,rhbz1973156 --daily-iso="$GITHUB_TOKEN" "$@" all ;;
+    daily-iso) $LAUNCH --skip-testtypes rhel-only,knownfailure,rhbz1964819,rhbz1964817,rhbz1973078,rhbz1973156 --daily-iso="$GITHUB_TOKEN" "$@" all ;;
 
     rhel8)
         if [ ! -e data/images/boot.iso ]; then
@@ -20,7 +20,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes fedora-only,knownfailure,rhel-8-failure,rhel-9-only,gh527,rhbz1963834 --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
+        $LAUNCH --skip-testtypes fedora-only,knownfailure,rhel-8-failure,rhel-9-only,rhbz1963834 --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
         ;;
 
     rhel9)
@@ -29,7 +29,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9-Beta/latest-RHEL-9/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes fedora-only,knownfailure,rhbz1960279,gh527 --platform rhel9 --defaults "$ROOTDIR/scripts/defaults-rhel9.sh" all
+        $LAUNCH --skip-testtypes fedora-only,knownfailure,rhbz1960279 --platform rhel9 --defaults "$ROOTDIR/scripts/defaults-rhel9.sh" all
         ;;
 
     # just run a single test on standard Rawhide; mostly for testing infrastructure

--- a/reboot-initial-setup-gui.ks.in
+++ b/reboot-initial-setup-gui.ks.in
@@ -43,6 +43,12 @@ cat > /usr/libexec/kickstart-test.sh << EOF
 journalctl -g "Starting Initial Setup GUI" >/dev/null \
 || echo "Failed to start Initial Setup GUI."
 
+journalctl -g "No supported window manager found!" >/dev/null \
+&& echo "Failed to start Initial Setup GUI. No supported window manager found."
+
+journalctl -g "Initial Setup finished successfully" >/dev/null \
+|| echo "Initial Setup has failed."
+
 journalctl -u initial-setup -g "Traceback" --quiet
 EOF
 

--- a/reboot-initial-setup-gui.ks.in
+++ b/reboot-initial-setup-gui.ks.in
@@ -20,6 +20,9 @@ graphical
 # Install the initial setup.
 initial-setup-gui
 
+# See https://github.com/rhinstaller/initial-setup/issues/131.
+gnome-kiosk
+
 # Install something that provides service(graphical-login).
 gdm
 

--- a/reboot-initial-setup-gui.sh
+++ b/reboot-initial-setup-gui.sh
@@ -15,12 +15,14 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-TESTTYPE="reboot initial-setup gh527"
+TESTTYPE="reboot initial-setup"
 
 . ${KSTESTDIR}/functions.sh
 
 additional_runner_args() {
-    echo "--wait"
+    # Wait for reboot and shutdown of the VM,
+    # but exit after the specified timeout.
+    echo "--wait $(get_timeout)"
 }
 
 kernel_args() {

--- a/reboot-initial-setup-tui.ks.in
+++ b/reboot-initial-setup-tui.ks.in
@@ -34,6 +34,9 @@ cat > /usr/libexec/kickstart-test.sh << EOF
 journalctl -g "Starting Initial Setup TUI" >/dev/null \
 || echo "Failed to start Initial Setup TUI."
 
+journalctl -g "Initial Setup finished successfully" >/dev/null \
+|| echo "Initial Setup has failed."
+
 journalctl -u initial-setup -g "Traceback" --quiet
 
 EOF

--- a/reboot-initial-setup-tui.sh
+++ b/reboot-initial-setup-tui.sh
@@ -17,12 +17,14 @@
 #
 
 # FIXME: Enable the test for RHEL.
-TESTTYPE="reboot initial-setup fedora-only gh527"
+TESTTYPE="reboot initial-setup fedora-only"
 
 . ${KSTESTDIR}/functions.sh
 
 additional_runner_args() {
-    echo "--wait"
+    # Wait for reboot and shutdown of the VM,
+    # but exit after the specified timeout.
+    echo "--wait $(get_timeout)"
 }
 
 kernel_args() {

--- a/reboot.sh
+++ b/reboot.sh
@@ -15,10 +15,12 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-TESTTYPE="reboot gh527"
+TESTTYPE="reboot"
 
 . ${KSTESTDIR}/functions.sh
 
 additional_runner_args() {
-    echo "--wait"
+    # Wait for reboot and shutdown of the VM,
+    # but exit after the specified timeout.
+    echo "--wait $(get_timeout)"
 }


### PR DESCRIPTION
Wait for reboot and shutdown of the virtual machine, but kill the test after the specified timeout.