### PR TITLE
Schedule daily testing runs of daily kstests run via permian

### DIFF
--- a/.github/workflows/scenarios-permian.yml
+++ b/.github/workflows/scenarios-permian.yml
@@ -1,6 +1,9 @@
 # Run all kickstart tests for all active branches in Permian
 name: Daily run in Permian
 on:
+  schedule:
+    # run after daily-boot-iso.yml
+    - cron: 0 23 * * *
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
We will run them in parallel with current scenario for a while on a
dedicated separate kstests-permian runner.

Before merging:
- [x] Do not mess weekly reports with results:  https://github.com/rhinstaller/kickstart-tests/pull/717