### PR TITLE
Detect the LUKS device in kickstart tests

### DIFF
--- a/autopart-encrypted-1.ks.in
+++ b/autopart-encrypted-1.ks.in
@@ -18,17 +18,26 @@ shutdown
 %end
 
 %post
-# Check if the type of /dev/vda2 is crypto_LUKS.
-crypted="/dev/vda2"
-type="$(blkid -o value -s TYPE ${crypted})"
+# Log the created partitioning.
+lsblk
 
-if [[ "$type" != "crypto_LUKS" ]] ; then
-    echo "*** unexpected type ${type} of ${crypted}" > /root/RESULT
+# Find the LUKS device.
+crypted="$(blkid --match-token TYPE="crypto_LUKS" --output device)"
+
+if [[ $? != 0 ]] ; then
+    echo "*** couldn't find a LUKS device" > /root/RESULT
+    exit 1
+fi
+
+# The LUKS device should be a parent of a root device.
+lsblk ${crypted} --output mountpoints | grep -x /
+
+if [[ $? != 0 ]] ; then
+    echo "*** ${crypted} doesn't contain a root device" > /root/RESULT
     exit 1
 fi
 
 # Try to use the passphrase.
-crypted="/dev/vda2"
 echo "passphrase" | cryptsetup luksOpen --test-passphrase "${crypted}"
 
 if [[ $? != 0 ]] ; then

--- a/autopart-encrypted-2.ks.in
+++ b/autopart-encrypted-2.ks.in
@@ -18,9 +18,8 @@ shutdown
 %end
 
 %post
-# Check the cipher name of /dev/vda2.
-crypted="/dev/vda2"
-
+# Check the cipher name of the LUKS device.
+crypted="$(blkid --match-token TYPE="crypto_LUKS" --output device)"
 cipher="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "Cipher:") print $2; }' )"
 
 if [[ "$cipher" != "aes-xts-plain64" ]] ; then

--- a/autopart-encrypted-3.ks.in
+++ b/autopart-encrypted-3.ks.in
@@ -68,7 +68,7 @@ if [[ $? != 0 ]] || [[ -z "$backup_passphrase" ]]; then
 fi
 
 # Try to use the backup passphrase.
-crypted="/dev/vda2"
+crypted="$(blkid --match-token TYPE="crypto_LUKS" --output device)"
 echo -n $backup_passphrase | cryptsetup luksOpen --test-passphrase "${crypted}"
 
 if [[ $? != 0 ]] ; then

--- a/autopart-luks-1.ks.in
+++ b/autopart-luks-1.ks.in
@@ -21,18 +21,15 @@ shutdown
 
 %post
 
-# Set the crypted device.
-crypted="/dev/vda2"
+# Find the LUKS device.
+crypted="$(blkid --match-token TYPE="crypto_LUKS" --output device)"
 
-# Check if the type of /dev/vda2 is crypto_LUKS.
-type="$(blkid -o value -s TYPE ${crypted})"
-
-if [[ "$type" != "crypto_LUKS" ]] ; then
-    echo "*** unexpected type ${type} of ${crypted}" > /root/RESULT
+if [[ $? != 0 ]] ; then
+    echo "*** couldn't find a LUKS device" > /root/RESULT
     exit 1
 fi
 
-# Check if the LUKS version of /dev/vda2 is luks1.
+# Check if the LUKS version is luks1.
 result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "Version:") print $2; }' )"
 
 if [[ "$result" != "1" ]] ; then

--- a/autopart-luks-2.ks.in
+++ b/autopart-luks-2.ks.in
@@ -21,18 +21,15 @@ shutdown
 
 %post
 
-# Set the crypted device.
-crypted="/dev/vda2"
+# Find the LUKS device.
+crypted="$(blkid --match-token TYPE="crypto_LUKS" --output device)"
 
-# Check if the type of /dev/vda2 is crypto_LUKS.
-type="$(blkid -o value -s TYPE ${crypted})"
-
-if [[ "$type" != "crypto_LUKS" ]] ; then
-    echo "*** unexpected type ${type} of ${crypted}" > /root/RESULT
+if [[ $? != 0 ]] ; then
+    echo "*** couldn't find a LUKS device" > /root/RESULT
     exit 1
 fi
 
-# Check if the LUKS version of /dev/vda2 is luks2.
+# Check if the LUKS version is luks2.
 result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "Version:") print $2; }' )"
 
 if [[ "$result" != "2" ]] ; then

--- a/autopart-luks-3.ks.in
+++ b/autopart-luks-3.ks.in
@@ -21,10 +21,15 @@ shutdown
 
 %post
 
-# Set the crypted device.
-crypted="/dev/vda2"
+# Find the LUKS device.
+crypted="$(blkid --match-token TYPE="crypto_LUKS" --output device)"
 
-# Check the PBKDF of /dev/vda2.
+if [[ $? != 0 ]] ; then
+    echo "*** couldn't find a LUKS device" > /root/RESULT
+    exit 1
+fi
+
+# Check the PBKDF of the LUKS device.
 result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "PBKDF:") print $2; }' )"
 
 if [[ "$result" != "pbkdf2" ]] ; then

--- a/autopart-luks-4.ks.in
+++ b/autopart-luks-4.ks.in
@@ -21,17 +21,22 @@ shutdown
 
 %post
 
-# Set the crypted device.
-crypted="/dev/vda2"
+# Find the LUKS device.
+crypted="$(blkid --match-token TYPE="crypto_LUKS" --output device)"
 
