### PR TITLE
Disable the authconfig test for Fedora

### DIFF
--- a/authconfig.sh
+++ b/authconfig.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE="security"
+TESTTYPE="security rhel-only"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
The support for the authconfig tool will be removed in Fedora 35:
https://fedoraproject.org/wiki/Changes/RemoveAuthselectCompatPackage