### PR TITLE
Do not load platform-specific defaults in daily-boot-iso-rhel8

### DIFF
--- a/.github/workflows/daily-boot-iso-rhel8.yml
+++ b/.github/workflows/daily-boot-iso-rhel8.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Run coverage tests
         run: |
           source $PWD/containers/runner/skip-testtypes
-          sudo TEST_JOBS=16 containers/runner/launch --retry --testtype coverage --skip-testtypes "$SKIP_TESTTYPES_RHEL8_DAILY" --platform rhel8 --defaults $PWD/scripts/defaults-rhel8.sh
+          sudo TEST_JOBS=16 containers/runner/launch --retry --testtype coverage --skip-testtypes "$SKIP_TESTTYPES_RHEL8_DAILY" --platform rhel8
 
       - name: Upload test logs
         if: always()


### PR DESCRIPTION
With commit d51b3edf29ae0d966d047dd58527beaf5142a8d9
they are loaded automatically.