### PR TITLE
Fix and enable the multilib kickstart test

### DIFF
--- a/packages-multilib.ks.in
+++ b/packages-multilib.ks.in
@@ -1,26 +1,33 @@
 #version=DEVEL
 #test name: packages-multilib
 #
-# Check multilib instalation fails in this concrete scenario.
+# Run a multilib installation.
 
 %ksappend repos/default.ks
 %ksappend common/common_no_payload.ks
 
 %packages --multilib
-@container-management
-@core
-@domain-client
-@hardware-support
-@headless-management
-@server-product
-@standard
 %end
 
 %post
-rpm -q fedora-release
-if [ -e /usr/lib/libc.so.6 ]; then
-    echo SUCCESS > /root/RESULT
-else
-    echo '*** no 32-bit libc package installed' > /root/RESULT
+# Check the installed glibc packages.
+if [[ ! -e /usr/lib/libc.so.6 ]]; then
+    echo "*** No 32-bit glibc package installed!" >> /root/RESULT
+    rpm -q glibc >> /root/RESULT
 fi
+
+if [[ ! -e /usr/lib64/libc.so.6 ]]; then
+    echo "*** No 64-bit glibc package installed!" >> /root/RESULT
+    rpm -q glibc >> /root/RESULT
+fi
+
+# Check the DNF configuration.
+cat /etc/dnf/dnf.conf | grep -q multilib_policy=all
+
+if [[ $? != 0 ]]; then
+    echo "*** multilib_policy=all is not set in /etc/dnf/dnf.conf: " >> /root/RESULT
+    cat /etc/dnf/dnf.conf >> /root/RESULT
+fi
+
+%ksappend validation/success_if_result_empty.ks
 %end

--- a/packages-multilib.sh
+++ b/packages-multilib.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="knownfailure packaging"
+TESTTYPE="packaging rhel-8-failure"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Check the installed packages and the DNF configuration.

**Depends on:** https://github.com/rhinstaller/anaconda/pull/3487
**Depends on:** https://github.com/rhinstaller/anaconda/pull/3425