### PR TITLE
Disable autopart-encrypted-1 temporarily on rhel8 (gh#772)

### DIFF
--- a/autopart-encrypted-1.sh
+++ b/autopart-encrypted-1.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
-TESTTYPE="autopart storage coverage"
+TESTTYPE="autopart storage coverage gh772"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -33,6 +33,7 @@ rhel8_skip_array=(
   gh576       # clearpart-4 test is flaky on all scenarios
   gh595       # proxy-cmdline failing on all scenarios
   gh670       # repo-include failing on rhel
+  gh772       # autopart-encrypted-1 failing on rhel8
 )
 
 rhel9_skip_array=(
@@ -49,6 +50,7 @@ rhel9_skip_array=(
 rhel8_daily_skip_array=(
   skip-on-rhel
   skip-on-rhel-8
+  gh772       # autopart-encrypted-1 failing on rhel8
 )
 
 _join_args_by_comma(){


### PR DESCRIPTION
Disable autopart-encrypted-1 on rhel8 until gh#772 is fixed.