### PR TITLE
Use the mountpoint column of the lsblk command

### DIFF
--- a/autopart-encrypted-1.ks.in
+++ b/autopart-encrypted-1.ks.in
@@ -30,7 +30,7 @@ if [[ $? != 0 ]] ; then
 fi
 
 # The LUKS device should be a parent of a root device.
-lsblk ${crypted} --output mountpoints | grep -x /
+lsblk ${crypted} --output mountpoint | grep -x /
 
 if [[ $? != 0 ]] ; then
     echo "*** ${crypted} doesn't contain a root device" > /root/RESULT


### PR DESCRIPTION
It looks like `lsblk` doesn't support `--output mountpoints` on RHEL 8.
Let's use the `mountpoint` column instead. The root device shouldn't be
mounted anywhere else in chroot.

Resolves: https://github.com/rhinstaller/kickstart-tests/issues/772