### PR TITLE
Don't install the kmod-kvdo package (gh#686) 

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -41,7 +41,6 @@ rhel9_skip_array=(
   rhbz1960279 # packages-weakdeps: "gnupg2 --recommends has changed, test needs to be updated"
   gh641       # packages-multilib failing on systemd conflict
   gh670       # repo-include failing on rhel
-  gh686       # packages-and-groups-1 failing due to async in devel compose
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/packages-and-groups-1.ks.in
+++ b/packages-and-groups-1.ks.in
@@ -23,6 +23,10 @@ kacst*
 
 # (4) Test that you can remove packages with a glob.
 -grub2-efi*
+
+# Skip kmod-kvdo to avoid conflicts with kernel (gh#686).
+-vdo
+-kmod-kvdo
 %end
 
 %post

--- a/packages-and-groups-1.sh
+++ b/packages-and-groups-1.sh
@@ -17,6 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-TESTTYPE="packaging gh686"
+TESTTYPE="packaging"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Skip kmod-kvdo to avoid conflicts with the kernel version.

Resolves https://github.com/rhinstaller/kickstart-tests/issues/686