### PR TITLE
Don't build testing rpms in a temporary directory

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -24,7 +24,6 @@ daily_iso_skip_array=(
   gh641       # packages-multilib failing on systemd conflict
   rhbz2052038 # selinux-context failing on rpm database location change
   gh658       # module-3 can't find 'nodejs:16' module
-  gh660       # repo-X tests can't find packages in additional repo
 )
 
 rhel8_skip_array=(
@@ -32,7 +31,6 @@ rhel8_skip_array=(
   skip-on-rhel-8
   gh576       # clearpart-4 test is flaky on all scenarios
   gh595       # proxy-cmdline failing on all scenarios
-  gh660       # repo-X tests can't find packages in additional repo
 )
 
 rhel9_skip_array=(
@@ -41,7 +39,6 @@ rhel9_skip_array=(
   gh576       # clearpart-4 test is flaky on all scenarios
   gh595       # proxy-cmdline failing on all scenarios
   rhbz1960279 # packages-weakdeps: "gnupg2 --recommends has changed, test needs to be updated"
-  gh660       # repo-X tests can't find packages in additional repo
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/repo-addrepo.sh
+++ b/repo-addrepo.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 
-TESTTYPE="packaging repo gh660"
+TESTTYPE="packaging repo"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/repo-enable.sh
+++ b/repo-enable.sh
@@ -16,7 +16,7 @@
 # Red Hat, Inc.
 #
 
-TESTTYPE="packaging repo gh660"
+TESTTYPE="packaging repo"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/repo-exclude.sh
+++ b/repo-exclude.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): David Shea <dshea@redhat.com>
 
-TESTTYPE="packaging repo gh660"
+TESTTYPE="packaging repo"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/repo-include.sh
+++ b/repo-include.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): David Shea <dshea@redhat.com>
 
-TESTTYPE="packaging repo gh660"
+TESTTYPE="packaging repo"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/scripts/generate-repository.py
+++ b/scripts/generate-repository.py
@@ -74,16 +74,18 @@ os.dup2(os.open(os.devnull, os.O_WRONLY), 1)
 # The repository contains one mandatory package.
 pkg = rpmfluff.SimpleRpmBuild(
     'mandatory-package-from-{}'.format(repo_name),
-    '1.0',
-    '1'
+    version='1.0',
+    release='1',
+    tmpdir=False,
 )
 pkg.make()
 
 # The repository contains one optional package.
 pkg = rpmfluff.SimpleRpmBuild(
     'optional-package-from-{}'.format(repo_name),
-    '1.0',
-    '1'
+    version='1.0',
+    release='1',
+    tmpdir=False,
 )
 pkg.make()
 
@@ -93,8 +95,9 @@ pkg.make()
 for i in (1, 2, 3):
     pkg = rpmfluff.SimpleRpmBuild(
         'package-{}'.format(i),
-        '1.0',
-        '1'
+        version='1.0',
+        release='1',
+        tmpdir=False,
     )
     pkg.add_installed_file(
         '/usr/share/package-{}/{}'.format(i, repo_name),


### PR DESCRIPTION
Use the local directory instead. Otherwise, the rpms will be created outside
of the testing repositories and won't be available for the installation.

Resolves https://github.com/rhinstaller/kickstart-tests/issues/660