### PR TITLE
Replace the ANA_INSTALL_PATH variable

### DIFF
--- a/autopart-encrypted-3.ks.in
+++ b/autopart-encrypted-3.ks.in
@@ -37,8 +37,8 @@ certutil -d /tmp/escrow_test/nss -L -n escrow_cert -a -o /tmp/escrow_test/escrow
 
 %pre-install
 # Copy the escrow database to the install path so we can use it during %post
-mkdir $ANA_INSTALL_PATH/root
-cp -a /tmp/escrow_test $ANA_INSTALL_PATH/root/
+mkdir /mnt/sysroot/root
+cp -a /tmp/escrow_test /mnt/sysroot/root/
 %end
 
 %post

--- a/bootloader-2.ks.in
+++ b/bootloader-2.ks.in
@@ -24,16 +24,14 @@ dd if=/dev/vda bs=512 count=1 of=/tmp/pre_install_mbr_content.bin
 
 
 %post --nochroot
-SYSROOT=${ANA_INSTALL_PATH:-/mnt/sysimage}
-
 # Get the current MBR.
 dd if=/dev/vda bs=512 count=1 of=/tmp/current_mbr_content.bin
 
 # Check the MBR.
 cmp /tmp/pre_install_mbr_content.bin /tmp/current_mbr_content.bin
 if [[ $? -ne 1 ]]; then
-    echo '*** Failed check: MBR should be changed' >> ${ANA_INSTALL_PATH}/root/RESULT
+    echo '*** Failed check: MBR should be changed' >> /mnt/sysroot/root/RESULT
 else
-    echo SUCCESS > ${ANA_INSTALL_PATH}/root/RESULT
+    echo SUCCESS > /mnt/sysroot/root/RESULT
 fi
 %end

--- a/bootloader-3.ks.in
+++ b/bootloader-3.ks.in
@@ -24,16 +24,14 @@ dd if=/dev/vda bs=512 count=1 of=/tmp/pre_install_mbr_content.bin
 
 
 %post --nochroot
-SYSROOT=${ANA_INSTALL_PATH:-/mnt/sysimage}
-
 # Get the current MBR.
 dd if=/dev/vda bs=512 count=1 of=/tmp/current_mbr_content.bin
 
 # Check the MBR.
 cmp /tmp/pre_install_mbr_content.bin /tmp/current_mbr_content.bin
 if [[ $? -ne 0 ]]; then
-    echo '*** Failed check: MBR should be the same' >> ${ANA_INSTALL_PATH}/root/RESULT
+    echo '*** Failed check: MBR should be the same' >> /mnt/sysroot/root/RESULT
 else
-    echo SUCCESS > ${ANA_INSTALL_PATH}/root/RESULT
+    echo SUCCESS > /mnt/sysroot/root/RESULT
 fi
 %end

--- a/bootloader-4.ks.in
+++ b/bootloader-4.ks.in
@@ -25,8 +25,6 @@ dd if=/dev/vdb bs=512 count=1 of=/tmp/pre_install_mbr_vdb.bin
 
 
 %post --nochroot
-SYSROOT=${ANA_INSTALL_PATH:-/mnt/sysimage}
-
 # Get the current MBR.
 dd if=/dev/vda bs=512 count=1 of=/tmp/current_mbr_vda.bin
 dd if=/dev/vdb bs=512 count=1 of=/tmp/current_mbr_vdb.bin
@@ -34,16 +32,16 @@ dd if=/dev/vdb bs=512 count=1 of=/tmp/current_mbr_vdb.bin
 # Check the MBR. The boot drive is defined by --boot-drive.
 cmp /tmp/pre_install_mbr_vda.bin /tmp/current_mbr_vda.bin
 if [[ $? -ne 0 ]]; then
-    echo '*** Failed check: MBR should be the same on vda' >> ${ANA_INSTALL_PATH}/root/RESULT
+    echo '*** Failed check: MBR should be the same on vda' >> /mnt/sysroot/root/RESULT
 fi
 
 cmp /tmp/pre_install_mbr_vdb.bin /tmp/current_mbr_vdb.bin
 if [[ $? -ne 1 ]]; then
