### PR TITLE
scenarios: raise workflow timeout temporarily for debugging

### DIFF
--- a/.github/workflows/scenarios.yml
+++ b/.github/workflows/scenarios.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
 
     # these settings depend on the infrastructure; on upshift ocp-master-xxl they take about 4 hours
-    timeout-minutes: 420
+    timeout-minutes: 480
     env:
       TEST_JOBS: 16
       GITHUB_TOKEN: /home/github/github-token


### PR DESCRIPTION
The daily-iso scenario seems to take ~1.7 times longer then rhel-9 since
some week ago. I am not able to reproduce the difference locally, so I'd
raise the timeout temporarily (by 1h) to allow the daily-iso to finish
so we can get the logs to see where the bottleneck can be.