### PR TITLE
Disable fedora-live-image-build test temporarily (gh#740)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -23,6 +23,7 @@ daily_iso_skip_array=(
   gh640       # authselect-not-set failing
   gh641       # packages-multilib failing on systemd conflict
   gh680       # proxy-kickstart and proxy-auth failing
+  gh740       # fedora-live-image-build fails on comps changes
 )
 
 rhel8_skip_array=(

--- a/fedora-live-image-build.sh
+++ b/fedora-live-image-build.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
-TESTTYPE="packaging skip-on-rhel"
+TESTTYPE="packaging skip-on-rhel gh740"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Disable fedora-live-image-build until gh#740 is fixed.