### PR TITLE
Add KS test for new critical Anaconda errors in Dracut

### DIFF
--- a/dracut-visible-warnings.ks.in
+++ b/dracut-visible-warnings.ks.in
@@ -1,0 +1,30 @@
+#version=DEVEL
+#test name: dracut-visible-warnings
+%ksappend repos/default.ks
+
+%ksappend common/common_no_payload.ks
+%ksappend payload/default_packages.ks
+
+%post --nochroot
+SYSROOT=${ANA_INSTALL_PATH:-/mnt/sysimage}
+
+for name in sshd vnc; do
+    ERROR_MSG="'$name' is deprecated and has been removed"
+    journalctl | grep -q "$ERROR_MSG" || echo "*** Failed check: The $name parameter warning wasn't detected in Dracut" >> $SYSROOT/root/RESULT
+
+    tmux capture-pane -p | grep -q "$ERROR_MSG" || echo "*** Failed check: The $name parameter warning wasn't detected in stage2" >> $SYSROOT/root/RESULT
+
+    REC_MSG="All usage of Anaconda boot arguments without 'inst.' prefix was removed. Please use inst.$name instead."
+
+    journalctl | grep -q "$REC_MSG" || echo "*** Failed check: The $name parameter recommendation wasn't detected in Dracut" >> $SYSROOT/root/RESULT
+
+    tmux capture-pane -p | grep -q "$REC_MSG" || echo "*** Failed check: The $name parameter recommendation wasn't detected in stage2" >> $SYSROOT/root/RESULT
+done
+
+tmux capture-pane -p | grep -q "Installer errors encountered during boot" || \
+    echo "*** Failed check: The Dracut error can't be detected in stage2 environment" >> $SYSROOT/root/RESULT
+
+if [[ ! -e $SYSROOT/root/RESULT ]]; then
+    echo SUCCESS > $SYSROOT/root/RESULT
+fi
+%end

--- a/dracut-visible-warnings.sh
+++ b/dracut-visible-warnings.sh
@@ -1,0 +1,27 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
+
+TESTTYPE="dracut skip-on-rhel"
+
+. ${KSTESTDIR}/functions.sh
+
+kernel_args() {
+    # Add kernel boot parameters without 'inst.' prefix to test printed warnings.
+    echo "${DEFAULT_BOOTOPTS} sshd vnc"
+}


### PR DESCRIPTION
This test will check if critical Dracut errors are printed visible.