### PR TITLE
Re-enable basic-ftp on daily-iso

### DIFF
--- a/basic-ftp.sh
+++ b/basic-ftp.sh
@@ -18,7 +18,6 @@
 #
 # Red Hat Author(s): David Shea <dshea@redhat.com>
 
-# dnf crashes with zchunk errors on ftp:// repos: https://bugzilla.redhat.com/show_bug.cgi?id=1886706
-TESTTYPE="method knownfailure"
+TESTTYPE="method skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
rhbz#1886706 is fixed

For rhel, we might need to find a suitable ftp repo. Using Fedora one
can be very fragile, if possible at all.