### PR TITLE
Disable 2 network tests temporarily for rhel8 (rhbz#2127057)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -38,6 +38,7 @@ rhel8_skip_array=(
   gh670       # repo-include failing on rhel
   gh774       # autopart-luks-1 failing
   rhbz1940919 # bond-ks-initramfs should be fixed in RHEL 8.8
+  rhbz2127057 # 2 network tests need the BZ fix in RHEL 8.8
 )
 
 rhel9_skip_array=(

--- a/network-addr-gen-mode-dhcpall.sh
+++ b/network-addr-gen-mode-dhcpall.sh
@@ -22,7 +22,7 @@
 # The latter is causing that kickstart network commands are not applied (ifcfg
 # files created) in initramfs.
 
-TESTTYPE="network"
+TESTTYPE="network rhbz2127057"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/network-autoconnections-dhcpall-httpks.sh
+++ b/network-autoconnections-dhcpall-httpks.sh
@@ -22,7 +22,7 @@
 # The latter is causing that kickstart network commands are not applied (ifcfg
 # files created) in initramfs.
 
-TESTTYPE="network"
+TESTTYPE="network rhbz2127057"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Disable 2 network tests on rhel8 until rhbz#2127057 is fixed.