### PR TITLE
Disable packages-multilib test temporarily on daily-iso (gh#641)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -22,6 +22,7 @@ daily_iso_skip_array=(
   gh595       # proxy-cmdline failing on all scenarios
   rhbz2018913 # /etc/resolv.conf is not a symlink after kickstart
   gh640       # authselect-not-set failing
+  gh641       # packages-multilib failing on systemd conflict
 )
 
 rhel8_skip_array=(

--- a/packages-multilib.sh
+++ b/packages-multilib.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="packaging skip-on-rhel-8"
+TESTTYPE="packaging skip-on-rhel-8 gh641"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Disable packages-multilib test on daily-iso until gh#641 is fixed.