### PR TITLE
Re-enable the selinux context test

### DIFF
--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -20,7 +20,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes skip-on-rhel,knownfailure,skip-on-rhel-8,rhbz1963834,rhbz1973156,rhbz1990358,gh564 --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
+        $LAUNCH --skip-testtypes skip-on-rhel,knownfailure,skip-on-rhel-8,rhbz1963834,rhbz1973156,gh564 --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
         ;;
 
     rhel9)

--- a/selinux-contexts.sh
+++ b/selinux-contexts.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Vladimir Slavik <vslavik@redhat.com>
 
-TESTTYPE="security selinux rhbz1990358"
+TESTTYPE="security selinux"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
The problem is fixed in https://bugzilla.redhat.com/show_bug.cgi?id=1991647, so we can re-enable the test. 

Resolves: [rhbz#1990358](https://bugzilla.redhat.com/show_bug.cgi?id=1990358)

Revert "Disable selinux-contexts test temporarily on rhel-8 (#1990358)"
This reverts commit 9e9c644ef48c549621dc0d37d12a5f230db4dfe2.