### PR TITLE
Disable authselect-not-set test temporarily on daily-iso (gh#640)

### DIFF
--- a/authselect-not-set.sh
+++ b/authselect-not-set.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE="security"
+TESTTYPE="security gh640"
 
 . ${KSTESTDIR}/functions.sh

--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -21,6 +21,7 @@ daily_iso_skip_array=(
   gh576       # clearpart-4 test is flaky on all scenarios
   gh595       # proxy-cmdline failing on all scenarios
   rhbz2018913 # /etc/resolv.conf is not a symlink after kickstart
+  gh640       # authselect-not-set failing
 )
 
 rhel8_skip_array=(


### PR DESCRIPTION
Disable authselect-not-set test on daily-iso until gh#640 is fixed.