### PR TITLE
Add new driverdisk test which will test inst.dd kernel args

### DIFF
--- a/driverdisk-disk-kargs.ks.in
+++ b/driverdisk-disk-kargs.ks.in
@@ -1,0 +1,35 @@
+#version=DEVEL
+#test name: driverdisk-disk
+%ksappend repos/default.ks
+
+%ksappend common/common_no_payload.ks
+%ksappend payload/default_packages.ks
+
+%post --nochroot
+SYSROOT=${ANA_INSTALL_PATH:-/mnt/sysimage}
+RESULTFILE=$SYSROOT/root/RESULT
+fail() { echo "*** $*" >> $RESULTFILE; }
+
+
+# Module version folder is created by the RPM with driver disk. The RPM is
+# created by the script in lib/mkdud.py. The kernel version is 3.0.0 if
+# version parameter is not explicitly set. Because the tests are run on a
+# boot.iso, we don't know which kernel version is there in time of the script
+# execution.
+# TODO: This can be improved by grabbing logs from Lorax when building this iso
+# or by running the boot.iso in some pre-testing phase.
+
+# check the installer environment
+[ -f /usr/lib/modules/3.0.0/extra/fake-dd.ko ] || fail "kmod not loaded"
+[ -f /usr/bin/fake-dd-bin ] || fail "installer-enhancement not loaded"
+
+# check the installed system
+[ -f $SYSROOT/root/fake-dd-2.ko ] || fail "kmod rpm not installed"
+[ ! -f $SYSROOT/usr/bin/fake-dd-bin ] || \
+    fail "installer-enhancement package installed to target system"
+
+# write successful result if nothing failed
+if [[ ! -e $RESULTFILE ]]; then
+    echo SUCCESS > $RESULTFILE
+fi
+%end

--- a/driverdisk-disk-kargs.sh
+++ b/driverdisk-disk-kargs.sh
@@ -15,7 +15,7 @@
 #
 # Author: Will Woods <wwoods@redhat.com>
 
-TESTTYPE="driverdisk rhbz1973156"
+TESTTYPE="driverdisk"
 
 . ${KSTESTDIR}/functions.sh
 
@@ -27,5 +27,9 @@ prepare_disks() {
 
     # driverdisk image
     ${KSTESTDIR}/lib/mkdud.py -k -b -L "TEST_DD" ${diskdir}/dd.iso >/dev/null
-    echo "${diskdir}/dd.iso,device=cdrom,readonly=on"
+    echo "path=${diskdir}/dd.iso,device=cdrom,readonly=on"
+}
+
+kernel_args() {
+   echo inst.dd=/dev/disk/by-label/TEST_DD
 }

--- a/driverdisk-disk.ks.in
+++ b/driverdisk-disk.ks.in
@@ -1,24 +1,11 @@
 #version=DEVEL
 #test name: driverdisk-disk
 %ksappend repos/default.ks
-network --bootproto=dhcp
 
-keyboard us
-lang en_US.UTF-8
-timezone America/New_York --utc
-rootpw testcase
-shutdown
-
-bootloader --timeout=1
-zerombr
-clearpart --all
-autopart
+%ksappend common/common_no_payload.ks
+%ksappend payload/default_packages.ks
 
 driverdisk /dev/disk/by-label/TEST_DD
-
-%packages
-@core
-%end
 
 %post --nochroot
 SYSROOT=${ANA_INSTALL_PATH:-/mnt/sysimage}


### PR DESCRIPTION
The driverdisk test is using kickstart command but it would be great to have both variants tested.

This will not work until https://github.com/rhinstaller/kickstart-tests/pull/621 is merged.