### PR TITLE
Use https for fedoraproject URLs

### DIFF
--- a/scripts/defaults.sh
+++ b/scripts/defaults.sh
@@ -7,6 +7,6 @@
 # CAUTION: the sed expression we currently use does not like white-space in the strings
 
 source network-device-names.cfg
-export KSTEST_URL='--url=http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/$basearch/os/'
-export KSTEST_MODULAR_URL='http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Modular/$basearch/os/'
+export KSTEST_URL='--url=https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/$basearch/os/'
+export KSTEST_MODULAR_URL='https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Modular/$basearch/os/'
 export KSTEST_FTP_URL='ftp://ftp.tu-chemnitz.de/pub/linux/fedora/linux/development/rawhide/Everything/$basearch/os/'


### PR DESCRIPTION
The https alternatives have existed for a while now so use them to be safe.