### PR TITLE
Load platform-specific defaults.sh automatically.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -175,9 +175,11 @@ kickstart file, the target of a substitution is any string starting with
 
 Configuration parameters may also come from special shell scripts that are
 sourced during run_kickstart_tests.sh.  It will first look at the defaults in
-scripts/defaults.sh.  It will then look at any user-specific defaults in
-~/.kstests.defaults.sh.  These take precedence over the local environment.
-Environment variables set on the command line have the highest priority.
+scripts/defaults.sh.  Next, if platform is specified using -p PLATFORM option,
+the scripts/defaults-PLATFORM.sh file is sourced.  Finally it will source any
+user-specific defaults in ~/.kstests.defaults.sh.  These take precedence over
+the local environment.  Environment variables set on the command line have the
+highest priority.
 
 Note that not every test needs every setting.  You can determine which are
 required for the test you are running by simply running "grep KSTEST_" on it.

--- a/containers/runner/scenario
+++ b/containers/runner/scenario
@@ -24,7 +24,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8.6/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes "$SKIP_TESTTYPES_RHEL8" --platform rhel8 --defaults "$ROOTDIR/scripts/defaults-rhel8.sh" all
+        $LAUNCH --skip-testtypes "$SKIP_TESTTYPES_RHEL8" --platform rhel8 all
         ;;
 
     rhel9)
@@ -33,7 +33,7 @@ case "$SCENARIO" in
             mkdir -p data/images
             curl -L http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9/latest-RHEL-9.0/compose/BaseOS/x86_64/os/images/boot.iso --output data/images/boot.iso
         fi
-        $LAUNCH --skip-testtypes "$SKIP_TESTTYPES_RHEL9" --platform rhel9 --defaults "$ROOTDIR/scripts/defaults-rhel9.sh" all
+        $LAUNCH --skip-testtypes "$SKIP_TESTTYPES_RHEL9" --platform rhel9 all
         ;;
 
     # just run a single test on standard Rawhide; mostly for testing infrastructure

--- a/scripts/run_kickstart_tests.sh
+++ b/scripts/run_kickstart_tests.sh
@@ -157,6 +157,13 @@ if [[ -e scripts/defaults.sh ]]; then
     . scripts/defaults.sh
 fi
 
+# Platform-specific defaults
+if [[ -n "${PLATFORM_NAME}" ]]; then
+    if [[ -e "scripts/defaults-${PLATFORM_NAME}.sh" ]]; then
+        . "scripts/defaults-${PLATFORM_NAME}.sh"
+    fi
+fi
+
 if [[ -e $HOME/.kstests.defaults.sh ]]; then
     . $HOME/.kstests.defaults.sh
 fi


### PR DESCRIPTION
This way we will no longer need to supply
--defaults <PATH>/scripts/defaults-rhel8.sh
additionally to --platform rhel8