-    echo '*** Failed check: MBR should be changed on vdb' >> ${ANA_INSTALL_PATH}/root/RESULT
+    echo '*** Failed check: MBR should be changed on vdb' >> /mnt/sysroot/root/RESULT
 fi
 
 # The test was successful.
-if [ ! -e  ${ANA_INSTALL_PATH}/root/RESULT ]; then
-    echo SUCCESS >  ${ANA_INSTALL_PATH}/root/RESULT
+if [ ! -e  /mnt/sysroot/root/RESULT ]; then
+    echo SUCCESS >  /mnt/sysroot/root/RESULT
 fi
 %end

--- a/bootloader-5.ks.in
+++ b/bootloader-5.ks.in
@@ -25,8 +25,6 @@ dd if=/dev/vdb bs=512 count=1 of=/tmp/pre_install_mbr_vdb.bin
 
 
 %post --nochroot
-SYSROOT=${ANA_INSTALL_PATH:-/mnt/sysimage}
-
 # Get the current MBR.
 dd if=/dev/vda bs=512 count=1 of=/tmp/current_mbr_vda.bin
 dd if=/dev/vdb bs=512 count=1 of=/tmp/current_mbr_vdb.bin
@@ -34,16 +32,16 @@ dd if=/dev/vdb bs=512 count=1 of=/tmp/current_mbr_vdb.bin
 # Check the MBR. The boot drive is defined by the first usable drive from --driveorder.
 cmp /tmp/pre_install_mbr_vda.bin /tmp/current_mbr_vda.bin
 if [[ $? -ne 0 ]]; then
-    echo '*** Failed check: MBR should be the same on vda' >> ${ANA_INSTALL_PATH}/root/RESULT
+    echo '*** Failed check: MBR should be the same on vda' >> /mnt/sysroot/root/RESULT
 fi
 
 cmp /tmp/pre_install_mbr_vdb.bin /tmp/current_mbr_vdb.bin
 if [[ $? -ne 1 ]]; then
-    echo '*** Failed check: MBR should be changed on vdb' >> ${ANA_INSTALL_PATH}/root/RESULT
+    echo '*** Failed check: MBR should be changed on vdb' >> /mnt/sysroot/root/RESULT
 fi
 
 # The test was successful.
-if [ ! -e  ${ANA_INSTALL_PATH}/root/RESULT ]; then
-    echo SUCCESS >  ${ANA_INSTALL_PATH}/root/RESULT
+if [ ! -e  /mnt/sysroot/root/RESULT ]; then
+    echo SUCCESS >  /mnt/sysroot/root/RESULT
 fi
 %end

--- a/clearpart-2.ks.in
+++ b/clearpart-2.ks.in
@@ -43,7 +43,7 @@ rmdir /vdb
 %end
 
 %post --nochroot
-SYSROOT=${ANA_INSTALL_PATH:-/mnt/sysimage}
+SYSROOT=/mnt/sysroot
 
 # Check that /dev/vda1 was cleared:
 

--- a/clearpart-3.ks.in
+++ b/clearpart-3.ks.in
@@ -43,7 +43,7 @@ rmdir /vdb
 %end
 
 %post --nochroot
-SYSROOT=${ANA_INSTALL_PATH:-/mnt/sysimage}
+SYSROOT=/mnt/sysroot
 
 # Check that /dev/vda1 was cleared:
 

--- a/clearpart-4.ks.in
+++ b/clearpart-4.ks.in
@@ -43,7 +43,7 @@ rmdir /vdb
 %end
 
 %post --nochroot
-SYSROOT=${ANA_INSTALL_PATH:-/mnt/sysimage}
+SYSROOT=/mnt/sysroot
 
 # Check that /dev/vda1 was cleared:
 

--- a/dracut-visible-warnings.ks.in
+++ b/dracut-visible-warnings.ks.in
@@ -6,7 +6,7 @@
 %ksappend payload/default_packages.ks
 
 %post --nochroot
-SYSROOT=${ANA_INSTALL_PATH:-/mnt/sysimage}
+SYSROOT=/mnt/sysroot
 
 for name in sshd vnc; do
     ERROR_MSG="'$name' is deprecated and has been removed"

