### PR TITLE
Disable tests failing on lvcreate --devices temporarily (rhbz#2031775)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -36,6 +36,7 @@ rhel9_skip_array=(
   gh576       # clearpart-4 test is flaky on all scenarios
   gh595       # proxy-cmdline failing on all scenarios
   rhbz1960279 # packages-weakdeps: "gnupg2 --recommends has changed, test needs to be updated"
+  rhbz2031775 # issue with lvcreate --devices option
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/lvm-thinp-1.sh
+++ b/lvm-thinp-1.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="lvm storage coverage"
+TESTTYPE="lvm storage coverage rhbz2031775"
 
 . ${KSTESTDIR}/functions.sh

--- a/lvm-thinp-2.sh
+++ b/lvm-thinp-2.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="lvm storage"
+TESTTYPE="lvm storage rhbz2031775"
 
 . ${KSTESTDIR}/functions.sh

--- a/snapshot-pre.sh
+++ b/snapshot-pre.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 
-TESTTYPE="snapshot lvm storage"
+TESTTYPE="snapshot lvm storage rhbz2031775"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Disable tests failing on lvcreate --device (lvm-thinp-1, lvm-thinp-2,
snapshot-pre) until rhbz#2031775 is fixed.