### PR TITLE
Disable network-addr-gen-mode-* tests temporarily (gh#748)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -24,6 +24,7 @@ daily_iso_skip_array=(
   gh641       # packages-multilib failing on systemd conflict
   gh680       # proxy-kickstart and proxy-auth failing
   gh740       # fedora-live-image-build fails on comps changes
+  gh748       # network-addr-gen-mode-* failing
 )
 
 rhel8_skip_array=(
@@ -42,6 +43,7 @@ rhel9_skip_array=(
   rhbz1960279 # packages-weakdeps: "gnupg2 --recommends has changed, test needs to be updated"
   gh641       # packages-multilib failing on systemd conflict
   gh670       # repo-include failing on rhel
+  gh748       # network-addr-gen-mode-* failing
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/network-addr-gen-mode-dhcpall.sh
+++ b/network-addr-gen-mode-dhcpall.sh
@@ -22,7 +22,7 @@
 # The latter is causing that kickstart network commands are not applied (ifcfg
 # files created) in initramfs.
 
-TESTTYPE="network"
+TESTTYPE="network gh748"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/network-addr-gen-mode.sh
+++ b/network-addr-gen-mode.sh
@@ -22,7 +22,7 @@
 # The latter is causing that kickstart network commands are not applied (ifcfg
 # files created) in initramfs.
 
-TESTTYPE="network"
+TESTTYPE="network gh748"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Disable network-addr-gen-mode-* tests until gh#748 is fixed.