### PR TITLE
Disable selinux-contests on daily-iso temporarily (rhbz#2052038)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -23,6 +23,7 @@ daily_iso_skip_array=(
   rhbz2018913 # /etc/resolv.conf is not a symlink after kickstart
   gh640       # authselect-not-set failing
   gh641       # packages-multilib failing on systemd conflict
+  rhbz2052038 # selinux-context failing on rpm database location change
 )
 
 rhel8_skip_array=(

--- a/selinux-contexts.sh
+++ b/selinux-contexts.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Vladimir Slavik <vslavik@redhat.com>
 
-TESTTYPE="security selinux"
+TESTTYPE="security selinux rhbz2052038"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Disable selinux-contexts until rhbz#2052038 is fixed.