### PR TITLE
Add test if menu-auto-hide boot option is added by default

### DIFF
--- a/default-menu-auto-hide-fedora.ks.in
+++ b/default-menu-auto-hide-fedora.ks.in
@@ -1,0 +1,18 @@
+#version=DEVEL
+#test name: default-menu-auto-hide
+%ksappend repos/default.ks
+
+%ksappend common/common_no_payload.ks
+%ksappend payload/default_packages.ks
+
+%post
+# log grubenv file
+cat /boot/grub2/grubenv
+
+# check the menu_auto_hide is correctly set
+grep -q "menu_auto_hide=1" /boot/grub2/grubenv || \
+     echo "*** Failed check: The menu_auto_hide is not part of the /boot/grub2/grubenv by default" >> /root/RESULT
+
+%ksappend validation/success_if_result_empty.ks
+
+%end

--- a/default-menu-auto-hide-fedora.sh
+++ b/default-menu-auto-hide-fedora.sh
@@ -1,0 +1,55 @@
+#
+# Copyright (C) 2022  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
+
+# This is duplicate test of RHEL test which is changing the configuration
+# option on Fedora to be able to test the functionality also there.
+TESTTYPE="bootloader skip-on-rhel"
+
+. ${KSTESTDIR}/functions.sh
+
+prepare_updates() {
+    local tmp_dir="${1}"
+    local updates_dir="${tmp_dir}/updates"
+    local updates_img="${tmp_dir}/updates.img"
+    local conf_dir="${updates_dir}/etc/anaconda/conf.d/"
+
+    # Define a configuration snippet.
+    mkdir -p "${conf_dir}"
+    cat > "${conf_dir}/99-testing.conf" <<EOF
+
+[Bootloader]
+# Enable this test on Fedora by enabling the feature for Fedora tests.
+menu_auto_hide = True
+
+EOF
+
+    # Apply the provided updates image if any.
+    apply_updates_image "${UPDATES}" "${updates_dir}"
+
+    # Create a new updates image.
+    create_updates_image "${updates_dir}" "${updates_img}"
+
+    # Provide the image. The function prints the URL.
+    upload_updates_image "${tmp_dir}" "${updates_img}"
+}
+
+cleanup() {
+    local tmp_dir="${1}"
+    stop_httpd "${tmp_dir}"
+}

--- a/default-menu-auto-hide-rhel.ks.in
+++ b/default-menu-auto-hide-rhel.ks.in
@@ -1,0 +1,18 @@
+#version=DEVEL
+#test name: default-menu-auto-hide
+%ksappend repos/default.ks
+
+%ksappend common/common_no_payload.ks
+%ksappend payload/default_packages.ks
+
+%post
+# log grubenv file
+cat /boot/grub2/grubenv
+
+# check the menu_auto_hide is correctly set
+grep -q "menu_auto_hide=1" /boot/grub2/grubenv || \
+     echo "*** Failed check: The menu_auto_hide is not part of the /boot/grub2/grubenv by default" >> /root/RESULT
+
+%ksappend validation/success_if_result_empty.ks
+
+%end

--- a/default-menu-auto-hide-rhel.sh
+++ b/default-menu-auto-hide-rhel.sh
@@ -1,0 +1,25 @@
+#
+# Copyright (C) 2022  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
+
+# We have this feature on Fedora, however, only for Workstation which is not
+# used by KS tests. There is another test which works for Fedora only and
+# changing configuration file.
+TESTTYPE="bootloader skip-on-rhel-8 skip-on-fedora"
+
+. ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Anaconda should add these to CentOS Stream and RHEL 9 and to Fedora. This boot option will hide boot menu during the boot and user can access it by pressing space key.

This is testing if the Anaconda configuration option menu_auto_hide is enabled for the given systems.

Related to https://github.com/rhinstaller/anaconda/pull/4050.