### PR TITLE
Add the missing reqpart command

### DIFF
--- a/btrfs-1.ks.in
+++ b/btrfs-1.ks.in
@@ -6,6 +6,7 @@ bootloader --timeout=1
 zerombr
 clearpart --all
 
+reqpart
 part --fstype=ext4 --size=500 /boot
 part --fstype=swap --size=500 swap
 part btrfs.10 --fstype="btrfs" --size=4400 --fsoptions=loud,noatime

--- a/btrfs-2.ks.in
+++ b/btrfs-2.ks.in
@@ -6,6 +6,7 @@ bootloader --timeout=1
 zerombr
 clearpart --all
 
+reqpart
 part --fstype=ext4 --size=500 /boot
 part --fstype=swap --size=500 swap
 part btrfs.10 --fstype="btrfs" --size=2200

--- a/default-fstype.ks.in
+++ b/default-fstype.ks.in
@@ -6,6 +6,8 @@ network --bootproto=dhcp
 bootloader --timeout=1
 zerombr
 clearpart --all --initlabel
+
+reqpart
 part /boot --size=500 --label=boot
 part pv.1 --fstype=lvmpv --size=4504
 volgroup fedora pv.1

--- a/encrypt-device.ks.in
+++ b/encrypt-device.ks.in
@@ -5,6 +5,8 @@ network --bootproto=dhcp
 bootloader --timeout=1
 zerombr
 clearpart --all --initlabel
+
+reqpart
 part pv.68 --asprimary --fstype="lvmpv" --ondisk=vda --size=7691
 part /boot --asprimary --fstype="ext4" --ondisk=vda --size=500
 volgroup vg01 --pesize=4096 pv.68

--- a/encrypt-swap.ks.in
+++ b/encrypt-swap.ks.in
@@ -6,6 +6,8 @@ network --bootproto=dhcp
 bootloader --timeout=1
 zerombr
 clearpart --all --initlabel
+
+reqpart
 part /boot --fstype=ext4 --size=500 --ondisk=vda
 part / --size=4000 --fstype=ext4 --fsoptions=loud,noatime --ondisk=vda --label=rootfs
 

--- a/escrow-cert.ks.in
+++ b/escrow-cert.ks.in
@@ -5,6 +5,8 @@ network --bootproto=dhcp
 bootloader --timeout=1
 zerombr
 clearpart --all
+
+reqpart
 part --fstype=ext4 --size=4400 --label=rootfs /
 part --fstype=ext4 --size=500 /boot
 part --fstype=swap --size=500 swap

--- a/fedora-live-image-build.ks.in
+++ b/fedora-live-image-build.ks.in
@@ -37,6 +37,7 @@ zerombr
 # Partition clearing information
 clearpart --all
 # Disk partitioning information
+reqpart
 part / --grow
 
 %post

--- a/harddrive-install-tree-relative.ks.in
+++ b/harddrive-install-tree-relative.ks.in
@@ -19,6 +19,7 @@
 zerombr
 clearpart --all --initlabel --drives=/dev/vda
 
+reqpart
 part / --fstype=ext4 --grow --size=4400 --ondisk=/dev/vda
 part /boot --fstype=ext4 --size=500 --ondisk=/dev/vda
 part swap --fstype=swap --size=500 --ondisk=/dev/vda

--- a/harddrive-install-tree.ks.in
+++ b/harddrive-install-tree.ks.in
@@ -16,6 +16,7 @@
 zerombr
 clearpart --all --initlabel --drives=/dev/vda
 
+reqpart
 part / --fstype=ext4 --grow --size=4400 --ondisk=/dev/vda
 part /boot --fstype=ext4 --size=500 --ondisk=/dev/vda
 part swap --fstype=swap --size=500 --ondisk=/dev/vda

--- a/harddrive-iso.ks.in
+++ b/harddrive-iso.ks.in
@@ -15,6 +15,7 @@
 zerombr
 clearpart --all --initlabel --drives=/dev/vda
 
+reqpart
 part / --fstype=ext4 --grow --size=4400 --ondisk=/dev/vda
 part /boot --fstype=ext4 --size=500 --ondisk=/dev/vda
 part swap --fstype=swap --size=500 --ondisk=/dev/vda

--- a/iscsi-bind.ks.in
+++ b/iscsi-bind.ks.in
@@ -12,6 +12,7 @@ autopart
 
 # for non-offload iSCSI /boot can be on iSCSI only when using iBFT,
 # so put it to local disk
+#reqpart
 #part /boot --size=500 --ondisk=vda
 #part / --size=5000 --ondisk=vdb --grow
 #part swap --size=1000 --ondisk=vdb

--- a/iscsi.ks.in
+++ b/iscsi.ks.in
@@ -12,6 +12,7 @@ autopart
 
 # for non-offload iSCSI /boot can be on iSCSI only when using iBFT,
 # so put it to local disk
