### PR TITLE
Disable proxy-cmdline test temporarily on all scenarios (gh#595)

### DIFF
--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -12,7 +12,7 @@ shift
 case "$SCENARIO" in
     rawhide) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure "$@" all ;;
     rawhide-text) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure --run-args '-eKSTEST_EXTRA_BOOTOPTS=inst.text' "$@" all ;;
-    daily-iso) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure,rhbz1973156,gh575,rhbz2006694 --daily-iso="$GITHUB_TOKEN" "$@" all ;;
+    daily-iso) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure,rhbz1973156,gh575,rhbz2006694,gh595 --daily-iso="$GITHUB_TOKEN" "$@" all ;;
 
     rhel8)
         if [ ! -e data/images/boot.iso ]; then
@@ -20,7 +20,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes skip-on-rhel,knownfailure,skip-on-rhel-8,rhbz1973156,gh564,rhbz1990145 --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
+        $LAUNCH --skip-testtypes skip-on-rhel,knownfailure,skip-on-rhel-8,rhbz1973156,gh564,rhbz1990145,gh595 --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
         ;;
 
     rhel9)
@@ -29,7 +29,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9-Beta/latest-RHEL-9/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes skip-on-rhel,skip-on-rhel-9,knownfailure,rhbz1960279,rhbz1973156 --platform rhel9 --defaults "$ROOTDIR/scripts/defaults-rhel9.sh" all
+        $LAUNCH --skip-testtypes skip-on-rhel,skip-on-rhel-9,knownfailure,rhbz1960279,rhbz1973156,gh595 --platform rhel9 --defaults "$ROOTDIR/scripts/defaults-rhel9.sh" all
         ;;
 
     # just run a single test on standard Rawhide; mostly for testing infrastructure

--- a/proxy-cmdline.sh
+++ b/proxy-cmdline.sh
@@ -18,7 +18,7 @@
 # Red Hat Author(s): David Shea <dshea@redhat.com>
 #                    Jiri Konecny <jkonecny@redhat.com>
 
-TESTTYPE="method proxy"
+TESTTYPE="method proxy gh595"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/functions-proxy.sh


### PR DESCRIPTION
Disable proxy-cmdline on all scenarios until gh#595 is fixed.