### PR TITLE
Disable repo-addrepo-hd-tree on rhel9 temporarily (gh#790)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -49,6 +49,7 @@ rhel9_skip_array=(
   gh670       # repo-include failing on rhel
   gh774       # autopart-luks-1 failing
   rhbz2120690 # DDF RAID not automatically assembled; likely should get fixed in 9.1
+  gh709       # repo-addrepo-hd-tree failing
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/repo-addrepo-hd-tree.sh
+++ b/repo-addrepo-hd-tree.sh
@@ -17,7 +17,7 @@
 #
 
 # FIXME: Fails on RHEL 8: "Nothing useful found for Hard drive ISO source"
-TESTTYPE="packaging repo harddrive skip-on-rhel-8"
+TESTTYPE="packaging repo harddrive skip-on-rhel-8 gh790"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Disable repo-addrepo-hd-tree on rhel9 until gh#790 is fixed.