### PR TITLE
Ignore CRIT sss_cache:No domains configured (gh#807)

### DIFF
--- a/scripts/launcher/lib/log_monitor/log_handler.py
+++ b/scripts/launcher/lib/log_monitor/log_handler.py
@@ -33,6 +33,9 @@ class VirtualLogRequestHandler(LogRequestHandler):
         # Team networking is deprecated
         "CRIT kernel:Warning: Deprecated Driver is detected: team ",
 
+        # See rhbz#2133437
+        "CRIT sss_cache:No domains configured, fatal error!",
+
         # Ignore a call trace during debugging.
         # Ignoring permanently for gh768.
         # https://github.com/rhinstaller/kickstart-tests/issues/768


### PR DESCRIPTION
Ignore the CRIT message in log monitor temporarily. Reported in rhbz#2133437 for further investigation.