### PR TITLE
Revert "Disable raid-ddf on rhel8 temporarrily (gh#799)"

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -38,7 +38,6 @@ rhel8_skip_array=(
   gh595       # proxy-cmdline failing on all scenarios
   gh670       # repo-include failing on rhel
   gh774       # autopart-luks-1 failing
-  gh799       # raid-ddf fix rhbz#2063791 is not in RHEL 8.8 yet
   rhbz1940919 # bond-ks-initramfs should be fixed in RHEL 8.8
 )
 

--- a/raid-ddf.sh
+++ b/raid-ddf.sh
@@ -19,7 +19,7 @@
 
 # This test covers https://bugzilla.redhat.com/show_bug.cgi?id=2063791
 
-TESTTYPE="raid storage skip-on-fedora rhbz2122327 gh799"
+TESTTYPE="raid storage skip-on-fedora rhbz2122327"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
This reverts commit 34731ea8ca8ab981683cbc67ad25e7873fa83e62.