### PR TITLE
Set environment to access quay.io secrets

### DIFF
--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -12,6 +12,7 @@ jobs:
   runner:
     name: Build kstest-runner container
     runs-on: ubuntu-latest
+    environment: quay.io
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
This way we will have the quay.io secrets only for the container-autoupdate workflow.