### PR TITLE
Temporarily disable the kdump addon in RHEL 9

### DIFF
--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -29,7 +29,8 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9-Beta/latest-RHEL-9/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes skip-on-rhel,skip-on-rhel-9,knownfailure,rhbz1960279,rhbz1973156 --platform rhel9 --defaults "$ROOTDIR/scripts/defaults-rhel9.sh" all
+        # FIXME: Temporarily disable the kdump addon in RHEL 9 (#1986942, #1986969).
+        $LAUNCH --skip-testtypes skip-on-rhel,skip-on-rhel-9,knownfailure,rhbz1960279,rhbz1973156 --run-args '-eKSTEST_EXTRA_BOOTOPTS=inst.kdump_addon' --platform rhel9 --defaults "$ROOTDIR/scripts/defaults-rhel9.sh" all
         ;;
 
     # just run a single test on standard Rawhide; mostly for testing infrastructure


### PR DESCRIPTION
Use `inst.kdump_addon` for daily runs to disable the add-on in RHEL 9.

Related: rhbz#1986942
Related: rhbz#1986969