### PR TITLE
Disable network-bootopts-team-dhcp-httpks test temporarily (gh#749)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -44,6 +44,7 @@ rhel9_skip_array=(
   gh641       # packages-multilib failing on systemd conflict
   gh670       # repo-include failing on rhel
   gh748       # network-addr-gen-mode-* failing
+  gh749       # network-bootopts-team-dhcp-httpks test is failing
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/network-bootopts-team-dhcp-httpks.sh
+++ b/network-bootopts-team-dhcp-httpks.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE=${TESTTYPE:-"network"}
+TESTTYPE=${TESTTYPE:-"network gh749"}
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Disable network-bootopts-team-dhcp-httpks until gh#749 is fixed.