### PR TITLE
weekly-summary: Add more information about the tests

### DIFF
--- a/scripts/weekly-summary
+++ b/scripts/weekly-summary
@@ -99,6 +99,10 @@ def get_artifacts(token, artifact_names, start, end):
 def run_curl(token, url, filename):
     """
     run_curl downloads an artifact file
+
+    It returns True if the response was a 200
+    If there was an exception is returns False and the error, as well as
+    printing it to stderr
     """
     with open(filename, "wb") as f:
         c = pycurl.Curl()
@@ -122,7 +126,8 @@ def run_curl(token, url, filename):
 
         try:
             c.perform()
-            ok = (True, None)
+            status = c.getinfo(pycurl.HTTP_CODE)
+            ok = (status == 200, None)
         except Exception as e:
             print(f"ERROR: {e}", file=sys.stderr)
             sys.stderr.flush()
@@ -135,19 +140,30 @@ def run_curl(token, url, filename):
 def download_artifacts(token, artifacts):
     """
     download_artifacts downloads the artifacts as uniquely named files
+
+    If there is a problem downloading an artifact it is skipped and not
+    added to the returned list.
+
+    It returns a list of tuples containing the artifact name, the
+    artifact name with the updated date appended (eg. logs-rhel8-2022-04-01),
+    and the filename of the zipfile.
     """
     zipfiles = []
     for a in artifacts:
         updated_at = datetime.fromisoformat(a["updated_at"][:-1])
         datename = a["name"]+updated_at.strftime("-%Y-%m-%d")
         filename = datename + ".zip"
-        zipfiles.append((a["name"], datename, filename))
         if os.path.exists(filename):
+            zipfiles.append((a["name"], datename, filename))
             print(f"{filename} skipped, already downloaded")
             continue
 
         print(f"Fetching {filename}")
-        run_curl(token, a["archive_download_url"], filename)
+        ok = run_curl(token, a["archive_download_url"], filename)
+        if not ok:
+            continue
+
+        zipfiles.append((a["name"], datename, filename))
 
     return zipfiles
 
@@ -187,36 +203,106 @@ def rebuild_logs(tdir):
                     data = f.read(1024**2)
 
 
-def pass_fail(tests):
+def check_tests(tests):
     """
-    pass_fail returns stats on the tests
+    Check the tests for success, failing, or flakes -- success after first failing
 
-    It returns a tuple of total tests run, number passed
+    This returns a tuple of:
+    - list of the names of successful tests
+    - dict of failed tests, each entry being a list of the failure details dict
+    - dict of flaky tests, each entry being a list of the flaky details dict
     """
-    success = sum(1 for t in tests if t["success"])
-    return len(tests), success
-
-
-def get_failed(tests):
-    """
-    get_failed returns a dict of failed tests
-
-    Tests may fail multiple times, so they are sorted by their start time
-    and the dict key is the name of the test.
-    """
+    success = []
     failed = {}
+    flakes = {}
+
+    # The goal is to sort the tests into good/failed and record the ones
+    # that passed after first failing in flakes
     for t in tests:
-        if not t["success"]:
-            if t["name"] not in failed:
-                failed[t["name"]] = [t]
+        name = t["name"]
+        if t["success"]:
+            # Tests should never have more than one success
+            if name in success:
+                raise RuntimeError(f"{name} already passed, should only be 1 per test")
+
+            success.append(name)
+            if name in failed:
+                # Previously failed, move that to flakes and remove it from the failed list
+                flakes[name] = failed[name]
+                flakes[name].append(t)
+                del failed[name]
+        else:
+            if name in success:
+                # Test was also successful, make sure to record it in flakes list
+                if name in flakes:
+                    flakes[name].append(t)
+                else:
+                    flakes[name] = [t]
             else:
-                failed[t["name"]].append(t)
+                if name in failed:
+                    failed[name].append(t)
+                else:
+                    failed[name] = [t]
 
