### PR TITLE
Add network options pre test

### DIFF
--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -20,7 +20,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes skip-on-rhel,knownfailure,skip-on-rhel-8,rhbz1973156,gh564 --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
+        $LAUNCH --skip-testtypes skip-on-rhel,knownfailure,skip-on-rhel-8,rhbz1973156,gh564,rhbz1990145 --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
         ;;
 
     rhel9)

--- a/network-options-pre.ks.in
+++ b/network-options-pre.ks.in
@@ -1,0 +1,46 @@
+#test name: onboot-options-pre
+# Test network command options defined in %pre section
+# --nodefroute
+%ksappend repos/default.ks
+
+%include /tmp/ksinclude
+%pre
+echo "network --device=@KSTEST_NETDEV2@ --bootproto dhcp --nodefroute" >> /tmp/ksinclude
+%end
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+%post --nochroot
+
+@KSINCLUDE@ post-nochroot-lib-network.sh
+
+check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@
+
+%end
+
+%post
+
+@KSINCLUDE@ post-lib-network.sh
+
+check_device_config_value @KSTEST_NETDEV1@ DEFROUTE yes ipv4 never-default __NONE
+check_device_config_value @KSTEST_NETDEV2@ DEFROUTE no ipv4 never-default true
+check_device_connected @KSTEST_NETDEV1@ yes
+check_device_connected @KSTEST_NETDEV2@ yes
+
+# No error was written to /root/RESULT file, everything is OK
+if [[ ! -e /root/RESULT ]]; then
+   echo SUCCESS > /root/RESULT
+fi
+%end

--- a/network-options-pre.sh
+++ b/network-options-pre.sh
@@ -24,7 +24,7 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
-TESTTYPE=${TESTTYPE:-"network"}
+TESTTYPE=${TESTTYPE:-"network rhbz1990145"}
 
 . ${KSTESTDIR}/functions.sh
 

--- a/network-options-pre.sh
+++ b/network-options-pre.sh
@@ -1,0 +1,40 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
+
+# This is actually testing application of kickstart network commands in
+# anaconda (which would normally be triggered by defining networking in %pre
+# and %including it into kickstart).  It is caused by network kickstart
+# commands not being applied in dracut because for ks=file:/ks.cfg (kickstart
+# injected in initrd) network devices are not found in sysfs in the time of
+# parsing the kickstart.
+
+TESTTYPE=${TESTTYPE:-"network"}
+
+. ${KSTESTDIR}/functions.sh
+
+
+kernel_args() {
+    echo ${DEFAULT_BOOTOPTS} ip=dhcp
+}
+
+# Arguments for virt-install --network options
+prepare_network() {
+    echo "user"
+    echo "user"
+}


### PR DESCRIPTION
For now the test checks only --nodefroute default option (for BZ 1990145) but it is intended to be used also for other options in the future if needed (so we save kickstart tests resources by testing multiple features in a single test).