### PR TITLE
Bring the timeout back to ~8h

### DIFF
--- a/.github/workflows/scenarios.yml
+++ b/.github/workflows/scenarios.yml
@@ -17,13 +17,13 @@ jobs:
       fail-fast: false
 
     # these settings depend on the infrastructure; on upshift ocp-master-xxl they take about 4 hours
-    timeout-minutes: 480
+    timeout-minutes: 500
     env:
       TEST_JOBS: 16
       GITHUB_TOKEN: /home/github/github-token
       # Should be smaller than job's timeout-minutes value so we get logs of the tests that finished
       # by the timeout.
-      SCENARIO_TIMEOUT: 450m
+      SCENARIO_TIMEOUT: 480m
 
     steps:
       # self-hosted runners don't do this automatically; also useful to keep stuff around for debugging


### PR DESCRIPTION
We effectively decreased it when we started to use lanucher timeout set
to 20 minutes less then the workflow timeout. As a result we are missing
a few tests tightly when the infrastructure performance is not great. So
bring it back to ~8h.