### PR TITLE
Create tag for manual tests, mark the unified tests as such

### DIFF
--- a/.github/workflows/daily-boot-iso-rhel8.yml
+++ b/.github/workflows/daily-boot-iso-rhel8.yml
@@ -99,7 +99,7 @@ jobs:
           cp /home/github/rhel8-daily-boot.iso data/images/boot.iso
 
       - name: Run coverage tests
-        run: sudo TEST_JOBS=16 containers/runner/launch --retry --testtype coverage --skip-testtypes skip-on-rhel,skip-on-rhel-8,knownfailure --platform rhel8 --defaults $PWD/scripts/defaults-rhel8.sh
+        run: sudo TEST_JOBS=16 containers/runner/launch --retry --testtype coverage --skip-testtypes skip-on-rhel,skip-on-rhel-8,knownfailure,manual --platform rhel8 --defaults $PWD/scripts/defaults-rhel8.sh
 
       - name: Upload test logs
         if: always()

--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -10,9 +10,9 @@ SCENARIO="$1"
 shift
 
 case "$SCENARIO" in
-    rawhide) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure "$@" all ;;
-    rawhide-text) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure --run-args '-eKSTEST_EXTRA_BOOTOPTS=inst.text' "$@" all ;;
-    daily-iso) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure,rhbz1973156,gh595,gh576 --daily-iso="$GITHUB_TOKEN" "$@" all ;;
+    rawhide) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure,manual "$@" all ;;
+    rawhide-text) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure,manual --run-args '-eKSTEST_EXTRA_BOOTOPTS=inst.text' "$@" all ;;
+    daily-iso) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure,manual,rhbz1973156,gh595,gh576 --daily-iso="$GITHUB_TOKEN" "$@" all ;;
 
     rhel8)
         if [ ! -e data/images/boot.iso ]; then
@@ -20,7 +20,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes skip-on-rhel,knownfailure,skip-on-rhel-8,rhbz1973156,gh564,gh595,gh576 --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
+        $LAUNCH --skip-testtypes skip-on-rhel,knownfailure,manual,skip-on-rhel-8,rhbz1973156,gh564,gh595,gh576 --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
         ;;
 
     rhel9)
@@ -29,7 +29,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9/latest-RHEL-9.0/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes skip-on-rhel,skip-on-rhel-9,knownfailure,rhbz1960279,rhbz1973156,gh595,gh564,gh601,gh576 --platform rhel9 --defaults "$ROOTDIR/scripts/defaults-rhel9.sh" all
+        $LAUNCH --skip-testtypes skip-on-rhel,skip-on-rhel-9,knownfailure,manual,rhbz1960279,rhbz1973156,gh595,gh564,gh601,gh576 --platform rhel9 --defaults "$ROOTDIR/scripts/defaults-rhel9.sh" all
         ;;
 
     # just run a single test on standard Rawhide; mostly for testing infrastructure

--- a/scripts/run_travis.sh
+++ b/scripts/run_travis.sh
@@ -13,6 +13,8 @@ TESTS=""
 for t in $CHANGED_TESTS; do
     if grep -q 'TESTTYPE.*knownfailure' ${t}.sh; then
         echo "Not running $t as it is a known failure"
+    elif grep -q 'TESTTYPE.*manual' ${t}.sh; then
+        echo "Not running $t as it requires manual preparation"
     else
         TESTS="$TESTS
 $t"

--- a/unified-cdrom.sh
+++ b/unified-cdrom.sh
@@ -25,6 +25,6 @@
 # which will be the want used for booting in our case.
 #
 
-TESTTYPE="knownfailure"
+TESTTYPE="skip-on-fedora manual"
 
 . ${KSTESTDIR}/functions.sh

--- a/unified-cmdline.sh
+++ b/unified-cmdline.sh
@@ -19,7 +19,7 @@
 
 #TESTTYPE="packaging"
 
-TESTTYPE="knownfailure"
+TESTTYPE="skip-on-fedora manual"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/unified-harddrive.sh
+++ b/unified-harddrive.sh
@@ -19,7 +19,7 @@
 
 #TESTTYPE="packaging skip-on-fedora"
 
-TESTTYPE="knownfailure"
+TESTTYPE="skip-on-fedora manual"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/unified-nfs.sh
+++ b/unified-nfs.sh
@@ -19,6 +19,6 @@
 
 #TESTTYPE="packaging skip-on-fedora"
 
-TESTTYPE="knownfailure"
+TESTTYPE="skip-on-fedora manual"
 
 . ${KSTESTDIR}/functions.sh

--- a/unified.sh
+++ b/unified.sh
@@ -18,6 +18,6 @@
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 
 # times out
-TESTTYPE="packaging skip-on-fedora knownfailure"
+TESTTYPE="packaging skip-on-fedora manual"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
This adds a new tag "manual" that must be ignored by all users starting kickstart tests in bulk.

Adjust all the launchers accordingly.

Soft-blocked by https://github.com/rhinstaller/anaconda/pull/3687