### PR TITLE
Use default %packages section for ntp-pool

### DIFF
--- a/ntp-pools.ks.in
+++ b/ntp-pools.ks.in
@@ -19,8 +19,7 @@ lang en_US.UTF-8
 rootpw testcase
 shutdown
 
-%packages --default
-%end
+%ksappend payload/default_packages.ks
 
 %post
 cat /etc/chrony.conf


### PR DESCRIPTION
Otherwise the test can fail for unrelated dependency issues.