### PR TITLE
Ignore kernel Call Trace in log monitor (gh#768)

### DIFF
--- a/scripts/launcher/lib/log_monitor/log_handler.py
+++ b/scripts/launcher/lib/log_monitor/log_handler.py
@@ -34,8 +34,8 @@ class VirtualLogRequestHandler(LogRequestHandler):
         "CRIT kernel:Warning: Deprecated Driver is detected: team ",
 
         # Ignore a call trace during debugging.
-        # Enabled temporarily for issue gh761
-        # https://github.com/rhinstaller/kickstart-tests/issues/761
+        # Ignoring permanently for gh768.
+        # https://github.com/rhinstaller/kickstart-tests/issues/768
         "Call Trace:"
     ]
 


### PR DESCRIPTION
Usually the Call Trace is not fatal for installation but log monitor
makes all the tests in the run fail. The reports for kernel team don't
seem to be useful either.