### PR TITLE
Enable RHEL tests that require a DVD ISO

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -49,7 +49,6 @@ rhel9_skip_array=(
   gh670       # repo-include failing on rhel
   gh774       # autopart-luks-1 failing
   rhbz2120690 # DDF RAID not automatically assembled; likely should get fixed in 9.1
-  gh709       # repo-addrepo-hd-tree failing
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/fragments/platform/fedora_rawhide/section-data/server-dvd-link.ks
+++ b/fragments/platform/fedora_rawhide/section-data/server-dvd-link.ks
@@ -1,7 +1,0 @@
-# Create a variable in the pre/post section with link to a Fedora rawhide server DVD.
-# The curl tool will download this ISO and it will be processed later in the section.
-_LINK="http://ftp.tu-chemnitz.de/pub/linux/fedora/linux/development/rawhide/Server/x86_64/iso"
-ISO_LOCATION="$(curl -L $_LINK | grep -Po "Fedora-Server-dvd-x86_64-.*?.iso" | head -n 1)"
-ISO_LOCATION="${_LINK}/${ISO_LOCATION}"
-
-echo $ISO_LOCATION

--- a/fragments/platform/rhel8/section-data/server-dvd-link.ks
+++ b/fragments/platform/rhel8/section-data/server-dvd-link.ks
@@ -1,7 +1,0 @@
-# Create a variable in the pre/post section with link to a RHEL DVD.
-# The curl tool will download this ISO and it will be processed later in the section.
-_LINK=<ADD_LINK_TO_RHEL-8_ISO_HERE>
-ISO_LOCATION="$(curl -L $_LINK | grep -Po "RHEL-8.*?-x86_64-dvd1.iso" | head -n 1)"
-ISO_LOCATION="${_LINK}/${ISO_LOCATION}"
-
-echo $ISO_LOCATION

--- a/fragments/platform/rhel9/section-data/server-dvd-link.ks
+++ b/fragments/platform/rhel9/section-data/server-dvd-link.ks
@@ -1,7 +1,0 @@
-# Create a variable in the pre/post section with link to a RHEL DVD.
-# The curl tool will download this ISO and it will be processed later in the section.
-_LINK=<ADD_LINK_TO_RHEL-9_ISO_HERE>
-ISO_LOCATION="$(curl -L $_LINK | grep -Po "RHEL-9.*?-x86_64-dvd1.iso" | head -n 1)"
-ISO_LOCATION="${_LINK}/${ISO_LOCATION}"
-
-echo $ISO_LOCATION

--- a/harddrive-install-tree-relative.ks.in
+++ b/harddrive-install-tree-relative.ks.in
@@ -28,7 +28,7 @@ harddrive --partition=/dev/vdb --dir=repo/
 
 %ksappend payload/default_packages.ks
 
-%pre
+%pre --erroronfail
 # Include helpful functions.
 @KSINCLUDE@ pre-lib-harddrive.sh
 

--- a/harddrive-install-tree-relative.ks.in
+++ b/harddrive-install-tree-relative.ks.in
@@ -32,8 +32,8 @@ harddrive --partition=/dev/vdb --dir=repo/
 # Include helpful functions.
 @KSINCLUDE@ pre-lib-harddrive.sh
 
-# This will add ISO_LOCATION with link to an ISO
-%ksappend section-data/server-dvd-link.ks
+# Where is the ISO that we want to download?
+ISO_LOCATION="@KSTEST_DVD_ISO_URL@"
 
 # Where we want to download the content of the ISO?
 DISK="/dev/vdb"

--- a/harddrive-install-tree-relative.sh
+++ b/harddrive-install-tree-relative.sh
@@ -17,9 +17,7 @@
 #
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 
-# FIXME: fails on RHEL 8:
-# SourceSetupError: Nothing useful found for Hard drive ISO source at partition=/dev/sdb directory=/repo/
-TESTTYPE="packaging skip-on-rhel"
+TESTTYPE="packaging"
 
 . ${KSTESTDIR}/harddrive-install-tree.sh
 

--- a/harddrive-install-tree.ks.in
+++ b/harddrive-install-tree.ks.in
@@ -25,7 +25,7 @@ harddrive --partition=/dev/vdb --dir=/repo/
 
 %ksappend payload/default_packages.ks
 
-%pre
+%pre --erroronfail
 # Include helpful functions.
 @KSINCLUDE@ pre-lib-harddrive.sh
 

--- a/harddrive-install-tree.ks.in
+++ b/harddrive-install-tree.ks.in
@@ -29,8 +29,8 @@ harddrive --partition=/dev/vdb --dir=/repo/
 # Include helpful functions.
 @KSINCLUDE@ pre-lib-harddrive.sh
 
-# This will add ISO_LOCATION with link to an ISO
-%ksappend section-data/server-dvd-link.ks
+# Where is the ISO that we want to download?
+ISO_LOCATION="@KSTEST_DVD_ISO_URL@"
 
 # Where we want to download the content of the ISO?
 DISK="/dev/vdb"

--- a/harddrive-install-tree.sh
+++ b/harddrive-install-tree.sh
@@ -17,9 +17,7 @@
 #
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 
-# FIXME: fails on RHEL 8:
-# SourceSetupError: Nothing useful found for Hard drive ISO source at partition=/dev/sdb directory=/repo/
-TESTTYPE=${TESTTYPE:-"packaging skip-on-rhel"}
+TESTTYPE=${TESTTYPE:-"packaging"}
 
 . ${KSTESTDIR}/functions.sh
 

--- a/harddrive-install-tree.sh
+++ b/harddrive-install-tree.sh
@@ -23,6 +23,10 @@ TESTTYPE=${TESTTYPE:-"packaging skip-on-rhel"}
 
 . ${KSTESTDIR}/functions.sh
 
+get_timeout() {
+    echo "120"
+}
+
 prepare_disks() {
     tmpdir=$1
 

--- a/harddrive-iso.ks.in
+++ b/harddrive-iso.ks.in
@@ -24,7 +24,7 @@ harddrive --partition=/dev/vdb --dir=/
 
 %ksappend payload/default_packages.ks
 
-%pre
+%pre --erroronfail
 # Include helpful functions.
 @KSINCLUDE@ pre-lib-harddrive.sh
 

--- a/harddrive-iso.ks.in
+++ b/harddrive-iso.ks.in
@@ -28,8 +28,8 @@ harddrive --partition=/dev/vdb --dir=/
 # Include helpful functions.
 @KSINCLUDE@ pre-lib-harddrive.sh
 
-# This will add ISO_LOCATION with link to an ISO
-%ksappend section-data/server-dvd-link.ks
+# Where is the ISO that we want to download?
+ISO_LOCATION="@KSTEST_DVD_ISO_URL@"
 
 # Where we want to download the ISO?
 DISK="/dev/vdb"

--- a/pre-lib-harddrive.sh
+++ b/pre-lib-harddrive.sh
@@ -1,5 +1,8 @@
 # Common functions for %pre kickstart section of hard drive tests.
 
+# Fail on errors and unassigned variables.
+set -eux
+
 # A temporary mount directory.
 MOUNT_DIR="/var/tmp/prep-mount"
 
@@ -18,7 +21,7 @@ function prepare_iso() {
     mount "${disk}" hdd-mount
 
     # Download iso to the DVD
-    curl -L "${url}" -o hdd-mount/dvd.iso
+    download_iso "${url}" "hdd-mount/dvd.iso"
 
     # Clean up
     umount hdd-mount
@@ -41,7 +44,7 @@ function prepare_tree() {
     pushd "${MOUNT_DIR}"
 
     # Mount the ISO
-    curl -L "${url}" -o source.iso
+    download_iso "${url}" "source.iso"
     mkdir iso-mount
     mount -oro source.iso iso-mount
 
@@ -58,4 +61,29 @@ function prepare_tree() {
     popd
     umount "${MOUNT_DIR}"
     rm -rf "${MOUNT_DIR}"
+}
+
+
+# Download the ISO and save it at the specified path.
+# The URL of the ISO can contain regexes in the ISO name.
+# For example: http://my-server/Fedora-.*?.iso
+function download_iso() {
+    local url_pattern="$1"
+    local output_path="$2"
+
+    local iso_pattern=""
+    iso_pattern="$(basename "${url_pattern}")"
+
+    local iso_location=""
+    iso_location="$(dirname "${url_pattern}")"
+
+    local iso_name=""
+    iso_name="$(curl -L ${iso_location} | grep -Po "${iso_pattern}" | head -n 1)"
+
+    if [ -z "${iso_name}" ]; then
+      echo "Nothing matched \"${iso_pattern}\" at \"${iso_location}\"."
+      exit 1
+    fi
+
+    curl -L "${iso_location}/${iso_name}" -o "${output_path}"
 }

--- a/repo-addrepo-hd-iso.ks.in
+++ b/repo-addrepo-hd-iso.ks.in
@@ -25,7 +25,7 @@ url --url=EMPTY_REPO_URL
 
 %ksappend payload/default_packages.ks
 
-%pre
+%pre --erroronfail
 # Include helpful functions.
 @KSINCLUDE@ pre-lib-harddrive.sh
 

--- a/repo-addrepo-hd-iso.ks.in
+++ b/repo-addrepo-hd-iso.ks.in
@@ -29,8 +29,8 @@ url --url=EMPTY_REPO_URL
 # Include helpful functions.
 @KSINCLUDE@ pre-lib-harddrive.sh
 
-# This will add ISO_LOCATION with link to an ISO
-%ksappend section-data/server-dvd-link.ks
+# Where is the ISO that we want to download?
+ISO_LOCATION="@KSTEST_DVD_ISO_URL@"
 
 # Where we want to download the ISO?
 DISK="/dev/vdb"

--- a/repo-addrepo-hd-iso.sh
+++ b/repo-addrepo-hd-iso.sh
@@ -20,6 +20,10 @@ TESTTYPE="packaging repo harddrive"
 
 . ${KSTESTDIR}/functions.sh
 
+get_timeout() {
+    echo "120"
+}
+
 prepare_disks() {
     local tmp_dir="${1}"
     qemu-img create -q -f qcow2 ${tmpdir}/disk-a.img 10G

--- a/repo-addrepo-hd-tree.ks.in
+++ b/repo-addrepo-hd-tree.ks.in
@@ -25,7 +25,7 @@ url --url=EMPTY_REPO_URL
 
 %ksappend payload/default_packages.ks
 
-%pre
+%pre --erroronfail
 # Include helpful functions.
 @KSINCLUDE@ pre-lib-harddrive.sh
 

--- a/repo-addrepo-hd-tree.ks.in
+++ b/repo-addrepo-hd-tree.ks.in
@@ -29,8 +29,8 @@ url --url=EMPTY_REPO_URL
 # Include helpful functions.
 @KSINCLUDE@ pre-lib-harddrive.sh
 
-# This will add ISO_LOCATION with link to an ISO
-%ksappend section-data/server-dvd-link.ks
+# Where is the ISO that we want to download?
+ISO_LOCATION="@KSTEST_DVD_ISO_URL@"
 
 # Where we want to download the content of the ISO?
 DISK="/dev/vdb"

--- a/repo-addrepo-hd-tree.sh
+++ b/repo-addrepo-hd-tree.sh
@@ -16,8 +16,7 @@
 # Red Hat, Inc.
 #
 
-# FIXME: Fails on RHEL 8: "Nothing useful found for Hard drive ISO source"
-TESTTYPE="packaging repo harddrive skip-on-rhel-8 gh790"
+TESTTYPE="packaging repo harddrive"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/repo-addrepo-hd-tree.sh
+++ b/repo-addrepo-hd-tree.sh
@@ -21,6 +21,10 @@ TESTTYPE="packaging repo harddrive skip-on-rhel-8 gh790"
 
 . ${KSTESTDIR}/functions.sh
 
+get_timeout() {
+    echo "120"
+}
+
 prepare_disks() {
     local tmp_dir="${1}"
     qemu-img create -q -f qcow2 ${tmpdir}/disk-a.img 10G

--- a/repo-addrepo.sh
+++ b/repo-addrepo.sh
@@ -21,6 +21,10 @@ TESTTYPE="packaging repo"
 
 . ${KSTESTDIR}/functions.sh
 
+get_timeout() {
+    echo "120"
+}
+
 prepare() {
     local ks=$1
     local tmp_dir=$2

--- a/scripts/defaults-rhel8.sh
+++ b/scripts/defaults-rhel8.sh
@@ -3,3 +3,4 @@
 source network-device-names.cfg
 export KSTEST_URL='http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8.7/compose/BaseOS/x86_64/os/'
 export KSTEST_MODULAR_URL='http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8.7/compose/AppStream/x86_64/os/'
+export KSTEST_DVD_ISO_URL='http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8.7/compose/BaseOS/x86_64/iso/RHEL-.*?-x86_64-dvd1.iso'

--- a/scripts/defaults-rhel8.sh
+++ b/scripts/defaults-rhel8.sh
@@ -3,4 +3,3 @@
 source network-device-names.cfg
 export KSTEST_URL='http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8.7/compose/BaseOS/x86_64/os/'
 export KSTEST_MODULAR_URL='http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8.7/compose/AppStream/x86_64/os/'
-export KSTEST_FTP_URL='ftp://ftp.tu-chemnitz.de/pub/linux/fedora/linux/development/rawhide/Everything/$basearch/os/'

--- a/scripts/defaults-rhel9.sh
+++ b/scripts/defaults-rhel9.sh
@@ -3,3 +3,4 @@
 source network-device-names.cfg
 export KSTEST_URL='http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9/latest-RHEL-9.1/compose/BaseOS/x86_64/os/'
 export KSTEST_MODULAR_URL='http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9/latest-RHEL-9.1/compose/AppStream/x86_64/os/'
+export KSTEST_DVD_ISO_URL='http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9/latest-RHEL-9.1/compose/BaseOS/x86_64/iso/RHEL-.*?-x86_64-dvd1.iso'

--- a/scripts/defaults-rhel9.sh
+++ b/scripts/defaults-rhel9.sh
@@ -3,5 +3,3 @@
 source network-device-names.cfg
 export KSTEST_URL='http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9/latest-RHEL-9.1/compose/BaseOS/x86_64/os/'
 export KSTEST_MODULAR_URL='http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9/latest-RHEL-9.1/compose/AppStream/x86_64/os/'
-export KSTEST_FTP_URL='ftp://ftp.tu-chemnitz.de/pub/linux/fedora/linux/development/rawhide/Everything/$basearch/os/'
-

--- a/scripts/defaults.sh
+++ b/scripts/defaults.sh
@@ -8,7 +8,7 @@
 
 source network-device-names.cfg
 export KSTEST_URL='http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/$basearch/os/'
-export KSTEST_METALINK='https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch'
-export KSTEST_MIRRORLIST='https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch'
+export KSTEST_METALINK='http://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch'
+export KSTEST_MIRRORLIST='http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch'
 export KSTEST_MODULAR_URL='http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Modular/$basearch/os/'
 export KSTEST_FTP_URL='ftp://ftp.tu-chemnitz.de/pub/linux/fedora/linux/development/rawhide/Everything/$basearch/os/'

--- a/scripts/defaults.sh
+++ b/scripts/defaults.sh
@@ -12,3 +12,4 @@ export KSTEST_METALINK='http://mirrors.fedoraproject.org/metalink?repo=fedora-$r
 export KSTEST_MIRRORLIST='http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch'
 export KSTEST_MODULAR_URL='http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Modular/$basearch/os/'
 export KSTEST_FTP_URL='ftp://ftp.tu-chemnitz.de/pub/linux/fedora/linux/development/rawhide/Everything/$basearch/os/'
+export KSTEST_DVD_ISO_URL='http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Server/x86_64/iso/Fedora-Server-dvd-x86_64-.*?.iso'

--- a/scripts/launcher/lib/log_monitor/log_handler.py
+++ b/scripts/launcher/lib/log_monitor/log_handler.py
@@ -57,6 +57,7 @@ class VirtualLogRequestHandler(LogRequestHandler):
         "storage configuration failed:",
         "Not enough space in file systems for the current software selection.",
         "anabot.service: Failed with result 'exit-code'.",
+        "Reporting the IPMI event: 10",
     ]
 
     def iserror(self, line):


### PR DESCRIPTION
Remove the `server-dvd-link` fragment. Use the `KSTEST_DVD_ISO_URL`
variable instead. The URL of the ISO can contain regexes in the ISO name.
For example: `http://my-server/Fedora-.*?.iso`

Tests that fail to download the required DVD ISO should fail early.
Use the `--erroronfail` option to achieve that.

Set higher timeout for tests that download a DVD ISO.

**TESTING IN PROGRESS**