### PR TITLE
Fix selinux context test

### DIFF
--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -12,7 +12,7 @@ shift
 case "$SCENARIO" in
     rawhide) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure "$@" all ;;
     rawhide-text) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure --run-args '-eKSTEST_EXTRA_BOOTOPTS=inst.text' "$@" all ;;
-    daily-iso) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure,rhbz1973156,gh575,gh595,gh598 --daily-iso="$GITHUB_TOKEN" "$@" all ;;
+    daily-iso) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure,rhbz1973156,gh575,gh595 --daily-iso="$GITHUB_TOKEN" "$@" all ;;
 
     rhel8)
         if [ ! -e data/images/boot.iso ]; then
@@ -20,7 +20,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes skip-on-rhel,knownfailure,skip-on-rhel-8,rhbz1973156,gh564,rhbz1990145,gh595,gh598 --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
+        $LAUNCH --skip-testtypes skip-on-rhel,knownfailure,skip-on-rhel-8,rhbz1973156,gh564,rhbz1990145,gh595 --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
         ;;
 
     rhel9)
@@ -29,7 +29,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9-Beta/latest-RHEL-9/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes skip-on-rhel,skip-on-rhel-9,knownfailure,rhbz1960279,rhbz1973156,gh595,gh564,gh601,gh598 --platform rhel9 --defaults "$ROOTDIR/scripts/defaults-rhel9.sh" all
+        $LAUNCH --skip-testtypes skip-on-rhel,skip-on-rhel-9,knownfailure,rhbz1960279,rhbz1973156,gh595,gh564,gh601 --platform rhel9 --defaults "$ROOTDIR/scripts/defaults-rhel9.sh" all
         ;;
 
     # just run a single test on standard Rawhide; mostly for testing infrastructure

--- a/selinux-contexts.ks.in
+++ b/selinux-contexts.ks.in
@@ -4,25 +4,23 @@
 %ksappend common/common_no_payload.ks
 %ksappend payload/default_packages.ks
 
-# Check files with wrong SElinux contexts. This *must* run in %post after the
-# "stock" %post script 80-setfilecons.ks. Thus, include that file before our
-# code, to make sure it is executed in the right order.
+# Reboot the installed system.
+reboot
 
-%include /usr/share/anaconda/post-scripts/80-setfilecons.ks
+# Validate on the first boot.
+%ksappend validation/success_on_first_boot.ks
 
+# Set up the actual test.
 %post
 
-echo "Listing files with wrong SElinux contexts..."
-restorecon -rvn / -e /mnt -e /proc -e /run -e /sys > /root/RESULT
+# Make sure something doesn't fix the labels before we can check them.
+systemctl disable selinux-autorelabel.service
 
-# Report success if no errors have been reported to /root/RESULT
-if [ ! -s /root/RESULT ]
-then
-    # result file empty or none -> success
-    echo SUCCESS > /root/RESULT
-else
-    # some errors happened
-    exit 1
-fi
+# Write the code to run after reboot. It lists files with wrong SELinux contexts.
+cat > /usr/libexec/kickstart-test.sh << 'EOF'
+
+restorecon -rvn / -e /mnt -e /proc -e /run -e /sys
+
+EOF
 
 %end

--- a/selinux-contexts.sh
+++ b/selinux-contexts.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Vladimir Slavik <vslavik@redhat.com>
 
-TESTTYPE="security selinux gh598"
+TESTTYPE="security selinux"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/selinux-contexts.sh
+++ b/selinux-contexts.sh
@@ -20,3 +20,9 @@
 TESTTYPE="security selinux gh598"
 
 . ${KSTESTDIR}/functions.sh
+
+additional_runner_args() {
+    # Wait for reboot and shutdown of the VM,
+    # but exit after the specified timeout.
+    echo "--wait $(get_timeout)"
+}


### PR DESCRIPTION
Make the test independent of how anaconda does it. Instead of hacking the `%post` script order, it's now a reboot test.

Closes #598.