### PR TITLE
Revert "Disable dns test temporarily on daily-iso (rhbz#2018913)"

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -20,7 +20,6 @@ daily_iso_skip_array=(
   skip-on-fedora
   gh576       # clearpart-4 test is flaky on all scenarios
   gh595       # proxy-cmdline failing on all scenarios
-  rhbz2018913 # /etc/resolv.conf is not a symlink after kickstart
   gh640       # authselect-not-set failing
   gh641       # packages-multilib failing on systemd conflict
 )

--- a/dns.sh
+++ b/dns.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE="network rhbz2018913"
+TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
This reverts commit a08786bb4b79cc226d41e909c41ff7871587c998.