### PR TITLE
Enable Dracut visible warnings test on RHEL-9

### DIFF
--- a/dracut-visible-warnings.sh
+++ b/dracut-visible-warnings.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 
-TESTTYPE="dracut skip-on-rhel"
+TESTTYPE="dracut skip-on-rhel-8"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
The feature should be on RHEL-9 now so it's safe to enable it there.