### PR TITLE
Disable packages-and-groups-1 test temporarily on rhel-9 (gh#564)

### DIFF
--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -29,7 +29,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9-Beta/latest-RHEL-9/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes skip-on-rhel,skip-on-rhel-9,knownfailure,rhbz1960279,rhbz1973156,gh595 --platform rhel9 --defaults "$ROOTDIR/scripts/defaults-rhel9.sh" all
+        $LAUNCH --skip-testtypes skip-on-rhel,skip-on-rhel-9,knownfailure,rhbz1960279,rhbz1973156,gh595,gh564 --platform rhel9 --defaults "$ROOTDIR/scripts/defaults-rhel9.sh" all
         ;;
 
     # just run a single test on standard Rawhide; mostly for testing infrastructure


### PR DESCRIPTION
Disable packages-and-groups-1 on rhel-9 until gh#564 is
fixed.

Related to https://github.com/rhinstaller/kickstart-tests/issues/564