### PR TITLE
virt-install: update --location of kernel and initramfs

### DIFF
--- a/scripts/launcher/lib/virtual_controller.py
+++ b/scripts/launcher/lib/virtual_controller.py
@@ -165,7 +165,7 @@ class VirtualInstall(object):
             args.append(extra_args)
 
             args.append("--location")
-            args.append(self._iso + ",kernel=isolinux/vmlinuz,initrd=isolinux/initrd.img")
+            args.append(self._iso + ",kernel=images/pxeboot/vmlinuz,initrd=images/pxeboot/initrd.img")
 
         channel_args = "tcp,host={0}:{1},mode=connect,target_type=virtio" \
                        ",name=org.fedoraproject.anaconda.log.0".format(


### PR DESCRIPTION
The isolinux was removed from boot.iso generated by lorax in pykickstart
37.3.

Resolves https://github.com/rhinstaller/kickstart-tests/issues/742