### PR TITLE
Disable the bootloader in the rpm-ostree test

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -22,7 +22,6 @@ daily_iso_skip_array=(
   gh595       # proxy-cmdline failing on all scenarios
   gh640       # authselect-not-set failing
   gh641       # packages-multilib failing on systemd conflict
-  gh667       # rpm-ostree failing
   gh680       # proxy-kickstart and proxy-auth failing
 )
 

--- a/rpm-ostree.ks.in
+++ b/rpm-ostree.ks.in
@@ -6,6 +6,9 @@
 # Set up the RPM OSTree source.
 ostreesetup --nogpg --osname=fedora-iot --remote=fedora-iot --url=https://kojipkgs.fedoraproject.org/compose/iot/repo/ --ref=fedora/rawhide/${basearch}/iot
 
+# Disable the bootloader (gh#667).
+bootloader --location=none
+
 %post
 # Check the name of the remote.
 name="$(ostree remote list)"

--- a/rpm-ostree.sh
+++ b/rpm-ostree.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
-TESTTYPE="payload ostree skip-on-rhel gh667"
+TESTTYPE="payload ostree skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Let's disable the bootloader installation for now, so we can keep testing
the rpm-ostree payload.

**Related:** https://github.com/rhinstaller/kickstart-tests/issues/667