### PR TITLE
log2json: Detect missing RESULT lines

### DIFF
--- a/.github/workflows/scenarios.yml
+++ b/.github/workflows/scenarios.yml
@@ -56,6 +56,7 @@ jobs:
           path: |
             data/logs/kstest.log
             data/logs/kstest.log.json
+            data/logs/kstest-list
             data/logs/kstest-*/*.log
             data/logs/kstest-*/anaconda/lorax-packages.log
 

--- a/containers/runner/run-kstest
+++ b/containers/runner/run-kstest
@@ -92,6 +92,7 @@ find /var/tmp/kstest-* -name "*.iso" -delete
 find /var/tmp/kstest-* -name "*.img" -delete
 cp $TEST_LOG ${LOGS_DIR}
 cp $TEST_LOG.json ${LOGS_DIR}
+cp /var/tmp/kstest-list ${LOGS_DIR}
 # Move to target logs directory; this sometimes fails on nested directory permission/ownership
 cp -pr /var/tmp/kstest-* ${LOGS_DIR} || true
 

--- a/scripts/log2json
+++ b/scripts/log2json
@@ -94,6 +94,21 @@ def parse_install_log(line):
     # We know it contains 'install_log =' so take the part after the =
     return line.split("=")[-1].strip()
 
+def guess_test_name(logfile):
+    """
+    Guess a test name based on the install_log
+
+    Used only as a last resort when RESULT is missing.
+    """
+    for e in logfile.split(os.path.sep):
+        if e.startswith("kstest-"):
+            # test name is after kstest- and before first '.' (unless this changes in the future)
+            # This should return the bare test name or fail by returning the full name
+            return e[7:].partition('.')[0]
+
+    # fall back to full directory name
+    return os.path.basename(os.path.dirname(logfile))
+
 def main(args):
     # Read the file, a line at a time
     # Start by ignoring lines
@@ -134,7 +149,7 @@ def main(args):
 
                 # Grab the test name from the result entry
                 # RESULT line is in the form of:
-                #     INFO: RESULT:[NAME]:[HOSTID]:[SUCCESS|FAIL]:[MESSAGE]
+                #     INFO: RESULT:[NAME]:[HOSTID]:[SUCCESS|FAILED]:[MESSAGE]
                 try:
                     entry["name"] = line.split(":")[2]
                 except IndexError:
@@ -157,6 +172,20 @@ def main(args):
                 continue
 
             if "INFO" in line:
+                if "install_log =" in line and entry.get("logfile"):
+                    # entry should be empty for every complete logfile entry, if it is not
+                    # that indicates there is a missing RESULT. Guess the test name and build a fake RESULT
+                    entry["name"] = guess_test_name(entry["logfile"])
+                    entry["scenario"] = args.scenario
+                    entry["result"] = "INFO: RESULT:%s:missing:FAILED:Missing RESULT line" % entry["name"]
+                    entry["success"] = False
+
+
+                    # Reset for the next entry
+                    tests.append(entry)
+                    capture_summary = False
+                    entry = {}
+
                 # install_log is the first line of a test
                 if "install_log =" in line:
                     entry["logfile"] = parse_install_log(line)
@@ -186,6 +215,14 @@ def main(args):
                         continue
                     # Capturing summary lines
                     entry["summary"].append(line)
+
+    # Check for a missing result at the end of the logfile
+    if entry.get("logfile") and not entry.get("result"):
+        entry["name"] = guess_test_name(entry["logfile"])
+        entry["scenario"] = args.scenario
+        entry["result"] = "INFO: RESULT:%s:missing:FAILED:Missing RESULT line" % entry["name"]
+        entry["success"] = False
+        tests.append(entry)
 
     return tests
 

--- a/scripts/log2json
+++ b/scripts/log2json
@@ -37,9 +37,9 @@
 #             "end_time": 1646385568.0,
 #             "elapsed_time": 1724.0
 #         },
-# 
+#
 #         ...
-# 
+#
 #         {
 #             "scenario": "logs-daily-iso",
 #             "logfile": "/var/tmp/kstest-driverdisk-disk-kargs.2022_03_04-02_42_13._25nhiki/virt-install.log",