--- a/driverdisk-disk-kargs.ks.in
+++ b/driverdisk-disk-kargs.ks.in
@@ -6,7 +6,7 @@
 %ksappend payload/default_packages.ks
 
 %post --nochroot
-SYSROOT=${ANA_INSTALL_PATH:-/mnt/sysimage}
+SYSROOT=/mnt/sysroot
 RESULTFILE=$SYSROOT/root/RESULT
 fail() { echo "*** $*" >> $RESULTFILE; }
 

--- a/driverdisk-disk.ks.in
+++ b/driverdisk-disk.ks.in
@@ -8,7 +8,7 @@
 driverdisk /dev/disk/by-label/TEST_DD
 
 %post --nochroot
-SYSROOT=${ANA_INSTALL_PATH:-/mnt/sysimage}
+SYSROOT=/mnt/sysroot
 RESULTFILE=$SYSROOT/root/RESULT
 fail() { echo "*** $*" >> $RESULTFILE; }
 

--- a/escrow-cert.ks.in
+++ b/escrow-cert.ks.in
@@ -38,8 +38,8 @@ certutil -d /tmp/escrow_test/nss -L -n escrow_cert -a -o /tmp/escrow_test/escrow
 
 %pre-install
 # Copy the escrow database to the install path so we can use it during %post
-mkdir $ANA_INSTALL_PATH/root
-cp -a /tmp/escrow_test $ANA_INSTALL_PATH/root/
+mkdir /mnt/sysroot/root
+cp -a /tmp/escrow_test /mnt/sysroot/root/
 %end
 
 %packages

--- a/geolocation-off-by-default-with-ks.ks.in
+++ b/geolocation-off-by-default-with-ks.ks.in
@@ -20,8 +20,7 @@ shutdown
 
 %post --nochroot
 # Specify the result file.
-SYSROOT=${ANA_INSTALL_PATH:-/mnt/sysimage}
-RESULT_FILE=${SYSROOT}/root/RESULT
+RESULT_FILE=/mnt/sysroot/root/RESULT
 
 # Geolocation should be off by default during a kickstart installation.
 # This can be tested by checking if the sensitive-info log contains

--- a/ignoredisk-1.ks.in
+++ b/ignoredisk-1.ks.in
@@ -31,7 +31,7 @@ rmdir /vdb
 %end
 
 %post --nochroot
-SYSROOT=${ANA_INSTALL_PATH:-/mnt/sysimage}
+SYSROOT=/mnt/sysroot
 
 mkdir /vdb
 mount /dev/vdb1 /vdb

--- a/ignoredisk-2.ks.in
+++ b/ignoredisk-2.ks.in
@@ -31,7 +31,7 @@ rmdir /vdb
 %end
 
 %post --nochroot
-SYSROOT=${ANA_INSTALL_PATH:-/mnt/sysimage}
+SYSROOT=/mnt/sysroot
 
 mkdir /vdb
 mount /dev/vdb1 /vdb

--- a/iscsi-bind.ks.in
+++ b/iscsi-bind.ks.in
@@ -27,7 +27,7 @@ shutdown
 
 %post --nochroot
 
