### PR TITLE
Ignore also /dev when checking wrong SELinux contexts

### DIFF
--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -29,7 +29,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9-Beta/latest-RHEL-9/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes skip-on-rhel,skip-on-rhel-9,knownfailure,rhbz1960279,rhbz1973156,gh595,gh564,gh601,gh576,gh607 --platform rhel9 --defaults "$ROOTDIR/scripts/defaults-rhel9.sh" all
+        $LAUNCH --skip-testtypes skip-on-rhel,skip-on-rhel-9,knownfailure,rhbz1960279,rhbz1973156,gh595,gh564,gh601,gh576 --platform rhel9 --defaults "$ROOTDIR/scripts/defaults-rhel9.sh" all
         ;;
 
     # just run a single test on standard Rawhide; mostly for testing infrastructure

--- a/selinux-contexts.ks.in
+++ b/selinux-contexts.ks.in
@@ -19,7 +19,7 @@ systemctl disable selinux-autorelabel.service
 # Write the code to run after reboot. It lists files with wrong SELinux contexts.
 cat > /usr/libexec/kickstart-test.sh << 'EOF'
 
-restorecon -rvn / -e /mnt -e /proc -e /run -e /sys
+restorecon -rvn / -e /dev -e /mnt -e /proc -e /run -e /sys
 
 EOF
 

--- a/selinux-contexts.sh
+++ b/selinux-contexts.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Vladimir Slavik <vslavik@redhat.com>
 
-TESTTYPE="security selinux gh607"
+TESTTYPE="security selinux"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Somehow this path disappeared during changes to the test with no explanation.

Closes #607

