### PR TITLE
Replace the rhel-8-failure tag

### DIFF
--- a/bindtomac-bridged-bond-httpks.sh
+++ b/bindtomac-bridged-bond-httpks.sh
@@ -18,7 +18,7 @@
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
 # FIXME: https://github.com/rhinstaller/kickstart-tests/issues/447
-TESTTYPE="network rhel-8-failure"
+TESTTYPE="network skip-on-rhel-8"
 
 . ${KSTESTDIR}/bridged-bond-httpks.sh
 

--- a/bridged-bond-httpks.sh
+++ b/bridged-bond-httpks.sh
@@ -18,7 +18,7 @@
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
 # FIXME: https://github.com/rhinstaller/kickstart-tests/issues/447
-TESTTYPE=${TESTTYPE:-"network rhel-8-failure"}
+TESTTYPE=${TESTTYPE:-"network skip-on-rhel-8"}
 
 . ${KSTESTDIR}/functions.sh
 

--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -20,7 +20,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes skip-on-rhel,knownfailure,rhel-8-failure,skip-on-rhel-8,rhbz1963834,rhbz1973156 --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
+        $LAUNCH --skip-testtypes skip-on-rhel,knownfailure,skip-on-rhel-8,rhbz1963834,rhbz1973156 --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
         ;;
 
     rhel9)

--- a/packages-multilib.sh
+++ b/packages-multilib.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="packaging rhel-8-failure"
+TESTTYPE="packaging skip-on-rhel-8"
 
 . ${KSTESTDIR}/functions.sh

--- a/reboot-initial-setup-tui.sh
+++ b/reboot-initial-setup-tui.sh
@@ -16,7 +16,7 @@
 # Red Hat, Inc.
 #
 # The fix requires https://github.com/rhinstaller/anaconda/commit/6b80b7b.
-TESTTYPE="reboot initial-setup smoke rhel-8-failure"
+TESTTYPE="reboot initial-setup smoke skip-on-rhel-8"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
The `rhel-8-failure` tag is not supported by the Anaconda CI.
Use the `skip-on-rhel-8` tag instead.

**Depends on:** https://github.com/rhinstaller/kickstart-tests/pull/547