-SYSROOT=${ANA_INSTALL_PATH:-/mnt/sysimage}
+SYSROOT=/mnt/sysroot
 
 function check_iscsi_session_nochroot() {
     local transport="$1"

--- a/iscsi.ks.in
+++ b/iscsi.ks.in
@@ -27,7 +27,7 @@ shutdown
 
 %post --nochroot
 
-SYSROOT=${ANA_INSTALL_PATH:-/mnt/sysimage}
+SYSROOT=/mnt/sysroot
 
 function check_iscsi_session_nochroot() {
     local transport="$1"

--- a/post-nochroot-lib-keyboard.sh
+++ b/post-nochroot-lib-keyboard.sh
@@ -1,4 +1,4 @@
-SYSROOT=${ANA_INSTALL_PATH:-/mnt/sysimage}
+SYSROOT=/mnt/sysroot
 RESULT_FILE=${SYSROOT}/root/RESULT
 
 # check_current_vc_keymap VC_KEYMAP "yes"|"no"

--- a/post-nochroot-lib-network.sh
+++ b/post-nochroot-lib-network.sh
@@ -1,4 +1,4 @@
-SYSROOT=${ANA_INSTALL_PATH:-/mnt/sysimage}
+SYSROOT=/mnt/sysroot
 
 # check_bridge_has_slave_nochroot BRIDGE SLAVE "yes|no"
 # Check that the bridge device BRIDGE has ("yes") or has not ("no") a slave device SLAVE

--- a/post-nochroot-lib-ui.sh
+++ b/post-nochroot-lib-ui.sh
@@ -1,7 +1,7 @@
 # The library for nochroot post scripts of the UI kickstart tests.
 
 # Specify the result file.
-SYSROOT=${ANA_INSTALL_PATH:-/mnt/sysimage}
+SYSROOT=/mnt/sysroot
 RESULT_FILE=${SYSROOT}/root/RESULT
 
 # Check that the current display mode is set to the expected value.

--- a/pre-install.ks.in
+++ b/pre-install.ks.in
@@ -20,8 +20,8 @@ shutdown
 
 %pre-install
 # TEST setting up /etc/passwd before package installation
-mkdir $ANA_INSTALL_PATH/etc
-cat > $ANA_INSTALL_PATH/etc/passwd << EOF
+mkdir /mnt/sysroot/etc
+cat > /mnt/sysroot/etc/passwd << EOF
 root:x:0:0:root:/root:/bin/bash
 bin:x:1:1:bin:/bin:/sbin/nologin
 daemon:x:2:2:daemon:/sbin:/sbin/nologin

--- a/proxy-auth.ks.in
+++ b/proxy-auth.ks.in
@@ -23,42 +23,42 @@ shutdown
 httpsdir=$(echo "@KSTEST_URL@" | grep -e '--url="\?https:')
 
 # Check that the addon repo file was installed
-if [[ ! -f $ANA_INSTALL_PATH/etc/yum.repos.d/kstest-http.repo ]]; then
-    echo 'kstest-http.repo does not exist' >> $ANA_INSTALL_PATH/root/RESULT
+if [[ ! -f /mnt/sysroot/etc/yum.repos.d/kstest-http.repo ]]; then
+    echo 'kstest-http.repo does not exist' >> /mnt/sysroot/root/RESULT
 fi
 
 # Check that the proxy configuration was written to the repo file
-grep -q 'proxy=http://anaconda:qweqwe@PROXY-ADDON' $ANA_INSTALL_PATH/etc/yum.repos.d/kstest-http.repo
+grep -q 'proxy=http://anaconda:qweqwe@PROXY-ADDON' /mnt/sysroot/etc/yum.repos.d/kstest-http.repo
 if [[ $? -ne 0 ]]; then
-    echo 'kstest-http.repo does not contain proxy information' >> $ANA_INSTALL_PATH/root/RESULT
+    echo 'kstest-http.repo does not contain proxy information' >> /mnt/sysroot/root/RESULT
 fi
 
 # Check that the installed repo file is usable
 # Find if this is using yum or dnf
-if [[ -f $ANA_INSTALL_PATH/usr/bin/dnf ]]; then
+if [[ -f /mnt/sysroot/usr/bin/dnf ]]; then
 	BIN="dnf"
 else
 	BIN="yum"
 fi
 
 # Clean packages to force package download
-chroot $ANA_INSTALL_PATH $BIN clean packages
+chroot /mnt/sysroot $BIN clean packages
 
 # Download package to test if the installed repository is usable
-chroot $ANA_INSTALL_PATH \
+chroot /mnt/sysroot \
     $BIN --disablerepo=\* --enablerepo=kstest-http --downloadonly --nogpgcheck -y \
          reinstall testpkg-http-core 2>/dev/null | \
         grep -q 'testpkg-http-core'
 if [[ $? -ne 0 ]]; then
-    echo 'unable to query kstest-http repo' >> $ANA_INSTALL_PATH/root/RESULT
+    echo 'unable to query kstest-http repo' >> /mnt/sysroot/root/RESULT
 fi
 
 # If nothing was written to RESULT, it worked
-if [[ ! -f $ANA_INSTALL_PATH/root/RESULT ]]; then
+if [[ ! -f /mnt/sysroot/root/RESULT ]]; then
     if [ "$httpsdir" ]; then
-        echo 'SUCCESS but limited testing for TLS repository server' > $ANA_INSTALL_PATH/root/RESULT
+        echo 'SUCCESS but limited testing for TLS repository server' > /mnt/sysroot/root/RESULT
     else
-        echo 'SUCCESS' > $ANA_INSTALL_PATH/root/RESULT
+        echo 'SUCCESS' > /mnt/sysroot/root/RESULT
     fi
 fi
 

--- a/proxy-kickstart.ks.in
+++ b/proxy-kickstart.ks.in
@@ -24,41 +24,41 @@ shutdown
 httpsdir=$(echo "@KSTEST_URL@" | grep -e '--url="\?https:')
 
 # Check that the addon repo file was installed
-if [[ ! -f $ANA_INSTALL_PATH/etc/yum.repos.d/kstest-http.repo ]]; then
-    echo 'kstest-http.repo does not exist' >> $ANA_INSTALL_PATH/root/RESULT
+if [[ ! -f /mnt/sysroot/etc/yum.repos.d/kstest-http.repo ]]; then
+    echo 'kstest-http.repo does not exist' >> /mnt/sysroot/root/RESULT
 fi
 
 # Check that the proxy configuration was written to the repo file
-grep -q 'proxy=PROXY-ADDON' $ANA_INSTALL_PATH/etc/yum.repos.d/kstest-http.repo
+grep -q 'proxy=PROXY-ADDON' /mnt/sysroot/etc/yum.repos.d/kstest-http.repo
 if [[ $? -ne 0 ]]; then
-    echo 'kstest-http.repo does not contain proxy information' >> $ANA_INSTALL_PATH/root/RESULT
+    echo 'kstest-http.repo does not contain proxy information' >> /mnt/sysroot/root/RESULT
 fi
 
 # Check that the installed repo file is usable
 # Find if this is using yum or dnf
-if [[ -f $ANA_INSTALL_PATH/usr/bin/dnf ]]; then
+if [[ -f /mnt/sysroot/usr/bin/dnf ]]; then
 	BIN="dnf"
 else
 	BIN="yum"
 fi
 
 # Clean packages to force package download
-chroot $ANA_INSTALL_PATH $BIN clean packages
+chroot /mnt/sysroot $BIN clean packages
 # Download package to test if the installed repository is usable
-chroot $ANA_INSTALL_PATH \
+chroot /mnt/sysroot \
     $BIN --disablerepo=\* --enablerepo=kstest-http --downloadonly --nogpgcheck -y \
          reinstall testpkg-http-core 2>/dev/null | \
         grep -q 'testpkg-http-core'
 if [[ $? -ne 0 ]]; then
-    echo 'unable to query kstest-http repo' >> $ANA_INSTALL_PATH/root/RESULT
+    echo 'unable to query kstest-http repo' >> /mnt/sysroot/root/RESULT
 fi
 
 # If nothing was written to RESULT, it worked
-if [[ ! -f $ANA_INSTALL_PATH/root/RESULT ]]; then
+if [[ ! -f /mnt/sysroot/root/RESULT ]]; then
     if [ "$httpsdir" ]; then
-        echo 'SUCCESS but limited testing for TLS repository server' > $ANA_INSTALL_PATH/root/RESULT
+        echo 'SUCCESS but limited testing for TLS repository server' > /mnt/sysroot/root/RESULT
     else
-        echo 'SUCCESS' > $ANA_INSTALL_PATH/root/RESULT
+        echo 'SUCCESS' > /mnt/sysroot/root/RESULT
     fi
 fi
 


### PR DESCRIPTION
The `ANA_INSTALL_PATH` environment variable is deprecated. The support for this
variable will be removed in future releases. Use the `/mnt/sysroot` path instead.

**Related:** https://github.com/rhinstaller/anaconda/pull/3731