### PR TITLE
Enable anabot-1 and packages-and-groups-1

### DIFF
--- a/anabot-1.sh
+++ b/anabot-1.sh
@@ -15,7 +15,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-TESTTYPE="ui anabot skip-on-rhel-8"
+TESTTYPE="ui anabot skip-on-rhel-8 knownfailure"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/anabot-1.sh
+++ b/anabot-1.sh
@@ -15,7 +15,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-TESTTYPE="ui anabot skip-on-rhel-8 gh601"
+TESTTYPE="ui anabot skip-on-rhel-8"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -20,7 +20,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8.6/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes skip-on-rhel,knownfailure,manual,skip-on-rhel-8,gh564,gh595,gh576 --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
+        $LAUNCH --skip-testtypes skip-on-rhel,knownfailure,manual,skip-on-rhel-8,gh595,gh576 --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
         ;;
 
     rhel9)
@@ -29,7 +29,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9/latest-RHEL-9.0/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes skip-on-rhel,skip-on-rhel-9,knownfailure,manual,rhbz1960279,gh595,gh564,gh601,gh576 --platform rhel9 --defaults "$ROOTDIR/scripts/defaults-rhel9.sh" all
+        $LAUNCH --skip-testtypes skip-on-rhel,skip-on-rhel-9,knownfailure,manual,rhbz1960279,gh595,gh576 --platform rhel9 --defaults "$ROOTDIR/scripts/defaults-rhel9.sh" all
         ;;
 
     # just run a single test on standard Rawhide; mostly for testing infrastructure

--- a/packages-and-groups-1.sh
+++ b/packages-and-groups-1.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="packaging gh564"
+TESTTYPE="packaging"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
It looks like there was a new release of the vdo package that required a newer
kernel, but only the old one was available in the development compose.

If it happens again, we might need to reconsider the development composes or
use another environment in these tests.

Resolves: gh#601, gh#564