### PR TITLE
permian: fix tclib query generating for list of tests

### DIFF
--- a/scripts/generate-permian-query.py
+++ b/scripts/generate-permian-query.py
@@ -24,7 +24,11 @@ if __name__ == "__main__":
 
     conditions = []
     if args.tests:
-        conditions = ['tc.name == "{}"'.format(test) for test in args.tests]
+        conditions = [
+            "("
+            + " or ".join(['tc.name == "{}"'.format(test) for test in args.tests])
+            + ")"
+        ]
     else:
         if args.testtype:
             conditions.extend(['"{}" in tc.tags'.format(args.testtype), '"knownfailure" not in tc.tags'])


### PR DESCRIPTION
I wrongly considered test case name matches (tc.name = 'name') as conditions to be aggregated in the final query conjunction while actually they should make a single condition composed of test case names disjunction (making possibly part of the final conjunction combined also with other conditions but not as a part of this PR as I don't want to change API in this PR).

Example of the error: https://github.com/rhinstaller/anaconda/actions/runs/3319030891 generating
```
'tc.name == "network-autoconnections-dhcpall-httpks" and tc.name == "ifname-httpks" and tc.name == "network-device-mac-pre"'
```
where the correct query should be
```
'(tc.name == "network-autoconnections-dhcpall-httpks" or tc.name == "ifname-httpks" or tc.name == "network-device-mac-pre")'
```