### PR TITLE
Revert "Disable 2 tests temporarily on rhel8 (#1975786)"

### DIFF
--- a/.github/workflows/daily-boot-iso-rhel8.yml
+++ b/.github/workflows/daily-boot-iso-rhel8.yml
@@ -99,7 +99,7 @@ jobs:
           cp /home/github/rhel8-daily-boot.iso data/images/boot.iso
 
       - name: Run coverage tests
-        run: sudo TEST_JOBS=16 containers/runner/launch --retry --testtype coverage --skip-testtypes fedora-only,knownfailure,rhbz1975786 --platform rhel8 --defaults $PWD/scripts/defaults-rhel8.sh
+        run: sudo TEST_JOBS=16 containers/runner/launch --retry --testtype coverage --skip-testtypes fedora-only,knownfailure --platform rhel8 --defaults $PWD/scripts/defaults-rhel8.sh
 
       - name: Upload test logs
         if: always()

--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -20,7 +20,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes fedora-only,knownfailure,rhel-8-failure,rhel-9-only,gh527,rhbz1963834,rhbz1975786 --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
+        $LAUNCH --skip-testtypes fedora-only,knownfailure,rhel-8-failure,rhel-9-only,gh527,rhbz1963834 --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
         ;;
 
     rhel9)

--- a/packages-and-groups-1.sh
+++ b/packages-and-groups-1.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="packaging rhbz1975786"
+TESTTYPE="packaging"
 
 . ${KSTESTDIR}/functions.sh

--- a/user-multiple.sh
+++ b/user-multiple.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
-TESTTYPE="users coverage rhbz1975786"
+TESTTYPE="users coverage"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
This reverts commit 31dbf8561428350709d99ad66428fcbb6492fa1d.

All right, that was just 1,5 nightly long issue (the development repo has been updated during yesterday's nightly). I should have checked yesterday's results before merging the PR for disabling.