### PR TITLE
Revert "Disable tests failing on lvcreate --device temporarily (rhbz#2031775)"

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -38,7 +38,6 @@ rhel9_skip_array=(
   gh576       # clearpart-4 test is flaky on all scenarios
   gh595       # proxy-cmdline failing on all scenarios
   rhbz1960279 # packages-weakdeps: "gnupg2 --recommends has changed, test needs to be updated"
-  rhbz2031775 # issue with lvcreate --devices option
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/lvm-thinp-1.sh
+++ b/lvm-thinp-1.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="lvm storage coverage rhbz2031775"
+TESTTYPE="lvm storage coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/lvm-thinp-2.sh
+++ b/lvm-thinp-2.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="lvm storage rhbz2031775"
+TESTTYPE="lvm storage"
 
 . ${KSTESTDIR}/functions.sh

--- a/snapshot-pre.sh
+++ b/snapshot-pre.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 
-TESTTYPE="snapshot lvm storage rhbz2031775"
+TESTTYPE="snapshot lvm storage"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Fix for bug [2031775](https://bugzilla.redhat.com/show_bug.cgi?id=2031775) is included in the latest development compose and the tests are passing again.

This reverts commit eded83f499971de44e9a198530812752cc187908.