### PR TITLE
daily scenario: increase XOrg timeout by 40 seconds (gh#795)

### DIFF
--- a/.github/workflows/scenarios-permian.yml
+++ b/.github/workflows/scenarios-permian.yml
@@ -151,6 +151,8 @@ jobs:
           timeout=${LAUNCHER_TIMEOUT_MINUTES}m
           retry_on_failure=True
           kstest_local_repo=${{ github.workspace }}/kickstart-tests
+          # gh#795
+          added_boot_options=inst.xtimeout=100
           [library]
           directPath=${{ github.workspace }}/kickstart-tests/testlib
           EOF


### PR DESCRIPTION
Address the kickstart-test issue gh#795 to reduce rising number of flakes on XOrg timeout.