### PR TITLE
Revert "Ignore CRIT sss_cache:No domains configured temporarily (gh#8…

### DIFF
--- a/scripts/launcher/lib/log_monitor/log_handler.py
+++ b/scripts/launcher/lib/log_monitor/log_handler.py
@@ -33,9 +33,6 @@ class VirtualLogRequestHandler(LogRequestHandler):
         # Team networking is deprecated
         "CRIT kernel:Warning: Deprecated Driver is detected: team ",
 
-        # See rhbz#2133437
-        "CRIT sss_cache:No domains configured, fatal error!",
-
         # Ignore a call trace during debugging.
         # Ignoring permanently for gh768.
         # https://github.com/rhinstaller/kickstart-tests/issues/768


### PR DESCRIPTION
…07)"

This reverts commit f143a13c31d78aca40b97665916bab60b78c5bf4.