### PR TITLE
Fix module installation tests 1-4

### DIFF
--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -12,7 +12,7 @@ shift
 case "$SCENARIO" in
     rawhide) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure "$@" all ;;
     rawhide-text) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure --run-args '-eKSTEST_EXTRA_BOOTOPTS=inst.text' "$@" all ;;
-    daily-iso) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure,rhbz1973156,gh575,gh595,gh576 --daily-iso="$GITHUB_TOKEN" "$@" all ;;
+    daily-iso) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure,rhbz1973156,gh595,gh576 --daily-iso="$GITHUB_TOKEN" "$@" all ;;
 
     rhel8)
         if [ ! -e data/images/boot.iso ]; then

--- a/module-1.ks.in
+++ b/module-1.ks.in
@@ -8,10 +8,10 @@
 %ksappend repos/modular.ks
 %ksappend common/common_no_payload.ks
 
-module --name=nodejs --stream=15
+module --name=nodejs --stream=16
 
 %packages
-@postgresql:13/server
+@postgresql:14/server
 %end
 
 %post

--- a/module-1.sh
+++ b/module-1.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
-TESTTYPE="packaging modularity skip-on-rhel gh575"
+TESTTYPE="packaging modularity skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/module-2.ks.in
+++ b/module-2.ks.in
@@ -8,10 +8,10 @@
 %ksappend repos/modular.ks
 %ksappend common/common_no_payload.ks
 
-module --name=nodejs --stream=15
+module --name=nodejs --stream=16
 
 %packages
-@nodejs:15/development
+@nodejs:16/development
 %end
 
 %post

--- a/module-2.sh
+++ b/module-2.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
-TESTTYPE="packaging modularity skip-on-rhel gh575"
+TESTTYPE="packaging modularity skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/module-3.ks.in
+++ b/module-3.ks.in
@@ -9,8 +9,8 @@
 
 %packages
 # lets use a non-default profile to see if it is correctly set afterwards
-@nodejs:15/default
-@nodejs:15/development
+@nodejs:16/default
+@nodejs:16/development
 %end
 
 %post
@@ -51,7 +51,7 @@ dnf module list --installed nodejs | grep "development[^,]*\[i\]" || echo "*** n
 dnf module list --installed nodejs | grep "minimal[^,]*\[i\]" && echo "*** nodejs module minimal profile marked as installed" >> /root/RESULT
 
 # check the stream
-dnf module list --enabled nodejs | grep "15[^,]*\[e\]" || echo "*** nodejs stream id 15 not marked as enabled" >> /root/RESULT
+dnf module list --enabled nodejs | grep "16[^,]*\[e\]" || echo "*** nodejs stream id 16 not marked as enabled" >> /root/RESULT
 
 %ksappend validation/success_if_result_empty.ks
 

--- a/module-3.sh
+++ b/module-3.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
-TESTTYPE="packaging modularity skip-on-rhel gh575"
+TESTTYPE="packaging modularity skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/module-4.ks.in
+++ b/module-4.ks.in
@@ -6,10 +6,10 @@
 %ksappend repos/modular.ks
 %ksappend common/common_no_payload.ks
 
-module --name=nodejs --stream=15
-module --name=nodejs --stream=15 --disable
-module --name=nodejs --stream=15
-module --name=postgresql --stream=13 --disable
+module --name=nodejs --stream=16
+module --name=nodejs --stream=16 --disable
+module --name=nodejs --stream=16
+module --name=postgresql --stream=14 --disable
 module --name=perl --stream=5.32
 
 %packages

--- a/module-4.sh
+++ b/module-4.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="packaging modularity skip-on-rhel gh575"
+TESTTYPE="packaging modularity skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
The unstoppable march of postgress yet again resulted in streams
that were once new and shiny being dead and forgotten and replaced
by streams that are new and shiny.

So fixup the module-1 to 4 tests with new and shiny nodejs and
postgressql stream names, fixing the tests once and for all (of November)!

Fixes #575