### PR TITLE
Remove --url from the KSTEST_URL variable

### DIFF
--- a/.github/defaults.sh
+++ b/.github/defaults.sh
@@ -1,3 +1,3 @@
 # The download.fedoraproject.org automatic redirector often selects download-ib01.f.o. for GitHub's cloud, which is too unreliable; use mirror from default scripts/defaults.sh configuration
-#export KSTEST_URL='--url=http://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/$basearch/os/'
+#export KSTEST_URL='http://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/$basearch/os/'
 #export KSTEST_MODULAR_URL='http://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Modular/$basearch/os/'

--- a/anabot-1.sh
+++ b/anabot-1.sh
@@ -23,7 +23,7 @@ kernel_args() {
     local tmp_dir="${1}"
 
     # Provide an installation source.
-    local repo_url="$( echo ${KSTEST_URL} | sed -e 's/^--url=//' )"
+    local repo_url="${KSTEST_URL}"
 
     # Provide the anabot recipe.
     cp ${KSTESTDIR}/${name}.xml ${tmp_dir}/http/example.xml

--- a/fragments/platform/fedora_rawhide/repos/default.ks
+++ b/fragments/platform/fedora_rawhide/repos/default.ks
@@ -1,2 +1,2 @@
 # Default Fedora Rawhide repositories
-url @KSTEST_URL@
+url --url @KSTEST_URL@

--- a/fragments/platform/rhel8/repos/default.ks
+++ b/fragments/platform/rhel8/repos/default.ks
@@ -1,3 +1,3 @@
 # Default RHEL8 repositories - BeseOS + AppStream or unified repo can be used
-url @KSTEST_URL@
+url --url @KSTEST_URL@
 repo --name=appstream --baseurl @KSTEST_MODULAR_URL@

--- a/fragments/platform/rhel9/repos/default.ks
+++ b/fragments/platform/rhel9/repos/default.ks
@@ -1,3 +1,3 @@
 # Default RHEL9 repositories - BeseOS + AppStream or unified repo can be used
-url @KSTEST_URL@
+url --url @KSTEST_URL@
 repo --name=appstream --baseurl @KSTEST_MODULAR_URL@

--- a/functions-proxy.sh
+++ b/functions-proxy.sh
@@ -6,13 +6,13 @@ function check_proxy_settings() {
 
     # Checks must differ depending on the form of KSTEST_URL
     # HTTP mirror list; we find the hostname with the cuts
-    httplist=$(echo "$KSTEST_URL" | grep -e '--mirrorlist="\?http:' | cut -d'=' -f2 | cut -d'/' -f3)
+    httplist=$(echo "$KSTEST_URL" | grep -e 'http:' | cut -d'/' -f3)
     # HTTPS mirror list; ditto
-    httpslist=$(echo "$KSTEST_URL" | grep -e '--mirrorlist="\?https:' | cut -d'=' -f2 | cut -d'/' -f3)
+    httpslist=$(echo "$KSTEST_URL" | grep -e 'https:' | cut -d'/' -f3)
     # HTTP direct mirror; ditto
-    httpdir=$(echo "$KSTEST_URL" | grep -e '--url="\?http:' | cut -d'=' -f2 | cut -d'/' -f3)
+    httpdir=$(echo "$KSTEST_URL" | grep -e 'http:' | cut -d'/' -f3)
     # HTTPS direct mirror; we don't need to capture hostname here
-    httpsdir=$(echo "$KSTEST_URL" | grep -e '--url="\?https:')
+    httpsdir=$(echo "$KSTEST_URL" | grep -e 'https:')
 
     if [ "$httpslist" ]; then
         # check for CONNECT request to mirrorlist host

--- a/proxy-auth.ks.in
+++ b/proxy-auth.ks.in
@@ -1,5 +1,5 @@
 #test name: proxy-auth
-url @KSTEST_URL@ --proxy=http://anaconda:qweqwe@PROXY-ADDON
+url --url=@KSTEST_URL@ --proxy=http://anaconda:qweqwe@PROXY-ADDON
 repo --name=kstest-http --baseurl=HTTP-ADDON-REPO --proxy=http://anaconda:qweqwe@PROXY-ADDON --install
 network --bootproto=dhcp
 
@@ -20,7 +20,7 @@ shutdown
 
 %post --nochroot
 # HTTPS direct mirror; we don't need to capture hostname here
-httpsdir=$(echo "@KSTEST_URL@" | grep -e '--url="\?https:')
+httpsdir=$(echo "@KSTEST_URL@" | grep -e 'https:')
 
 # Check that the addon repo file was installed
 if [[ ! -f /mnt/sysroot/etc/yum.repos.d/kstest-http.repo ]]; then

--- a/proxy-auth.sh
+++ b/proxy-auth.sh
@@ -58,7 +58,7 @@ validate() {
     check_proxy_settings $tmpdir
 
     # HTTPS direct mirror; we don't need to capture hostname here
-    httpsdir=$(echo "$KSTEST_URL" | grep -e '--url="\?https:')
+    httpsdir=$(echo "$KSTEST_URL" | grep -e 'https:')
 
     # unless direct https URL was used, also check for:
     if [ ! "$httpsdir" ]; then

--- a/proxy-kickstart.ks.in
+++ b/proxy-kickstart.ks.in
@@ -1,5 +1,5 @@
 #test name: proxy-kickstart
-url @KSTEST_URL@ --proxy=PROXY-ADDON
+url --url=@KSTEST_URL@ --proxy=PROXY-ADDON
 repo --name=kstest-http --baseurl=HTTP-ADDON-REPO --proxy=PROXY-ADDON --install
 
 network --bootproto=dhcp
@@ -21,7 +21,7 @@ shutdown
 
 %post --nochroot
 # HTTPS direct mirror; we don't need to capture hostname here
-httpsdir=$(echo "@KSTEST_URL@" | grep -e '--url="\?https:')
+httpsdir=$(echo "@KSTEST_URL@" | grep -e 'https:')
 
 # Check that the addon repo file was installed
 if [[ ! -f /mnt/sysroot/etc/yum.repos.d/kstest-http.repo ]]; then

--- a/proxy-kickstart.sh
+++ b/proxy-kickstart.sh
@@ -54,7 +54,7 @@ validate() {
     check_proxy_settings $tmpdir
 
     # HTTPS direct mirror; we don't need to capture hostname here
-    httpsdir=$(echo "$KSTEST_URL" | grep -e '--url="\?https:')
+    httpsdir=$(echo "$KSTEST_URL" | grep -e 'https:')
 
     # unless direct https URL was used, also check for:
     if [ ! "$httpsdir" ]; then

--- a/scripts/defaults-rhel8.sh
+++ b/scripts/defaults-rhel8.sh
@@ -1,6 +1,6 @@
 # Default settings for testing RHEL 8. This requires being inside the Red Hat VPN.
 
 source network-device-names.cfg
-export KSTEST_URL='--url=http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8.6/compose/BaseOS/x86_64/os/'
+export KSTEST_URL='http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8.6/compose/BaseOS/x86_64/os/'
 export KSTEST_MODULAR_URL='http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8.6/compose/AppStream/x86_64/os/'
 export KSTEST_FTP_URL='ftp://ftp.tu-chemnitz.de/pub/linux/fedora/linux/development/rawhide/Everything/$basearch/os/'

--- a/scripts/defaults-rhel9.sh
+++ b/scripts/defaults-rhel9.sh
@@ -1,7 +1,7 @@
 # Default settings for testing RHEL 9. This requires being inside the Red Hat VPN.
 
 source network-device-names.cfg
-export KSTEST_URL='--url=http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9/latest-RHEL-9.0/compose/BaseOS/x86_64/os/'
+export KSTEST_URL='http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9/latest-RHEL-9.0/compose/BaseOS/x86_64/os/'
 export KSTEST_MODULAR_URL='http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9/latest-RHEL-9.0/compose/AppStream/x86_64/os/'
 export KSTEST_FTP_URL='ftp://ftp.tu-chemnitz.de/pub/linux/fedora/linux/development/rawhide/Everything/$basearch/os/'
 

--- a/scripts/defaults.sh
+++ b/scripts/defaults.sh
@@ -7,6 +7,6 @@
 # CAUTION: the sed expression we currently use does not like white-space in the strings
 
 source network-device-names.cfg
-export KSTEST_URL='--url=http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/$basearch/os/'
+export KSTEST_URL='http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/$basearch/os/'
 export KSTEST_MODULAR_URL='http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Modular/$basearch/os/'
 export KSTEST_FTP_URL='ftp://ftp.tu-chemnitz.de/pub/linux/fedora/linux/development/rawhide/Everything/$basearch/os/'


### PR DESCRIPTION
The `KSTEST_URL` variable should contain only the URL, so it can be easily used for anything else.