### PR TITLE
Disable repo-install test temporarily on daily-iso (gh#662)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -23,6 +23,7 @@ daily_iso_skip_array=(
   rhbz2018913 # /etc/resolv.conf is not a symlink after kickstart
   gh640       # authselect-not-set failing
   gh641       # packages-multilib failing on systemd conflict
+  gh662       # repo-install failing
 )
 
 rhel8_skip_array=(

--- a/repo-install.sh
+++ b/repo-install.sh
@@ -16,7 +16,7 @@
 # Red Hat, Inc.
 #
 
-TESTTYPE="packaging repo"
+TESTTYPE="packaging repo gh662"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Disable repo-install test on daily-iso until gh#662 is fixed.