### PR TITLE
Ignore "Call Trace:" in logs temporarily

### DIFF
--- a/scripts/launcher/lib/log_monitor/log_handler.py
+++ b/scripts/launcher/lib/log_monitor/log_handler.py
@@ -34,7 +34,8 @@ class VirtualLogRequestHandler(LogRequestHandler):
         "CRIT kernel:Warning: Deprecated Driver is detected: team ",
 
         # Ignore a call trace during debugging.
-        # "Call Trace:"
+        # Enabled tempoarily for rhbz#2070019
+        "Call Trace:"
     ]
 
     # Specify error lines you want to add on top


### PR DESCRIPTION
Ignore Call Traces so that rhbz#2070019 doesn't block Anaconda
testing and development of testing tools.