-    # Sort each failed test list by the start time
-    for t in failed:
-        failed[t] = sorted(failed[t], key=lambda x: x.get("start_time", 0))
+    return sorted(success), failed, flakes
 
-    return failed
+
+def print_test_details(scenario, days, test_name, buf):
+    """Add the details of the named tests (failed-tests or flaky-tests) to the buffer
+    """
+    for d in days:
+        if scenario not in days[d]:
+            continue
+
+        for n in days[d][scenario][test_name]:
+            print(f"\n{n}:", file=buf)
+            for test in days[d][scenario][test_name][n]:
+                if "start_time" not in test:
+                    start_time = ""
+                else:
+                    start_time = datetime.fromtimestamp(test["start_time"]).strftime("%m/%d/%Y %H:%M:%S")
+
+                if "elapsed_time" not in test:
+                    elapsed_time = 0
+                else:
+                    elapsed_time = test["elapsed_time"]
+
+                # Get the result message
+                msg = test["result"].rsplit("FAILED:")[-1]
+                print(f'        {start_time} ({elapsed_time}s): {msg}', file=buf)
+
+
+def process_logs(logs):
+    """
+    Process the logfiles into a data structure
+
+    Returns a dictionary with each log's data that looks similar to this:
+
+    {"20220401": {"logs-daily-iso": [{test data dict}, ...], ...}}, ...}
+
+    So every day has an entry for the scenarios that were run on that day.
+    Note that sometimes a scenario can be missing if there was a problem running it at all.
+    """
+    all_data = {}
+    for log in logs:
+        with open(log) as f:
+            data = json.load(f)
+            scenario = data[0].get("scenario", None)
+            if scenario is None:
+                # No scenario name, no way to organize the data
+                continue
+
+            # Use the log's date as the run identifier
+            # This assumes the format is SCENARIO-YYYY-MM-DD.json
+            # NOTE: This may not match the GitHub Action run dates due to tests taking
+            #       a very long time.
+            day = datetime.strptime(log[1+len(scenario):-5], "%Y-%m-%d").strftime("%Y%m%d")
+            if day not in all_data:
+                all_data[day] = {}
+
+            # Group them by scenario, assume each file is from one scenario per day
+            all_data[day][scenario] = data
+    return all_data
 
 
 def summary(args, logs):
