### PR TITLE
Update default RHEL repositories to 8.8 and 9.2

### DIFF
--- a/scripts/defaults-rhel8.sh
+++ b/scripts/defaults-rhel8.sh
@@ -1,6 +1,6 @@
 # Default settings for testing RHEL 8. This requires being inside the Red Hat VPN.
 
 source network-device-names.cfg
-export KSTEST_URL='http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8.7/compose/BaseOS/x86_64/os/'
-export KSTEST_MODULAR_URL='http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8.7/compose/AppStream/x86_64/os/'
+export KSTEST_URL='http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8.8.0/compose/BaseOS/x86_64/os/'
+export KSTEST_MODULAR_URL='http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8.8.0/compose/AppStream/x86_64/os/'
 export KSTEST_FTP_URL='ftp://ftp.tu-chemnitz.de/pub/linux/fedora/linux/development/rawhide/Everything/$basearch/os/'

--- a/scripts/defaults-rhel9.sh
+++ b/scripts/defaults-rhel9.sh
@@ -1,7 +1,7 @@
 # Default settings for testing RHEL 9. This requires being inside the Red Hat VPN.
 
 source network-device-names.cfg
-export KSTEST_URL='http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9/latest-RHEL-9.1/compose/BaseOS/x86_64/os/'
-export KSTEST_MODULAR_URL='http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9/latest-RHEL-9.1/compose/AppStream/x86_64/os/'
+export KSTEST_URL='http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9/latest-RHEL-9.2.0/compose/BaseOS/x86_64/os/'
+export KSTEST_MODULAR_URL='http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9/latest-RHEL-9.2.0/compose/AppStream/x86_64/os/'
 export KSTEST_FTP_URL='ftp://ftp.tu-chemnitz.de/pub/linux/fedora/linux/development/rawhide/Everything/$basearch/os/'
 


### PR DESCRIPTION
This is for local runs using rhel isos and --platform rhelX.
For daily workflow it has been changed here: https://github.com/rhinstaller/kickstart-tests/pull/796