### PR TITLE
Disable proxy-auth and proxy-kickstart on daily-iso temporarily (gh#680)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -23,6 +23,7 @@ daily_iso_skip_array=(
   gh640       # authselect-not-set failing
   gh641       # packages-multilib failing on systemd conflict
   gh667       # rpm-ostree failing
+  gh680       # proxy-kickstart and proxy-auth failing
 )
 
 rhel8_skip_array=(

--- a/proxy-auth.sh
+++ b/proxy-auth.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 
-TESTTYPE="method proxy"
+TESTTYPE="method proxy gh680"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/functions-proxy.sh

--- a/proxy-kickstart.sh
+++ b/proxy-kickstart.sh
@@ -18,7 +18,7 @@
 # Red Hat Author(s): David Shea <dshea@redhat.com>
 #                    Jiri Konecny <jkonecny@redhat.com>
 
-TESTTYPE="method proxy"
+TESTTYPE="method proxy gh680"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/functions-proxy.sh


### PR DESCRIPTION
Disable proxy-auth and proxy-kickstart test on daily-iso until gh#680 is fixed.