### PR TITLE
Disable rootpw-allow-ssh on rhel9 temporarrily (gh#815)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -51,6 +51,7 @@ rhel9_skip_array=(
   gh670       # repo-include failing on rhel
   gh774       # autopart-luks-1 failing
   gh790       # repo-addrepo-hd-tree failing
+  gh815       # rootpw-allow-ssh failing
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/rootpw-allow-ssh.sh
+++ b/rootpw-allow-ssh.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE="users skip-on-rhel-8"
+TESTTYPE="users skip-on-rhel-8 gh815"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Disable rootpw-allow-ssh on rhel9 until gh#815 is fixed.