### PR TITLE
Disable groups-and-envs-2 on daily-iso temporarrily (gh#812)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -28,6 +28,7 @@ daily_iso_skip_array=(
   gh774       # autopart-luks-1 failing
   gh777       # raid-1 failing
   rhbz2122327 # installation with an existing DDF RAID device fails
+  gh812       # groups-and-envs-2 needs package check update
 )
 
 rhel8_skip_array=(

--- a/groups-and-envs-2.sh
+++ b/groups-and-envs-2.sh
@@ -18,7 +18,7 @@
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
 # FIXME: times out on rhel8
-TESTTYPE="packaging skip-on-rhel"
+TESTTYPE="packaging skip-on-rhel gh812"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Disable groups-and-envs-2 on daily-iso until gh#812 is fixed.