### PR TITLE
Disable tests without appstream on rhel8 temporarily (gh#841)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -38,6 +38,7 @@ rhel8_skip_array=(
   gh670       # repo-include failing on rhel
   gh774       # autopart-luks-1 failing
   gh830       # packages-weakdeps failing
+  gh841       # 4 tests disabled due to dnf rhbz#2152846
 )
 
 rhel9_skip_array=(

--- a/proxy-auth.sh
+++ b/proxy-auth.sh
@@ -17,7 +17,7 @@
 #
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 
-TESTTYPE="method proxy gh680"
+TESTTYPE="method proxy gh680 gh841"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/functions-proxy.sh

--- a/proxy-kickstart.sh
+++ b/proxy-kickstart.sh
@@ -18,7 +18,7 @@
 # Red Hat Author(s): David Shea <dshea@redhat.com>
 #                    Jiri Konecny <jkonecny@redhat.com>
 
-TESTTYPE="method proxy gh680"
+TESTTYPE="method proxy gh680 gh841"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/functions-proxy.sh

--- a/repo-baseurl.sh
+++ b/repo-baseurl.sh
@@ -16,7 +16,7 @@
 # Red Hat, Inc.
 #
 
-TESTTYPE="packaging repo"
+TESTTYPE="packaging repo gh841"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/url-baseurl.sh
+++ b/url-baseurl.sh
@@ -16,6 +16,6 @@
 # Red Hat, Inc.
 #
 
-TESTTYPE="packaging url"
+TESTTYPE="packaging url gh841"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Disable tests without appstream repo on rhel8 until gh#841 / rhbz#2152846 is fixed.