### PR TITLE
Revert "[RTT-4754] Skip DDF RAID test on RHEL-9"

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -48,7 +48,6 @@ rhel9_skip_array=(
   gh641       # packages-multilib failing on systemd conflict
   gh670       # repo-include failing on rhel
   gh774       # autopart-luks-1 failing
-  rhbz2120690 # DDF RAID not automatically assembled; likely should get fixed in 9.1
   gh790       # repo-addrepo-hd-tree failing
 )
 

--- a/raid-ddf.sh
+++ b/raid-ddf.sh
@@ -19,7 +19,7 @@
 
 # This test covers https://bugzilla.redhat.com/show_bug.cgi?id=2063791
 
-TESTTYPE="raid storage skip-on-fedora rhbz2122327 rhbz2120690"
+TESTTYPE="raid storage skip-on-fedora rhbz2122327"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
This reverts commit 92b4003826e9f08eb90c0adca9aee474635b481c.