@@ -67,6 +67,7 @@ def parse_args():
     parser = argparse.ArgumentParser(description="Convert kstest logs to JSON")
     parser.add_argument("--scenario", required=True, help="Name of test scenario")
     parser.add_argument("--output", help="Output filename (default is stdout)")
+    parser.add_argument("--kstest-list", help="File containing list of expected tests")
     parser.add_argument("LOGFILE", type=os.path.abspath, help="File to convert")
 
     return parser.parse_args()
@@ -177,7 +178,7 @@ def main(args):
                     # that indicates there is a missing RESULT. Guess the test name and build a fake RESULT
                     entry["name"] = guess_test_name(entry["logfile"])
                     entry["scenario"] = args.scenario
-                    entry["result"] = "INFO: RESULT:%s:missing:FAILED:Missing RESULT line" % entry["name"]
+                    entry["result"] = "INFO: RESULT:%s:missing:MISSING:Missing RESULT line" % entry["name"]
                     entry["success"] = False
 
 
@@ -220,9 +221,25 @@ def main(args):
     if entry.get("logfile") and not entry.get("result"):
         entry["name"] = guess_test_name(entry["logfile"])
         entry["scenario"] = args.scenario
-        entry["result"] = "INFO: RESULT:%s:missing:FAILED:Missing RESULT line" % entry["name"]
+        entry["result"] = "INFO: RESULT:%s:missing:MISSING:Missing RESULT line" % entry["name"]
         entry["success"] = False
-        tests.append(entry)
+
+    # Optionally check for any missing tests, adding entries for them
+    kstest_list = args.kstest_list or os.path.join(os.path.dirname(args.LOGFILE), "kstest-list")
+    if os.path.exists(kstest_list):
+        # The kstest-list file is a list of test names, one per line.
+        with open(kstest_list) as f:
+            expected_tests = set(t.strip() for t in f.readlines())
+        ran_tests = set(t["name"] for t in tests)
+        missing = expected_tests - ran_tests
+        for t in missing:
+            entry = {
+                "name": t,
+                "result": "INFO: RESULT:%s:missing:MISSING:Missing test" % t,
+                "success": False,
+                "logfile": ""
+            }
+            tests.append(entry)
 
     return tests
 

--- a/scripts/run_kickstart_tests.sh
+++ b/scripts/run_kickstart_tests.sh
@@ -330,6 +330,14 @@ for t in ${tests}; do
     done
 done
 
+# Save the names of the tests that should be executed to /var/tmp/kstest-list
+echo "Saving list of expected tests to /var/tmp/kstest-list"
+[ -e /var/tmp/kstest-list ] && rm /var/tmp/kstest-list
+for t in ${tests}; do
+    name=$(basename "${t/.sh/}")
+    echo "${name}" >> /var/tmp/kstest-list
+done
+
 # collect the prerequisite list for the requested tests. If there is
 # anything in the list, build it.
 

--- a/scripts/weekly-summary
+++ b/scripts/weekly-summary
@@ -179,6 +179,36 @@ def extract_logs(f):
     return tdir
 
 
+def generate_test_list(tdir):
+    """
+    Build kstest-list if it is missing
+
+    This is a list of the expected tests, and it is used to help detect when
+    tests are totally missing from the results.
+
+    The original kstest.log has a line:
+    Running tests: ./bridge-httpks.sh ./packages-instlangs-1.sh  ...
+
+    Parse this and create kstest-list, one test name per line for later use.
+    """
+
+    # Skip this if it already exists
+    if os.path.exists(os.path.join(tdir.name, "kstest-list")):
+        return
+
+    kstest_log = os.path.join(tdir.name, "kstest.log")
+    with open(kstest_log) as f:
+        for line in f.readlines():
+            if not line.startswith("Running tests: "):
+                continue
+
+            tests = [os.path.basename(os.path.splitext(s)[0]) for s in line[15:].split()]
+            with open(os.path.join(tdir.name, "kstest-list"), "wt") as klf:
+                for t in tests:
+                    print(t, file=klf)
+            break
+
+
 def rebuild_logs(tdir):
     """
     rebuild_logs recreates kstest.log with timestamps
@@ -531,6 +561,7 @@ def main(args, token):
 
             # This is needed for logs without timestamps
             if args.rebuild:
+                generate_test_list(all_logs[datename])
                 rebuild_logs(all_logs[datename])
 
             # Run summary on kstest.log

--- a/scripts/weekly-summary
+++ b/scripts/weekly-summary
@@ -202,14 +202,16 @@ def rebuild_logs(tdir):
 
 def check_tests(tests):
     """
