### PR TITLE
Fix packages section so it doesn't fail on unrelated issues

### DIFF
--- a/user-multiple.ks.in
+++ b/user-multiple.ks.in
@@ -20,7 +20,7 @@ timezone America/New_York
 
 rootpw qweqwe
 
-%packages --default
+%packages
 %end
 
 # Create multiple users, including incorrect user specifications that should be skipped


### PR DESCRIPTION
This should fix also creating of rhel boot iso workflow (make coverage tests pass).