### PR TITLE
Disable packages-and-groups-1 test temporarily on rhel-9 (gh#686)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -42,6 +42,7 @@ rhel9_skip_array=(
   rhbz1960279 # packages-weakdeps: "gnupg2 --recommends has changed, test needs to be updated"
   gh641       # packages-multilib failing on systemd conflict
   gh670       # repo-include failing on rhel
+  gh686       # packages-and-groups-1 failing due to async in devel compose
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/packages-and-groups-1.sh
+++ b/packages-and-groups-1.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="packaging"
+TESTTYPE="packaging gh686"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Disable packages-and-groups-1 on rhel-9 until gh#686 is fixed.