-# Check the PBKDF of /dev/vda2.
+if [[ $? != 0 ]] ; then
+    echo "*** couldn't find a LUKS device" > /root/RESULT
+    exit 1
+fi
+
+# Check the PBKDF of the LUKS device.
 result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "PBKDF:") print $2; }' )"
 
 if [[ "$result" != "argon2i" ]] ; then
     echo "*** unexpected PBKDF for ${crypted}: ${result}" >> /root/RESULT
 fi
 
-# Check the memory of /dev/vda2.
+# Check the memory of the LUKS device.
 result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "Memory:") print $2; }' )"
 
 if [[ "$result" != "64" ]] ; then

--- a/autopart-luks-5.ks.in
+++ b/autopart-luks-5.ks.in
@@ -21,24 +21,29 @@ shutdown
 
 %post
 
-# Set the crypted device.
-crypted="/dev/vda2"
+# Find the LUKS device.
+crypted="$(blkid --match-token TYPE="crypto_LUKS" --output device)"
 
-# Check the PBKDF of /dev/vda2.
+if [[ $? != 0 ]] ; then
+    echo "*** couldn't find a LUKS device" > /root/RESULT
+    exit 1
+fi
+
+# Check the PBKDF of the LUKS device.
 result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "PBKDF:") print $2; }' )"
 
 if [[ "$result" != "argon2id" ]] ; then
     echo "*** unexpected PBKDF for ${crypted}: ${result}" >> /root/RESULT
 fi
 
-# Check the iterations of /dev/vda2.
+# Check the iterations of the LUKS device.
 result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "Time" && $2 == "cost:") print $3; }' )"
 
 if [[ "$result" != "4" ]] ; then
     echo "*** unexpected iterations for ${crypted}: ${result}" >> /root/RESULT
 fi
 
-# Check the memory of /dev/vda2.
+# Check the memory of the LUKS device.
 result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "Memory:") print $2; }' )"
 
 if [[ "$result" != "64" ]] ; then

--- a/lvm-luks-3.ks.in
+++ b/lvm-luks-3.ks.in
@@ -32,7 +32,7 @@ shutdown
 # Set the crypted device.
 crypted="/dev/mapper/fedora-root"
 
-# Check the PBKDF of /dev/vda2.
+# Check the PBKDF of the LUKS device.
 result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "PBKDF:") print $2; }' )"
 
 if [[ "$result" != "pbkdf2" ]] ; then

--- a/part-luks-1.ks.in
+++ b/part-luks-1.ks.in
@@ -25,14 +25,12 @@ shutdown
 
 %post
 
-# Set the crypted device.
-crypted="/dev/vda2"
+# Find the LUKS device.
+crypted="$(blkid --match-token TYPE="crypto_LUKS" --output device)"
 
-# Check if the type of the crypted device is crypto_LUKS.
-type="$(blkid -o value -s TYPE ${crypted})"
-
-if [[ "$type" != "crypto_LUKS" ]] ; then
-    echo "*** unexpected type ${type} of ${crypted}" >> /root/RESULT
+if [[ $? != 0 ]] ; then
+    echo "*** couldn't find a LUKS device" > /root/RESULT
+    exit 1
 fi
 
 # Check if the LUKS version is luks1.

--- a/part-luks-2.ks.in
+++ b/part-luks-2.ks.in
@@ -25,8 +25,13 @@ shutdown
 
 %post
 
-# Set the crypted device.
-crypted="/dev/vda2"
+# Find the LUKS device.
+crypted="$(blkid --match-token TYPE="crypto_LUKS" --output device)"
+
+if [[ $? != 0 ]] ; then
+    echo "*** couldn't find a LUKS device" > /root/RESULT
+    exit 1
+fi
 
 # Check if the type of the crypted device is crypto_LUKS.
 type="$(blkid -o value -s TYPE ${crypted})"

--- a/part-luks-3.ks.in
+++ b/part-luks-3.ks.in
@@ -25,10 +25,15 @@ shutdown
 
 %post
 
-# Set the crypted device.
-crypted="/dev/vda2"
+# Find the LUKS device.
+crypted="$(blkid --match-token TYPE="crypto_LUKS" --output device)"
 
-# Check the PBKDF of /dev/vda2.
+if [[ $? != 0 ]] ; then
+    echo "*** couldn't find a LUKS device" > /root/RESULT
+    exit 1
+fi
+
+# Check the PBKDF of the LUKS device.
 result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "PBKDF:") print $2; }' )"
 
 if [[ "$result" != "pbkdf2" ]] ; then

--- a/part-luks-4.ks.in
+++ b/part-luks-4.ks.in
@@ -25,8 +25,13 @@ shutdown
 
 %post
 
-# Set the crypted device.
-crypted="/dev/vda2"
+# Find the LUKS device.
+crypted="$(blkid --match-token TYPE="crypto_LUKS" --output device)"
+
+if [[ $? != 0 ]] ; then
+    echo "*** couldn't find a LUKS device" > /root/RESULT
+    exit 1
+fi
 
 # Check the PBKDF.
 result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "PBKDF:") print $2; }' )"

--- a/raid-luks-3.ks.in
+++ b/raid-luks-3.ks.in
@@ -31,7 +31,7 @@ shutdown
 # Set the crypted device.
 crypted="/dev/md/root"
 
-# Check the PBKDF of /dev/vda2.
+# Check the PBKDF of the root device.
 result="$(cryptsetup luksDump ${crypted} | awk '{ if ($1 == "PBKDF:") print $2; }' )"
 
 if [[ "$result" != "pbkdf2" ]] ; then


### PR DESCRIPTION
Automatically detect the LUKS device created by Anaconda for the `/` mount point.
Using `/dev/vda2` is no longer valid, because we create an `biosboot` partition
since Fedora 37, that changes the number of expected partitions.