### PR TITLE
Revert "Use vga video driver until rhbz#2020438 is fixed"

### DIFF
--- a/scripts/launcher/lib/virtual_controller.py
+++ b/scripts/launcher/lib/virtual_controller.py
@@ -123,7 +123,7 @@ class VirtualInstall(object):
             args.append("none")
 
         args.append("--video")
-        args.append("vga")
+        args.append("virtio")
 
         for ks in self._ks_paths:
             args.append("--initrd-inject")


### PR DESCRIPTION
This reverts commit 01fd0ff7a8ee4d33d1c7b86a726dcfd0b1614270.