@@ -225,18 +311,7 @@ def summary(args, logs):
 
     It returns a string with the summary text
     """
-    all_data = {}
-    for log in logs:
-        with open(log) as f:
-            data = json.load(f)
-
-            # Group them by scenario, assume each file is from one scenario
-            if "scenario" in data[0]:
-                if data[0]["scenario"] not in all_data:
-                    all_data[data[0]["scenario"]] = data
-                else:
-                    all_data[data[0]["scenario"]].extend(data)
-
+    all_data = process_logs(logs)
     if args.debug:
         print(json.dumps(all_data))
 
@@ -246,75 +321,100 @@ def summary(args, logs):
     end = args.end.strftime("%m/%d/%Y %H:%M:%S")
     print(f"Test Summary Report: {start} -> {end}\n", file=buf)
 
+    # Calculate test failures per day/scenario
+    all_days = {}                   # dict of per-scenario counts
+    days = {}                       # dict of per-day -> per-scenario counts and test names
+    top_failed = {}                 # dict of per-test failure counts
+    top_flakes = {}                 # dict of per-test flake counts
+    for day in sorted(all_data.keys()):
+        days[day] = {}
+        for scenario in sorted(all_data[day].keys()):
+            if scenario not in all_days:
+                all_days[scenario] = {"success": 0, "failed": 0, "flakes": 0}
+
+            # Figure out how many were successful, failed, or were flakes
+            success, failed, flakes = check_tests(all_data[day][scenario])
+
+            days[day][scenario] = {
+                    "success": len(success),
+                    "failed": len(failed),
+                    "flakes": len(flakes),
+                    "failed-tests": failed,
+                    "flaky-tests": flakes}
+            all_days[scenario]["success"] += len(success)
+            all_days[scenario]["failed"] += len(failed)
+            all_days[scenario]["flakes"] += len(flakes)
+
+            for n in failed:
+                top_failed[n] = top_failed.get(n, 0) + 1
+
+            for n in flakes:
+                top_flakes[n] = top_flakes.get(n, 0) + 1
+
+
     # Summary of tests per scenario
-    for g in sorted(all_data.keys()):
-        total, good = pass_fail(all_data[g])
-        bad = total - good
-        print(f"{g}: Ran {total} tests. {good} passed, {bad} failed.", file=buf)
+    print("Weekly summary", file=buf)
+    print("==============", file=buf)
+    for scenario in sorted(all_days.keys()):
+        success = all_days[scenario]["success"]
+        failed = all_days[scenario]["failed"]
+        flakes = all_days[scenario]["flakes"]
+
+        print(f"{scenario}: Ran {success+failed} tests. {success} passed, {failed} failed, {flakes} flakes.", file=buf)
     print("\n", file=buf)
 
-    # Test failures per day/scenario
-    days = {}
-    for g in sorted(all_data.keys()):
-        for t in all_data[g]:
-            if t["success"]:
-                continue
-            # Get the Year Month Day if 'start_time' is present
-            # otherwise day is set to '19691231'
-            day = datetime.fromtimestamp(t.get("start_time", 0)).strftime("%Y%m%d")
-            if day not in days:
-                days[day] = {g: [t["name"]]}
-            else:
-                if g not in days[day]:
-                    days[day][g] = [t["name"]]
-                else:
-                    days[day][g].append(t["name"])
+    print("Top 5 failed tests for the week", file=buf)
+    for n in sorted((n for n in top_failed), key=lambda x: top_failed[x], reverse=True)[:5]:
+        print(f"    {n} - {top_failed[n]}", file=buf)
+    print("\n", file=buf)
 
+    print("Top 5 flaky tests for the week", file=buf)
+    for n in sorted((n for n in top_flakes), key=lambda x: top_flakes[x], reverse=True)[:5]:
+        print(f"    {n} - {top_flakes[n]}", file=buf)
+    print("\n", file=buf)
+
+    # Print daily stats
     for day in sorted(days.keys()):
-        if day == "19691231":
-            # 'start_time' wasn't included, no wat to tell when it was run.
-            print("unknown day", file=buf)
-        else:
-            print(datetime.strptime(day, "%Y%m%d").strftime("%m/%d/%Y"), file=buf)
-        for g in sorted(days[day].keys()):
-            print(f"    {g}:", file=buf)
-            for n in sorted(days[day][g]):
-                print(f"        {n}", file=buf)
+        print(datetime.strptime(day, "%Y%m%d").strftime("%m/%d/%Y"), file=buf)
+        for scenario in sorted(days[day].keys()):
+            s = days[day][scenario]
+            success = s["success"]
+            failed = s["failed"]
+            total = success + failed
+            flakes = s["flakes"]
+            print(f"    {scenario} (Ran {total}, {success} passed, {failed} failed. {flakes} flakes) :", file=buf)
+            if s["failed-tests"]:
+                print("        Failed:", file=buf)
+                for n in sorted(s["failed-tests"].keys()):
+                    print(f"            {n}", file=buf)
+            if s["flaky-tests"]:
+                print("        Flakes:", file=buf)
+                for n in sorted(s["flaky-tests"].keys()):
+                    print(f"            {n}", file=buf)
         print("\n", file=buf)
 
-    # Gather up detailed failure results
-    for g in sorted(all_data.keys()):
-        print("=" * 40, file=buf)
-        total, good = pass_fail(all_data[g])
-        bad = total - good
-        print(f"{g} summary: Ran {total} tests. {good} passed, {bad} failed.", file=buf)
-        print("=" * 40, file=buf)
+    # Print the failure details for each scenario, on each day.
+    for scenario in sorted(all_days.keys()):
+        success = all_days[scenario]["success"]
+        failed = all_days[scenario]["failed"]
+        flakes = all_days[scenario]["flakes"]
 
-        # Print the details of each failed test occurrence
-        failed = get_failed(all_data[g])
-        for name in failed:
-            # Print the details of the failed test
-            ess = "s" if (len(failed[name]) > 1) else ""
-            print(f"{name} failed {len(failed[name])} time{ess}", file=buf)
-            print("-" * 40, file=buf)
-            for f in failed[name]:
-                if "start_time" not in f:
-                    start_time = ""
-                else:
-                    start_time = datetime.fromtimestamp(f["start_time"]).strftime("%m/%d/%Y %H:%M:%S")
+        msg = f"{scenario}: Ran {success+failed} tests. {success} passed, {failed} failed, {flakes} flakes."
+        print("=" * len(msg), file=buf)
+        print(msg, file=buf)
+        print("=" * len(msg), file=buf)
 
-                if "elapsed_time" not in f:
-                    elapsed_time = 0
-                else:
-                    elapsed_time = f["elapsed_time"]
+        if args.flake_details:
+            print("Failed test details", file=buf)
+            print("-------------------", file=buf)
+        print_test_details(scenario, days, "failed-tests", buf)
 
-                # Get the result message
-                msg = f["result"].rsplit("FAILED:")[-1]
-                print(f'\n{start_time} ({elapsed_time}s): {msg}', file=buf)
-            print("\n", file=buf)
+        if args.flake_details:
+            print("\nFlake test details", file=buf)
+            print("-------------------", file=buf)
+            print_test_details(scenario, days, "flaky-tests", buf)
 
-        if len(failed):
-            print("\n", file=buf)
+        print("\n", file=buf)
 
     return buf.getvalue()
 
@@ -327,9 +427,16 @@ def main(args, token):
     if args.debug:
         print(f"zipfiles = {zipfiles}")
 
+    datenames = []          # List of valid logfile names
     for name, datename, f in zipfiles:
         if args.rebuild or not os.path.exists(datename+".json"):
-            logs = extract_logs(f)
+            try:
+                logs = extract_logs(f)
+            except zipfile.BadZipFile:
+                # GitHub can responds with a 200 and a json error instead of a zip
+                # so if it isn't a valid zip, just skip it.
+                os.unlink(f)
+                continue
 
             # This is needed for logs without timestamps
             if args.rebuild:
@@ -345,7 +452,11 @@ def main(args, token):
                 print(cmd)
             check_call(cmd)
 
-    report = summary(args, (d+".json" for _, d, _ in zipfiles))
+        # If the summary exists, add it to the list
+        if os.path.exists(datename+".json"):
+            datenames.append(datename)
+
+    report = summary(args, (d+".json" for d in datenames))
     if args.output:
         with open(args.output, "w") as f:
             f.write(report)
@@ -369,6 +480,9 @@ if __name__ == '__main__':
     parser.add_argument("--rebuild",
             default=False, action="store_true",
             help="Rebuild logs with timestamps")
+    parser.add_argument("--flake-details",
+            default=False, action="store_true",
+            help="Include details about flaky tests in summary")
     parser.add_argument("--output",
             help="Path and filename to write summary report to")
     parser.add_argument("--debug", default=False, action="store_true")


### PR DESCRIPTION
This adds a count of the 'flaky' tests, ones which fail at first but
eventually succeed. This now counts as a successful test, but is also
listed separately.

This adds an option to include detailed info about the flaky tests if
you pass `--flaky-details` to the script.

This now handles expired artifacts -- GitHub is not returning an error
if you try to retrieve an expired artifact, so it needs to handle trying
to unzip a non-zipfile (it's a json blob).

Remove unused functions, and split up some of the logic into functions.
Also improves documentation of the data structures created for
generating the reports and stats.

This should Fix #702, #704