### PR TITLE
Disable network-addr-gen-mode-* tests on rhel8 temporarily (gh#748)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -32,6 +32,7 @@ rhel8_skip_array=(
   gh576       # clearpart-4 test is flaky on all scenarios
   gh595       # proxy-cmdline failing on all scenarios
   gh670       # repo-include failing on rhel
+  gh748       # network-addr-gen-mode-* waiting for new build
 )
 
 rhel9_skip_array=(

--- a/network-addr-gen-mode-dhcpall.sh
+++ b/network-addr-gen-mode-dhcpall.sh
@@ -22,7 +22,7 @@
 # The latter is causing that kickstart network commands are not applied (ifcfg
 # files created) in initramfs.
 
-TESTTYPE="network"
+TESTTYPE="network gh748"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/network-addr-gen-mode.sh
+++ b/network-addr-gen-mode.sh
@@ -22,7 +22,7 @@
 # The latter is causing that kickstart network commands are not applied (ifcfg
 # files created) in initramfs.
 
-TESTTYPE="network"
+TESTTYPE="network gh748"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Disable network-addr-gen-mode-* tests on rhel8 until gh#748 is fixed
(a new NM build gets in).