+#reqpart
 #part /boot --size=500 --ondisk=vda
 #part / --size=5000 --ondisk=vdb --grow
 #part swap --size=1000 --ondisk=vdb

--- a/lvm-1.ks.in
+++ b/lvm-1.ks.in
@@ -6,6 +6,8 @@ network --bootproto=dhcp
 bootloader --timeout=1
 zerombr
 clearpart --all --initlabel
+
+reqpart
 part /boot --fstype=ext4 --size=500
 part pv.1 --fstype=lvmpv --size=4504
 volgroup fedora pv.1

--- a/lvm-2.ks.in
+++ b/lvm-2.ks.in
@@ -6,6 +6,8 @@ network --bootproto=dhcp
 bootloader --timeout=1
 zerombr
 clearpart --all --initlabel
+
+reqpart
 part /boot --fstype=ext4 --size=500
 part pv.1 --fstype=lvmpv --size=5000
 volgroup fedora pv.1

--- a/lvm-cache-1.ks.in
+++ b/lvm-cache-1.ks.in
@@ -6,6 +6,8 @@ network --bootproto=dhcp
 bootloader --timeout=1
 zerombr
 clearpart --all --initlabel
+
+reqpart
 part /boot --fstype=ext4 --size=300
 part pv.1 --fstype=lvmpv --size=6500
 part pv.2 --fstype=lvmpv --size=3100

--- a/lvm-cache-2.ks.in
+++ b/lvm-cache-2.ks.in
@@ -6,6 +6,8 @@ network --bootproto=dhcp
 bootloader --timeout=1
 zerombr
 clearpart --all --initlabel
+
+reqpart
 part /boot --fstype=ext4 --size=300
 part pv.1 --fstype=lvmpv --size=6600
 part pv.2 --fstype=lvmpv --size=3100

--- a/lvm-luks-1.ks.in
+++ b/lvm-luks-1.ks.in
@@ -10,6 +10,7 @@ clearpart --all --initlabel
 # Test LUKS 2 with default values.
 # FIXME: remove the --pbkdf-time option
 
+reqpart
 part /boot --fstype="ext4" --size=1024
 part pv.1 --fstype="lvmpv" --size=9215
 

--- a/lvm-luks-2.ks.in
+++ b/lvm-luks-2.ks.in
@@ -9,6 +9,7 @@ clearpart --all --initlabel
 
 # Test LUKS 2 with default values.
 
+reqpart
 part /boot --fstype="ext4" --size=1024
 part pv.1 --fstype="lvmpv" --size=9215
 

--- a/lvm-luks-3.ks.in
+++ b/lvm-luks-3.ks.in
@@ -9,6 +9,7 @@ clearpart --all --initlabel
 
 # Test LUKS 2 with pbkdf2 and the --pbkdf-time option.
 
+reqpart
 part /boot --fstype="ext4" --size=1024
 part pv.1 --fstype="lvmpv" --size=9215
 

--- a/lvm-luks-4.ks.in
+++ b/lvm-luks-4.ks.in
@@ -9,6 +9,7 @@ clearpart --all --initlabel
 
 # Test LUKS 2 with argon2i and options --pbkdf-iterations and --pbkdf-memory.
 
+reqpart
 part /boot --fstype="ext4" --size=1024
 part pv.1 --fstype="lvmpv" --size=9215
 

--- a/lvm-raid-1.ks.in
+++ b/lvm-raid-1.ks.in
@@ -6,6 +6,8 @@ network --bootproto=dhcp
 bootloader --timeout=1
 zerombr
 clearpart --all --initlabel
+
+reqpart
 part /boot --fstype=ext4 --size=500
 part raid.01 --size=7500 --ondisk=vda
 part raid.02 --size=7500 --ondisk=vdb

--- a/lvm-thinp-1.ks.in
+++ b/lvm-thinp-1.ks.in
@@ -6,6 +6,8 @@ network --bootproto=dhcp
 bootloader --timeout=1
 zerombr
 clearpart --all --initlabel
+
+reqpart
 part /boot --fstype=ext4 --size=500
 part pv.1 --fstype=lvmpv --size=9004
 volgroup fedora pv.1

--- a/lvm-thinp-2.ks.in
+++ b/lvm-thinp-2.ks.in
@@ -6,6 +6,8 @@ network --bootproto=dhcp
 bootloader --timeout=1
 zerombr
 clearpart --all --initlabel
+
+reqpart
 part /boot --fstype=ext4 --size=500
 part pv.1 --fstype=lvmpv --size=9004
 volgroup fedora pv.1

--- a/part-luks-1.ks.in
+++ b/part-luks-1.ks.in
@@ -9,6 +9,7 @@ clearpart --all --initlabel
 
 # Test LUKS 1 with default values.
 