-    Check the tests for success, failing, or flakes -- success after first failing
+    Check the tests for success, failing, missing, or flakes -- success after first failing
 
     This returns a tuple of:
     - list of the names of successful tests
+    - list of the names of the missing tests
     - dict of failed tests, each entry being a list of the failure details dict
     - dict of flaky tests, each entry being a list of the flaky details dict
     """
     success = []
+    missing = []
     failed = {}
     flakes = {}
 
@@ -228,7 +230,10 @@ def check_tests(tests):
                 flakes[name] = failed[name]
                 del failed[name]
         else:
-            if name in success:
+            if "MISSING" in t["result"]:
+                # Test is completely missing, don't count it as failed
+                missing.append(name)
+            elif name in success:
                 # Test was also successful, make sure to record it in flakes list
                 if name in flakes:
                     flakes[name].append(t)
@@ -240,7 +245,7 @@ def check_tests(tests):
                 else:
                     failed[name] = [t]
 
-    return sorted(success), failed, flakes
+    return sorted(success), sorted(missing), failed, flakes
 
 
 def print_test_details(scenario, days, test_name, buf):
@@ -316,9 +321,12 @@ def archive_test_logs(days, archive_path, all_logs):
             for name in failed:
                 i = 1
                 for t in sorted(failed[name], key=lambda x: x["start_time"]):
-                    logdir = kstest_logdir(tmpdir, t)
-                    if not os.path.exists(logdir):
-                        raise RuntimeError(f"Missing logdir - {logdir}")
+                    try:
+                        logdir = kstest_logdir(tmpdir, t)
+                        if not os.path.exists(logdir):
+                            raise RuntimeError(f"Missing logdir - {logdir}")
+                    except RuntimeError:
+                        continue
                     dst = os.path.join(scenario_archive, "failed", name, str(i))
                     shutil.copytree(logdir, dst)
                     i += 1
@@ -326,9 +334,12 @@ def archive_test_logs(days, archive_path, all_logs):
             for name in flakes:
                 i = 1
                 for t in sorted(flakes[name], key=lambda x: x["start_time"]):
-                    logdir = kstest_logdir(tmpdir, t)
-                    if not os.path.exists(logdir):
-                        raise RuntimeError(f"Missing logdir - {logdir}")
+                    try:
+                        logdir = kstest_logdir(tmpdir, t)
+                        if not logdir or not os.path.exists(logdir):
+                            raise RuntimeError(f"Missing logdir - {logdir}")
+                    except RuntimeError:
+                        continue
                     dst = os.path.join(scenario_archive, "flakes", name, str(i))
                     shutil.copytree(logdir, dst)
                     i += 1
@@ -392,18 +403,21 @@ def summary(args, json_logs, all_logs):
         days[day] = {}
         for scenario in sorted(all_data[day].keys()):
             if scenario not in all_days:
-                all_days[scenario] = {"success": 0, "failed": 0, "flakes": 0}
+                all_days[scenario] = {"success": 0, "missing": 0, "failed": 0, "flakes": 0}
 
             # Figure out how many were successful, failed, or were flakes
-            success, failed, flakes = check_tests(all_data[day][scenario])
+            success, missing, failed, flakes = check_tests(all_data[day][scenario])
 
             days[day][scenario] = {
                     "success": len(success),
+                    "missing": len(missing),
                     "failed": len(failed),
                     "flakes": len(flakes),
+                    "missing-tests": missing,
                     "failed-tests": failed,
                     "flaky-tests": flakes}
             all_days[scenario]["success"] += len(success)
+            all_days[scenario]["missing"] += len(missing)
             all_days[scenario]["failed"] += len(failed)
             all_days[scenario]["flakes"] += len(flakes)
 
@@ -419,10 +433,11 @@ def summary(args, json_logs, all_logs):
     print("==============", file=buf)
     for scenario in sorted(all_days.keys()):
         success = all_days[scenario]["success"]
+        missing = all_days[scenario]["missing"]
         failed = all_days[scenario]["failed"]
         flakes = all_days[scenario]["flakes"]
 
-        print(f"{scenario}: Ran {success+failed} tests. {success} passed, {failed} failed, {flakes} flakes.", file=buf)
+        print(f"{scenario}: Ran {success+failed+missing} tests. {success} passed, {failed} failed, {missing} missing, {flakes} flakes.", file=buf)
     print("\n", file=buf)
 
     print("Top 5 failed tests for the week", file=buf)
@@ -441,10 +456,15 @@ def summary(args, json_logs, all_logs):
         for scenario in sorted(days[day].keys()):
             s = days[day][scenario]
             success = s["success"]
+            missing = s["missing"]
             failed = s["failed"]
-            total = success + failed
+            total = success + failed + missing
             flakes = s["flakes"]
-            print(f"    {scenario} (Ran {total}, {success} passed, {failed} failed. {flakes} flakes) :", file=buf)
+            print(f"    {scenario} (Ran {total}, {success} passed, {failed} failed, {missing} missing. {flakes} flakes) :", file=buf)
+            if s["missing-tests"]:
+                print("        Missing:", file=buf)
+                for n in sorted(s["missing-tests"].keys()):
+                    print(f"            {n}", file=buf)
             if s["failed-tests"]:
                 print("        Failed:", file=buf)
                 for n in sorted(s["failed-tests"].keys()):

--- a/scripts/weekly-summary
+++ b/scripts/weekly-summary
@@ -493,7 +493,7 @@ def summary(args, json_logs, all_logs):
             print(f"    {scenario} (Ran {total}, {success} passed, {failed} failed, {missing} missing. {flakes} flakes) :", file=buf)
             if s["missing-tests"]:
                 print("        Missing:", file=buf)
-                for n in sorted(s["missing-tests"].keys()):
+                for n in s["missing-tests"]:
                     print(f"            {n}", file=buf)
             if s["failed-tests"]:
                 print("        Failed:", file=buf)
@@ -537,6 +537,34 @@ def summary(args, json_logs, all_logs):
         print(f"\nERROR: Problem archiving test logs - {e}", file=buf)
 
     return buf.getvalue()
+
+
+def test_summary(args, path):
+    """
+    Test the weekly summary on a single directory
+
+    Instead of pulling artifacts from github use a single directory with
+    kstest.log.json and the log directories.
+    """
+    log = os.path.join(path, "kstest.log.json")
+    with open(log) as f:
+        data = json.load(f)
+        scenario = data[0].get("scenario", None)
+    if not scenario:
+        raise RuntimeError("No scenario found in %s" % log)
+
+    # The json log filename needs to be in the form of <scenario>-<YYYY-MM-DD>.json
+    datename = f"{scenario}-1990-01-01"
+    shutil.copy(log, datename+".json")
+    datenames = [datename]
+    all_logs = {datename: path}
+
+    report = summary(args, (d+".json" for d in datenames), all_logs)
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(report)
+    else:
+        print(report)
 
 
 def main(args, token):
@@ -609,6 +637,7 @@ if __name__ == '__main__':
             help="Optionally collect the failed/flake logs in an archive directory tree")
     parser.add_argument("--output",
             help="Path and filename to write summary report to")
+    parser.add_argument("--test", help=argparse.SUPPRESS)
     parser.add_argument("--debug", default=False, action="store_true")
     parser.add_argument("--verbose", default=False, action="store_true")
     args = parser.parse_args()
@@ -620,4 +649,7 @@ if __name__ == '__main__':
     if args.debug:
         print(f"args = {args}")
 
-    main(args, os.environ["GITHUB_TOKEN"])
+    if args.test:
+        test_summary(args, args.test)
+    else:
+        main(args, os.environ["GITHUB_TOKEN"])


### PR DESCRIPTION
Some tests can fail without emitting a RESULT line. Catch these cases
and create a fake RESULT entry, and guess at the test name based on the
install_log filename. If the format of the kstest-... part of that
filename ever changes this will need to be updated.

Fixes #713