### PR TITLE
Use vga video driver until rhbz#2020438 is fixed

### DIFF
--- a/scripts/launcher/lib/virtual_controller.py
+++ b/scripts/launcher/lib/virtual_controller.py
@@ -123,7 +123,7 @@ class VirtualInstall(object):
             args.append("none")
 
         args.append("--video")
-        args.append("virtio")
+        args.append("vga")
 
         for ks in self._ks_paths:
             args.append("--initrd-inject")


### PR DESCRIPTION
Tracked in rhbz#2020438 and
https://github.com/rhinstaller/kickstart-tests/issues/618