### PR TITLE
Separate values in KSTEST_EXTRA_BOOTOPTS by a semicolon

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -239,7 +239,8 @@ The following environment variables are currently supported:
 
 - KSTEST_EXTRA_BOOTOPTS - This variable is used in functions.sh to pass
   additional kernel command line options. For example, setting this to `inst.text`
-  enables Anaconda's text mode (instead of the default GUI).
+  enables Anaconda's text mode (instead of the default GUI). Multiple values
+  separated by semicolon can be passed.
 
 Chapter 5. Sharing common code in kickstart (.ks.in) files
 ==========================================================

--- a/containers/runner/README.md
+++ b/containers/runner/README.md
@@ -55,7 +55,7 @@ Environment variables for the container (`--env` option):
 * KSTESTS_REPOSITORY - kickstart-tests git repository to be used
 * KSTESTS_BRANCH - kickstart-tests git branch to be used
 * BOOT_ISO - name of the installer boot iso from `data/images` to be tested (default is "boot.iso")
-* KSTEST_EXTRA_BOOTOPTS - additional boot options applied to all tests
+* KSTEST_EXTRA_BOOTOPTS - additional boot options applied to all tests (semicolon separated)
 
 By default, the container runs the [run-kstest](./run-kstest) script. To get an
 interactive shell, append `bash` to the command line.

--- a/functions.sh
+++ b/functions.sh
@@ -39,7 +39,9 @@ inject_ks_to_initrd() {
     echo "true"
 }
 
-DEFAULT_BASIC_BOOTOPTS="debug=1 inst.debug ${KSTEST_EXTRA_BOOTOPTS}"
+EXTRA_BOOTOPTS=$(echo "${KSTEST_EXTRA_BOOTOPTS}" | tr ';' ' ')
+
+DEFAULT_BASIC_BOOTOPTS="debug=1 inst.debug ${EXTRA_BOOTOPTS}"
 
 DEFAULT_DRACUT_BOOTOPTS="rd.shell=0 rd.emergency=poweroff"
 


### PR DESCRIPTION
So that multiple values can be passed using --run-args launcher option, for example

--run-args '-eKSTEST_EXTRA_BOOTOPTS=inst.xtimeout=100;inst.sshd=1'
