### PR TITLE
Use empty repositories in the repo-install test

### DIFF
--- a/repo-install.ks.in
+++ b/repo-install.ks.in
@@ -6,11 +6,11 @@
 %ksappend common/common_no_payload.ks
 %ksappend payload/default_packages.ks
 
-repo --name=test01 --baseurl=@KSTEST_URL@
-repo --name=test02 --baseurl=@KSTEST_URL@ --install
-repo --name=test03 --baseurl=@KSTEST_URL@ --cost=25  --install
-repo --name=test04 --baseurl=@KSTEST_URL@ --noverifyssl --install
-repo --name=test05 --baseurl=@KSTEST_URL@ --includepkgs=p1,p2 --excludepkgs=p3,p4 --install
+repo --name=test01 --baseurl=EMPTY_REPO_URL
+repo --name=test02 --baseurl=EMPTY_REPO_URL --install
+repo --name=test03 --baseurl=EMPTY_REPO_URL --cost=25  --install
+repo --name=test04 --baseurl=EMPTY_REPO_URL --noverifyssl --install
+repo --name=test05 --baseurl=EMPTY_REPO_URL --includepkgs=p1,p2 --excludepkgs=p3,p4 --install
 
 %post
 

--- a/repo-install.sh
+++ b/repo-install.sh
@@ -19,3 +19,25 @@
 TESTTYPE="packaging repo"
 
 . ${KSTESTDIR}/functions.sh
+
+prepare() {
+    local ks="$1"
+    local tmp_dir="$2"
+    local httpd_url=""
+
+    # Create an empty repository.
+    mkdir -p "${tmp_dir}/http/repo"
+    createrepo_c -q "${tmp_dir}/http/repo"
+
+    # Start a http server to serve the repository.
+    start_httpd "${tmp_dir}/http" "${tmp_dir}"
+
+    # Substitute variables in the kickstart file.
+    sed -e "s|EMPTY_REPO_URL|${httpd_url}/repo|" "${ks}" > "${tmp_dir}/ks.cfg"
+    echo "${tmp_dir}/ks.cfg"
+}
+
+cleanup() {
+    local tmp_dir="${1}"
+    stop_httpd "${tmp_dir}"
+}


### PR DESCRIPTION
We set up a lot of additional repositories for the test and it can fail
with the "No space left on device" error if they are too big.