### PR TITLE
Disable raid-ddf on rhel8 temporarrily (gh#799)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -37,6 +37,7 @@ rhel8_skip_array=(
   gh595       # proxy-cmdline failing on all scenarios
   gh670       # repo-include failing on rhel
   gh774       # autopart-luks-1 failing
+  gh799       # raid-ddf fix rhbz#2063791 is not in RHEL 8.8 yet
 )
 
 rhel9_skip_array=(

--- a/raid-ddf.sh
+++ b/raid-ddf.sh
@@ -19,7 +19,7 @@
 
 # This test covers https://bugzilla.redhat.com/show_bug.cgi?id=2063791
 
-TESTTYPE="raid storage skip-on-fedora rhbz2122327"
+TESTTYPE="raid storage skip-on-fedora rhbz2122327 gh799"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Disable raid-ddf on rhel8 until gh#799 is fixed.