### PR TITLE
Disable rpm-ostree test temporarily on daily-iso (gh#667)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -22,6 +22,7 @@ daily_iso_skip_array=(
   gh595       # proxy-cmdline failing on all scenarios
   gh640       # authselect-not-set failing
   gh641       # packages-multilib failing on systemd conflict
+  gh667       # rpm-ostree failing
 )
 
 rhel8_skip_array=(

--- a/rpm-ostree.sh
+++ b/rpm-ostree.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
-TESTTYPE="payload ostree skip-on-rhel"
+TESTTYPE="payload ostree skip-on-rhel gh667"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Disable rpm-ostree test on daily-iso until gh#667 is fixed.