### PR TITLE
Master fix driverdisk test

### DIFF
--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -12,7 +12,7 @@ shift
 case "$SCENARIO" in
     rawhide) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure,manual "$@" all ;;
     rawhide-text) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure,manual --run-args '-eKSTEST_EXTRA_BOOTOPTS=inst.text' "$@" all ;;
-    daily-iso) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure,manual,rhbz1973156,gh595,gh576 --daily-iso="$GITHUB_TOKEN" "$@" all ;;
+    daily-iso) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure,manual,gh595,gh576 --daily-iso="$GITHUB_TOKEN" "$@" all ;;
 
     rhel8)
         if [ ! -e data/images/boot.iso ]; then
@@ -20,7 +20,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes skip-on-rhel,knownfailure,manual,skip-on-rhel-8,rhbz1973156,gh564,gh595,gh576 --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
+        $LAUNCH --skip-testtypes skip-on-rhel,knownfailure,manual,skip-on-rhel-8,gh564,gh595,gh576 --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
         ;;
 
     rhel9)
@@ -29,7 +29,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9/latest-RHEL-9.0/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes skip-on-rhel,skip-on-rhel-9,knownfailure,manual,rhbz1960279,rhbz1973156,gh595,gh564,gh601,gh576 --platform rhel9 --defaults "$ROOTDIR/scripts/defaults-rhel9.sh" all
+        $LAUNCH --skip-testtypes skip-on-rhel,skip-on-rhel-9,knownfailure,manual,rhbz1960279,gh595,gh564,gh601,gh576 --platform rhel9 --defaults "$ROOTDIR/scripts/defaults-rhel9.sh" all
         ;;
 
     # just run a single test on standard Rawhide; mostly for testing infrastructure

--- a/driverdisk-disk.sh
+++ b/driverdisk-disk.sh
@@ -15,7 +15,7 @@
 #
 # Author: Will Woods <wwoods@redhat.com>
 
-TESTTYPE="driverdisk rhbz1973156"
+TESTTYPE="driverdisk"
 
 . ${KSTESTDIR}/functions.sh
 
@@ -27,7 +27,7 @@ prepare_disks() {
 
     # driverdisk image
     ${KSTESTDIR}/lib/mkdud.py -k -b -L "TEST_DD" ${diskdir}/dd.iso >/dev/null
-    echo "${diskdir}/dd.iso,device=cdrom,readonly=on"
+    echo "path=${diskdir}/dd.iso,device=cdrom,readonly=on"
 }
 
 #kernel_args() {

--- a/functions.sh
+++ b/functions.sh
@@ -65,6 +65,11 @@ prepare_updates() {
 }
 
 prepare_disks() {
+    # This function has to 'echo' one of the following.
+    #
+    # echo '<disk_path>'                                    -- ',bus=virtio' will be added automatically
+    # echo '<disk_path>,<virt_install_disk_arguments>'      -- ',bus=virtio' will be added automatically
+    # echo 'path=<disk_path>,<virt_install_disk_arguments>' -- the string is taken in this form (nothing will be added)
     tmpdir=$1
 
     qemu-img create -q -f qcow2 ${tmpdir}/disk-a.img 10G

--- a/scripts/launcher/lib/virtual_controller.py
+++ b/scripts/launcher/lib/virtual_controller.py
@@ -131,7 +131,10 @@ class VirtualInstall(object):
 
         for disk in self._disk_paths:
             args.append("--disk")
-            args.append("path={0},bus=virtio".format(disk))
+            if disk.startswith("path="):
+                args.append(disk)
+            else:
+                args.append("path={0},bus=virtio".format(disk))
 
         nics = self._nics or ["user"]
         for nic in nics:


### PR DESCRIPTION
The problem was that cdrom couldn't be type of 'virtio' but 'virtio' type was added automatically. Change the solution that when the disk string starts with `path=` it will not change this string and allow complete specification.

Closes #605.