### PR TITLE
Add a longer wait for Xorg

### DIFF
--- a/scripts/launcher/lib/virtual_controller.py
+++ b/scripts/launcher/lib/virtual_controller.py
@@ -151,6 +151,10 @@ class VirtualInstall(object):
         if self._kernel_args:
             extra_args += " " + self._kernel_args
 
+        # work around too slow VMs failing to start Xorg
+        # TODO: Remove this again once we know how to run things normally.
+        extra_args += " inst.xtimeout=300"
+
         extra_args += " inst.stage2=hd:CDLABEL={0}".format(udev_escape(self._label))
 
         if self._boot:


### PR DESCRIPTION
Kickstart tests usually run en masse in VMs, which invites slow I/O.
Unfortunately, that is the leading known cause of Xorg timeouts.