### PR TITLE
Update network tests counting NM connections for new NM version (#215…

### DIFF
--- a/bond-ks-initramfs.ks.in
+++ b/bond-ks-initramfs.ks.in
@@ -33,7 +33,8 @@ else
     check_config_exists bond0 no
     check_config_exists @KSTEST_NETDEV1@ no
     check_config_exists @KSTEST_NETDEV2@ no
-    check_number_of_connections 3
+    # includes "lo" connection
+    check_number_of_connections 4
 fi
 
 check_device_connected bond0 yes

--- a/network-autoconnections-dhcpall-httpks.ks.in
+++ b/network-autoconnections-dhcpall-httpks.ks.in
@@ -41,7 +41,8 @@ check_device_connected @KSTEST_NETDEV3@ yes
 if [ $(is_rhel8 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@) == "yes" ]; then
     check_number_of_connections 2
 else
-    check_number_of_connections 1
+    # includes "lo" connection
+    check_number_of_connections 2
 fi
 
 check_connection_device "Wired Connection" @KSTEST_NETDEV1@
@@ -74,6 +75,7 @@ check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@ @KSTEST_NETDEV3@
 %post
 
 @KSINCLUDE@ post-lib-network.sh
+@KSINCLUDE@ scripts-lib.sh
 
 check_device_config_value @KSTEST_NETDEV1@ ONBOOT yes connection autoconnect __NONE
 check_device_config_value @KSTEST_NETDEV2@ ONBOOT yes connection autoconnect __NONE
@@ -87,7 +89,13 @@ check_device_connected @KSTEST_NETDEV3@ yes
 check_connection_device "Wired Connection" @KSTEST_NETDEV2@
 check_connection_device @KSTEST_NETDEV2@
 
-check_number_of_connections 4
+if [ $(is_rhel8 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@) == "yes" ]; then
+    check_number_of_connections 4
+else
+    # includes "lo" connection
+    check_number_of_connections 5
+fi
+
 check_connection_device "Wired Connection" @KSTEST_NETDEV1@
 check_connection_device @KSTEST_NETDEV1@
 check_connection_device "Wired Connection" @KSTEST_NETDEV3@

--- a/network-autoconnections-httpks.ks.in
+++ b/network-autoconnections-httpks.ks.in
@@ -56,12 +56,14 @@ if [[ $nm_has_autoconnections_off -eq 0 ]]; then
     if [ $(is_rhel8 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@) == "yes" ]; then
         check_number_of_connections 2
     else
-        check_number_of_connections 1
+        # includes "lo" connection
+        check_number_of_connections 2
     fi
     check_device_connected @KSTEST_NETDEV3@ no
     check_device_connected @KSTEST_NETDEV2@ no
 else
-    check_number_of_connections 3
+    # includes "lo" connection
+    check_number_of_connections 4
     check_device_connected @KSTEST_NETDEV3@ yes
     # This is no more prevented by ifcfg file created in initramfs
     check_device_connected @KSTEST_NETDEV2@ yes
@@ -91,6 +93,7 @@ check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@ @KSTEST_NETDEV3@
 %post
 
 @KSINCLUDE@ post-lib-network.sh
+@KSINCLUDE@ scripts-lib.sh
 
 check_device_config_value @KSTEST_NETDEV1@ ONBOOT yes connection autoconnect __NONE
 check_device_config_value @KSTEST_NETDEV2@ ONBOOT yes connection autoconnect __NONE
@@ -100,7 +103,12 @@ detect_nm_has_autoconnections_off
 nm_has_autoconnections_off=$?
 if [[ $nm_has_autoconnections_off -eq 0 ]]; then
     check_device_config_value @KSTEST_NETDEV3@ ONBOOT no connection autoconnect false
-    check_number_of_connections 3
+    if [ $(is_rhel8 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@) == "yes" ]; then
+        check_number_of_connections 3
+    else
+        # includes "lo" connection
+        check_number_of_connections 4
+    fi
     check_device_connected @KSTEST_NETDEV1@ yes
     check_device_connected @KSTEST_NETDEV2@ no
     check_device_connected @KSTEST_NETDEV3@ no
@@ -109,7 +117,8 @@ if [[ $nm_has_autoconnections_off -eq 0 ]]; then
     check_connection_device @KSTEST_NETDEV2@
 else
     check_device_config_value @KSTEST_NETDEV3@ ONBOOT yes connection autoconnect __NONE
-    check_number_of_connections 4
+    # includes "lo" connection
+    check_number_of_connections 5
     check_device_connected @KSTEST_NETDEV1@ yes
     # This is no more prevented by ifcfg file created in initramfs
     check_device_connected @KSTEST_NETDEV2@ yes


### PR DESCRIPTION
…0773)

The loopback device is now managed with lo connection created in initramfs.

Tracked in gh#835.