### PR TITLE
Increase timeout for daily scenarios by 30 minutes

### DIFF
--- a/.github/workflows/scenarios-permian.yml
+++ b/.github/workflows/scenarios-permian.yml
@@ -19,13 +19,13 @@ jobs:
       fail-fast: false
 
     # these settings depend on the infrastructure; on upshift ocp-master-xxl they take about 4 hours
-    timeout-minutes: 530
+    timeout-minutes: 560
     env:
       TEST_JOBS: 16
       GITHUB_TOKEN: /home/github/github-token
       # The timeout should be ~20 minutes less then the job's timeout-minutes
       # so that we get partial results and logs in case of the timeout.
-      LAUNCHER_TIMEOUT_MINUTES: 510
+      LAUNCHER_TIMEOUT_MINUTES: 540
 
     steps:
       # self-hosted runners don't do this automatically; also useful to keep stuff around for debugging


### PR DESCRIPTION
We are tight to the limit for daily-iso and have some instances of 1
missing test in the run. I will look also if refreshing the runners
helps.