### PR TITLE
Switch container to base on Fedora-34

### DIFF
--- a/containers/runner/Dockerfile
+++ b/containers/runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:32
+FROM fedora:34
 LABEL maintainer='anaconda-devel-list@redhat.com'
 
 RUN dnf -y update && \
@@ -8,12 +8,12 @@ RUN dnf -y update && \
     rsync \
     git \
     virt-install \
-    libguestfs-tools \
+    guestfs-tools \
     genisoimage \
     lorax-lmc-virt \
     parallel \
     python3-libvirt \
-    createrepo \
+    createrepo_c \
     python3-rpmfluff \
     squid \
     make \


### PR DESCRIPTION
Fedora-32 is now EOL. So use something still updated.

I have to fix dependencies a bit:

- The libguestfs-tools doesn't provide us tools we need.
- The createrepo works but the correct name of the package is createrepo_c so use that instead of installing it based on the provides.