### PR TITLE
Add libvirtd.log to the output logs

### DIFF
--- a/containers/runner/run-kstest
+++ b/containers/runner/run-kstest
@@ -56,7 +56,7 @@ mkdir -p ~/.cache/virt-manager/boot
 # Disable TLS; we don't have a certificate setup, and this is all local anyway
 mkdir -p ~/.config/libvirt
 printf 'listen_tls = 0\nlisten_tcp = 1\nauth_tcp = "none"\n' > ~/.config/libvirt/libvirtd.conf
-libvirtd --listen > ~/libvirtd.log 2>&1 &
+libvirtd --listen > ${LOGS_DIR}/libvirtd.log 2>&1 &
 
 # this only works with a bridged network; user containers use SLIRP and only have a tun0 interface
 if MY_IP=$(ip -4 -c a show dev eth0 2>/dev/null | grep -Eo '[0-9.]+\.[0-9]+' | grep -v '\.255'); then


### PR DESCRIPTION
It may contain useful information especially in case that the VM doesn't start. Without this log it's hard to debug such a case.