### PR TITLE
Revert "Disable rootpw-allow-ssh on rhel9 temporarrily (gh#815)"

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -52,7 +52,6 @@ rhel9_skip_array=(
   gh670       # repo-include failing on rhel
   gh774       # autopart-luks-1 failing
   gh790       # repo-addrepo-hd-tree failing
-  gh815       # rootpw-allow-ssh failing
   rhbz2133053 # bond-ks-initramfs should be fixed in RHEL 9.2
 )
 

--- a/rootpw-allow-ssh.sh
+++ b/rootpw-allow-ssh.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-TESTTYPE="users skip-on-rhel-8 gh815"
+TESTTYPE="users skip-on-rhel-8"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
This reverts commit a17fe4f1bbc7c0c2693a8d6215b9a6659c9767fe.

The issue seems to be gone.  I am not able to reproduce it - it seemed that in one case the .hushlogin did not have effect to insights-client's /etc/motd.d/insights-client which produces the message causing the test failure but I am not 100% sure and I was not able to reproduce it again.