+reqpart
 part / --fstype="ext4" --size=8191 --encrypted --passphrase="passphrase" --luks-version=luks1
 part /boot --fstype="ext4" --size=1024
 part swap --fstype="swap" --size=1024

--- a/part-luks-2.ks.in
+++ b/part-luks-2.ks.in
@@ -9,6 +9,7 @@ clearpart --all --initlabel
 
 # Test LUKS 2 with default values.
 
+reqpart
 part / --fstype="ext4" --size=8191 --encrypted --passphrase="passphrase" --luks-version=luks2
 part /boot --fstype="ext4" --size=1024
 part swap --fstype="swap" --size=1024

--- a/part-luks-3.ks.in
+++ b/part-luks-3.ks.in
@@ -9,6 +9,7 @@ clearpart --all --initlabel
 
 # Test LUKS 2 with pbkdf2 and the --pbkdf-time option.
 
+reqpart
 part / --fstype="ext4" --size=8191 --encrypted --passphrase="passphrase" --luks-version=luks2 --pbkdf=pbkdf2 --pbkdf-time=10
 part /boot --fstype="ext4" --size=1024
 part swap --fstype="swap" --size=1024

--- a/part-luks-4.ks.in
+++ b/part-luks-4.ks.in
@@ -9,6 +9,7 @@ clearpart --all --initlabel
 
 # Test LUKS 2 with argon2i and options --pbkdf-iterations and --pbkdf-memory.
 
+reqpart
 part / --fstype="ext4" --size=8191 --encrypted --passphrase="passphrase" --luks-version=luks2 --pbkdf=argon2i --pbkdf-iterations=4 --pbkdf-memory=64
 part /boot --fstype="ext4" --size=1024
 part swap --fstype="swap" --size=1024

--- a/raid-luks-1.ks.in
+++ b/raid-luks-1.ks.in
@@ -9,6 +9,7 @@ clearpart --all --initlabel
 
 # Test LUKS 1 with default values.
 
+reqpart
 part /boot --fstype="ext4" --size=1024
 part swap --fstype="swap" --size=2048
 part raid.1 --fstype="mdmember" --ondisk=vda --size=7167

--- a/raid-luks-2.ks.in
+++ b/raid-luks-2.ks.in
@@ -9,6 +9,7 @@ clearpart --all --initlabel
 
 # Test LUKS 2 with default values.
 
+reqpart
 part /boot --fstype="ext4" --size=1024
 part swap --fstype="swap" --size=2048
 part raid.1 --fstype="mdmember" --ondisk=vda --size=7167

--- a/raid-luks-3.ks.in
+++ b/raid-luks-3.ks.in
@@ -9,6 +9,7 @@ clearpart --all --initlabel
 
 # Test LUKS 2 with pbkdf2 and the --pbkdf-time option.
 
+reqpart
 part /boot --fstype="ext4" --size=1024
 part swap --fstype="swap" --size=2048
 part raid.1 --fstype="mdmember" --ondisk=vda --size=7167

--- a/raid-luks-4.ks.in
+++ b/raid-luks-4.ks.in
@@ -9,6 +9,7 @@ clearpart --all --initlabel
 
 # Test LUKS 2 with argon2i and options --pbkdf-iterations and --pbkdf-memory.
 
+reqpart
 part /boot --fstype="ext4" --size=1024
 part swap --fstype="swap" --size=2048
 part raid.1 --fstype="mdmember" --ondisk=vda --size=7167

--- a/snapshot-post.ks.in
+++ b/snapshot-post.ks.in
@@ -5,6 +5,8 @@ network --bootproto=dhcp
 bootloader --timeout=1
 zerombr
 clearpart --all
+
+reqpart
 part /boot --fstype=ext4 --size=600
 part pv.1 --fstype=lvmpv --size=6000 --grow
 

--- a/snapshot-pre.ks.in
+++ b/snapshot-pre.ks.in
@@ -3,6 +3,8 @@
 network --bootproto=dhcp
 
 bootloader --timeout=1
+
+reqpart
 part /boot --fstype=ext4 --size=600
 volgroup testvg --useexisting --noformat
 logvol swap --name=swap --vgname=testvg --size=500 --fstype=swap

--- a/tmpfs-fixed_size.ks.in
+++ b/tmpfs-fixed_size.ks.in
@@ -6,6 +6,7 @@ bootloader --timeout=1
 zerombr
 clearpart --all
 
+reqpart
 part --fstype=ext4 --size=4400 --label=rootfs --fsoptions=loud,noatime /
 part --fstype=ext4 --size=500 /boot
 part --fstype=swap --size=500 swap


### PR DESCRIPTION
Add the `reqpart` command to all tests with custom partitioning. It will ensure
creation of the `biosboot` partition if required by the installed system.