### PR TITLE
Revert "Disable container test temporarily on daily-iso (#2006694)"

### DIFF
--- a/container.sh
+++ b/container.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="bootloader packaging coverage skip-on-rhel rhbz2006694"
+TESTTYPE="bootloader packaging coverage skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -12,7 +12,7 @@ shift
 case "$SCENARIO" in
     rawhide) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure "$@" all ;;
     rawhide-text) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure --run-args '-eKSTEST_EXTRA_BOOTOPTS=inst.text' "$@" all ;;
-    daily-iso) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure,rhbz1973156,gh575,rhbz2006694,gh595 --daily-iso="$GITHUB_TOKEN" "$@" all ;;
+    daily-iso) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure,rhbz1973156,gh575,gh595 --daily-iso="$GITHUB_TOKEN" "$@" all ;;
 
     rhel8)
         if [ ! -e data/images/boot.iso ]; then


### PR DESCRIPTION
This reverts commit 80c8dd8504fe0ecfdc6e361263324c2155dd40e7.

Related: [rhbz#2006694](https://bugzilla.redhat.com/show_bug.cgi?id=2006694), #590

Likely requires a compose with today's anaconda release.