### PR TITLE
Add github reporting to kstsest on PR testplan

### DIFF
--- a/testlib/test_plans/pull-request.plan.yaml
+++ b/testlib/test_plans/pull-request.plan.yaml
@@ -8,3 +8,8 @@ verified_by:
     query: 'True'
 configurations:
   - architecture: x86_64
+reporting:
+  - type: github-pr
+    data:
+      pr-check-name: "Kickstart tests"
+      pr-check-summary: "Kickstart tests run on a pull request comment"


### PR DESCRIPTION
Will be used in permian main branch gating: https://github.com/rhinstaller/permian/pull/30
And later in anaconda PRs kstests