### PR TITLE
Remove the definition of skip-testtypes from the scenario script

### DIFF
--- a/.github/workflows/daily-boot-iso-rhel8.yml
+++ b/.github/workflows/daily-boot-iso-rhel8.yml
@@ -99,7 +99,9 @@ jobs:
           cp /home/github/rhel8-daily-boot.iso data/images/boot.iso
 
       - name: Run coverage tests
-        run: sudo TEST_JOBS=16 containers/runner/launch --retry --testtype coverage --skip-testtypes skip-on-rhel,skip-on-rhel-8,knownfailure,manual --platform rhel8 --defaults $PWD/scripts/defaults-rhel8.sh
+        run: |
+          source $PWD/containers/runner/skip-testtypes
+          sudo TEST_JOBS=16 containers/runner/launch --retry --testtype coverage --skip-testtypes "$SKIP_TESTTYPES_RHEL8_DAILY" --platform rhel8 --defaults $PWD/scripts/defaults-rhel8.sh
 
       - name: Upload test logs
         if: always()

--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -9,10 +9,13 @@ ROOTDIR=$(dirname $(dirname "$MYDIR"))
 SCENARIO="$1"
 shift
 
+# Read the test types (SKIP_TESTTYPES_*) to be skipped by scenarios
+source "$MYDIR/skip-testtypes"
+
 case "$SCENARIO" in
-    rawhide) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure,manual "$@" all ;;
-    rawhide-text) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure,manual --run-args '-eKSTEST_EXTRA_BOOTOPTS=inst.text' "$@" all ;;
-    daily-iso) $LAUNCH --skip-testtypes skip-on-fedora,knownfailure,manual,gh595,gh576,rhbz2018913 --daily-iso="$GITHUB_TOKEN" "$@" all ;;
+    rawhide) $LAUNCH --skip-testtypes "$SKIP_TESTTYPES_RAWHIDE" "$@" all ;;
+    rawhide-text) $LAUNCH --skip-testtypes "$SKIP_TESTTYPES_RAWHIDE_TEXT" --run-args '-eKSTEST_EXTRA_BOOTOPTS=inst.text' "$@" all ;;
+    daily-iso) $LAUNCH --skip-testtypes "$SKIP_TESTTYPES_DAILY_ISO" --daily-iso="$GITHUB_TOKEN" "$@" all ;;
 
     rhel8)
         if [ ! -e data/images/boot.iso ]; then
@@ -20,7 +23,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8.6/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes skip-on-rhel,knownfailure,manual,skip-on-rhel-8,gh595,gh576 --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
+        $LAUNCH --skip-testtypes "$SKIP_TESTTYPES_RHEL8" --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
         ;;
 
     rhel9)
@@ -29,7 +32,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9/latest-RHEL-9.0/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes skip-on-rhel,skip-on-rhel-9,knownfailure,manual,rhbz1960279,gh595,gh576 --platform rhel9 --defaults "$ROOTDIR/scripts/defaults-rhel9.sh" all
+        $LAUNCH --skip-testtypes "$SKIP_TESTTYPES_RHEL9" --platform rhel9 --defaults "$ROOTDIR/scripts/defaults-rhel9.sh" all
         ;;
 
     # just run a single test on standard Rawhide; mostly for testing infrastructure

--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -1,0 +1,58 @@
+# The file defines types of tests to be skipped by the --skip-testtypes option
+# of the containers/runner/launch script.
+# The file is sourced from shell scripts.
+
+# test types skipped in all scenarios
+common_skip_array=(
+  knownfailure
+  manual
+)
+
+rawhide_skip_array=(
+  skip-on-fedora
+)
+
+rawhide_text_skip_array=(
+  skip-on-fedora
+)
+
+daily_iso_skip_array=(
+  skip-on-fedora
+  gh576       # clearpart-4 test is flaky on all scenarios
+  gh595       # proxy-cmdline failing on all scenarios
+  rhbz2018913 # /etc/resolv.conf is not a symlink after kickstart
+)
+
+rhel8_skip_array=(
+  skip-on-rhel
+  skip-on-rhel-8
+  gh576       # clearpart-4 test is flaky on all scenarios
+  gh595       # proxy-cmdline failing on all scenarios
+)
+
+rhel9_skip_array=(
+  skip-on-rhel
+  skip-on-rhel-9
+  gh576       # clearpart-4 test is flaky on all scenarios
+  gh595       # proxy-cmdline failing on all scenarios
+  rhbz1960279 # packages-weakdeps: "gnupg2 --recommends has changed, test needs to be updated"
+)
+
+# used in workflows/daily-boot-iso-rhel8.yml
+rhel8_daily_skip_array=(
+  skip-on-rhel
+  skip-on-rhel-8
+)
+
+_join_args_by_comma(){
+  local IFS=","
+  echo "$*"
+}
+
+# Do not forget to add new releases below as well
+SKIP_TESTTYPES_RAWHIDE=$(_join_args_by_comma "${common_skip_array[@]}" "${rawhide_skip_array[@]}")
+SKIP_TESTTYPES_RAWHIDE_TEXT=$(_join_args_by_comma "${common_skip_array[@]}" "${rawhide_text_skip_array[@]}")
+SKIP_TESTTYPES_DAILY_ISO=$(_join_args_by_comma "${common_skip_array[@]}" "${daily_iso_skip_array[@]}")
+SKIP_TESTTYPES_RHEL8=$(_join_args_by_comma "${common_skip_array[@]}" "${rhel8_skip_array[@]}")
+SKIP_TESTTYPES_RHEL9=$(_join_args_by_comma "${common_skip_array[@]}" "${rhel9_skip_array[@]}")
+SKIP_TESTTYPES_RHEL8_DAILY=$(_join_args_by_comma "${common_skip_array[@]}" "${rhel8_daily_skip_array[@]}")


### PR DESCRIPTION
The main motivation for this change is to be able to use the defined skip-testtypes from other scripts than `containers/runner/scenario`. Specifically to make it easier to run kickstart-tests in downstream.