### PR TITLE
Replace teaming with bonding in coverage tests.

### DIFF
--- a/bond2-pre.sh
+++ b/bond2-pre.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE=${TESTTYPE:-"network"}
+TESTTYPE="${TESTTYPE:-"network"} coverage"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/team-pre.sh
+++ b/team-pre.sh
@@ -24,7 +24,7 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
-TESTTYPE="${TESTTYPE:-"network"} coverage"
+TESTTYPE=${TESTTYPE:-"network"}
 
 . ${KSTESTDIR}/team.sh
 


### PR DESCRIPTION
Team driver is going to be deprecated.

Prevent 
```
team-pre                                                | FAILED     | error in log: Warning: Deprecated Driver is detected: team will not be maintained in a future major release and may be disabled
```
failure in coverage tests for "Build and test daily RHEL boot.iso" workflow.
https://github.com/rhinstaller/kickstart-tests/actions/runs/1776201607