### PR TITLE
Enable rootpw-allow-ssh test on rhel-9 (rhbz#2033849)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -42,7 +42,6 @@ rhel9_skip_array=(
   rhbz1960279 # packages-weakdeps: "gnupg2 --recommends has changed, test needs to be updated"
   gh641       # packages-multilib failing on systemd conflict
   gh670       # repo-include failing on rhel
-  rhbz2033849 # rootpw-allow-ssh will be added in 9.1
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/rootpw-allow-ssh.sh
+++ b/rootpw-allow-ssh.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE="users skip-on-rhel-8 rhbz2033849"
+TESTTYPE="users skip-on-rhel-8"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
The feature is included in RHEL-9.1 development composes.