### PR TITLE
Update string for ignoring deprecated team driver CRIT message

### DIFF
--- a/scripts/launcher/lib/log_monitor/log_handler.py
+++ b/scripts/launcher/lib/log_monitor/log_handler.py
@@ -31,7 +31,7 @@ class VirtualLogRequestHandler(LogRequestHandler):
         "CRIT mdadm:DegradedArray event detected",
 
         # Team networking is deprecated
-        "CRIT kernel:Warning: team - this hardware",
+        "CRIT kernel:Warning: Deprecated Driver is detected: team ",
 
         # Ignore a call trace during debugging.
         # "Call Trace:"


### PR DESCRIPTION
The issue (tests failing due to the message) can be seen here:
https://github.com/rhinstaller/kickstart-tests/runs/5029339952?check_suite_focus=true