### PR TITLE
Fix the reboot-initial-setup tests

### DIFF
--- a/reboot-initial-setup-gui.ks.in
+++ b/reboot-initial-setup-gui.ks.in
@@ -40,6 +40,13 @@ gdm
 # Remove EULA if any.
 rm /usr/share/redhat-release/EULA
 
+# Disable EULA for the initial setup.
+# FIXME: This is a temporary workaround for RHEL 9.
+cat > /etc/initial-setup/conf.d/90-no-eula.conf << EOF
+[License]
+eula =
+EOF
+
 # Create a script with the first boot test.
 # Print errors to stdout.
 cat > /usr/libexec/kickstart-test.sh << EOF

--- a/reboot-initial-setup-gui.ks.in
+++ b/reboot-initial-setup-gui.ks.in
@@ -44,13 +44,13 @@ rm /usr/share/redhat-release/EULA
 # Print errors to stdout.
 cat > /usr/libexec/kickstart-test.sh << EOF
 
-journalctl -g "Starting Initial Setup GUI" >/dev/null \
+journalctl | grep -q "Starting Initial Setup GUI" \
 || echo "Failed to start Initial Setup GUI."
 
-journalctl -g "No supported window manager found!" >/dev/null \
+journalctl | grep -q "No supported window manager found!" \
 && echo "Failed to start Initial Setup GUI. No supported window manager found."
 
-journalctl -g "Initial Setup finished successfully" >/dev/null \
+journalctl | grep -q "Initial Setup finished successfully" \
 || echo "Initial Setup has failed."
 
 journalctl -u initial-setup -g "Traceback" --quiet

--- a/reboot-initial-setup-tui.ks.in
+++ b/reboot-initial-setup-tui.ks.in
@@ -27,6 +27,13 @@ initial-setup
 # Remove EULA if any.
 rm /usr/share/redhat-release/EULA
 
+# Disable EULA for the initial setup.
+# FIXME: This is a temporary workaround for RHEL 9.
+cat > /etc/initial-setup/conf.d/90-no-eula.conf << EOF
+[License]
+eula =
+EOF
+
 # Create a script with the first boot test.
 # Print errors to stdout.
 cat > /usr/libexec/kickstart-test.sh << EOF

--- a/reboot-initial-setup-tui.ks.in
+++ b/reboot-initial-setup-tui.ks.in
@@ -31,10 +31,10 @@ rm /usr/share/redhat-release/EULA
 # Print errors to stdout.
 cat > /usr/libexec/kickstart-test.sh << EOF
 
-journalctl -g "Starting Initial Setup TUI" >/dev/null \
+journalctl | grep -q "Starting Initial Setup TUI" \
 || echo "Failed to start Initial Setup TUI."
 
-journalctl -g "Initial Setup finished successfully" >/dev/null \
+journalctl | grep -q "Initial Setup finished successfully" \
 || echo "Initial Setup has failed."
 
 journalctl -u initial-setup -g "Traceback" --quiet

--- a/reboot-initial-setup-tui.sh
+++ b/reboot-initial-setup-tui.sh
@@ -15,9 +15,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-
-# FIXME: Enable the test for RHEL.
-TESTTYPE="reboot initial-setup fedora-only smoke"
+# The fix requires https://github.com/rhinstaller/anaconda/commit/6b80b7b.
+TESTTYPE="reboot initial-setup smoke rhel-8-failure"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
* Don't use the return value of `journalctl -g` in RHEL 8.
* Disable the EULA spoke in the initial setup in RHEL 9.
* Enable `reboot-initial-setup-tui` on RHEL 9