### PR TITLE
Fix the validation in the anaconda-modules test

### DIFF
--- a/anaconda-modules.ks.in
+++ b/anaconda-modules.ks.in
@@ -28,11 +28,6 @@ org.fedoraproject.Anaconda.Modules.Timezone
 org.fedoraproject.Anaconda.Modules.Users
 EOF
 
-# Drop the Subscription module if this is not RHEL.
-if [[ "@KSTEST_OS_NAME@" != "rhel" ]]; then
-    sed -i '/Subscription/d' /tmp/expected.out
-fi
-
 # Check the output
 diff /tmp/expected.out /tmp/generated.out
 


### PR DESCRIPTION
The Subscription module is always activated now. It will refuse to start
if the environment doesn't provide required dependencies and services.