### PR TITLE
Install only minimal package set by anabot

### DIFF
--- a/anabot-1.xml
+++ b/anabot-1.xml
@@ -16,6 +16,9 @@
       <disk name="*" action="select" />
       <done />
     </partitioning>
+    <software_selection>
+      <environment id="minimal-environment" />
+    </software_selection>
     <begin_installation />
   </hub>
   <configuration>


### PR DESCRIPTION
Fewer packages means less time to run the test.
Fewer packages means lower chance of hitting issues with broken rpm
dependencies (like kmod-kvdo).
Fewer packages means ~330 instead of ~1160 on RHEL.

On the other hand, there is no benefit for rawhide/Everything variant,
where the default and minimal environments install the same package set.