### PR TITLE
Disable shellcheck SC2034 for TESTTYPE definition (gh#853)

### DIFF
--- a/anabot-1.sh
+++ b/anabot-1.sh
@@ -15,6 +15,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="ui anabot skip-on-rhel-8 knownfailure"
 
 . ${KSTESTDIR}/functions.sh

--- a/anaconda-conf.sh
+++ b/anaconda-conf.sh
@@ -15,6 +15,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="anaconda"
 
 . ${KSTESTDIR}/functions.sh

--- a/anaconda-modules.sh
+++ b/anaconda-modules.sh
@@ -15,6 +15,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="anaconda"
 
 . ${KSTESTDIR}/functions.sh

--- a/authconfig.sh
+++ b/authconfig.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="security skip-on-fedora"
 
 . ${KSTESTDIR}/functions.sh

--- a/authselect-not-set.sh
+++ b/authselect-not-set.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="security gh640"
 
 . ${KSTESTDIR}/functions.sh

--- a/authselect.sh
+++ b/authselect.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="security"
 
 . ${KSTESTDIR}/functions.sh

--- a/autopart-encrypted-1.sh
+++ b/autopart-encrypted-1.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="autopart storage coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/autopart-encrypted-2.sh
+++ b/autopart-encrypted-2.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="autopart storage"
 
 . ${KSTESTDIR}/functions.sh

--- a/autopart-encrypted-3.sh
+++ b/autopart-encrypted-3.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="autopart storage"
 
 . ${KSTESTDIR}/functions.sh

--- a/autopart-fstype.sh
+++ b/autopart-fstype.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="autopart storage"
 
 

--- a/autopart-luks-1.sh
+++ b/autopart-luks-1.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="autopart storage luks gh774"
 
 . ${KSTESTDIR}/functions.sh

--- a/autopart-luks-2.sh
+++ b/autopart-luks-2.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="autopart storage luks"
 
 . ${KSTESTDIR}/functions.sh

--- a/autopart-luks-3.sh
+++ b/autopart-luks-3.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="autopart storage luks"
 
 . ${KSTESTDIR}/functions.sh

--- a/autopart-luks-4.sh
+++ b/autopart-luks-4.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="autopart storage luks"
 
 . ${KSTESTDIR}/functions.sh

--- a/autopart-luks-5.sh
+++ b/autopart-luks-5.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="autopart storage luks"
 
 . ${KSTESTDIR}/functions.sh

--- a/autopart-nohome.sh
+++ b/autopart-nohome.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="autopart storage"
 
 . ${KSTESTDIR}/functions.sh

--- a/basic-ftp.sh
+++ b/basic-ftp.sh
@@ -18,6 +18,8 @@
 #
 # Red Hat Author(s): David Shea <dshea@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="method skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/basic-ostree.sh
+++ b/basic-ostree.sh
@@ -19,6 +19,8 @@
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
 #TESTTYPE="method"
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="knownfailure"
 
 . ${KSTESTDIR}/functions.sh

--- a/bindtomac-bond-vlan-httpks.sh
+++ b/bindtomac-bond-vlan-httpks.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/bond-vlan-httpks.sh

--- a/bindtomac-bond2-httpks.sh
+++ b/bindtomac-bond2-httpks.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/bond2-httpks.sh

--- a/bindtomac-bond2-pre.sh
+++ b/bindtomac-bond2-pre.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/bond2-pre.sh

--- a/bindtomac-bridge-2devs-httpks.sh
+++ b/bindtomac-bridge-2devs-httpks.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/bridge-2devs-httpks.sh

--- a/bindtomac-bridge-2devs-pre.sh
+++ b/bindtomac-bridge-2devs-pre.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/bridge-2devs-pre.sh

--- a/bindtomac-bridge-httpks.sh
+++ b/bindtomac-bridge-httpks.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/bridge-httpks.sh

--- a/bindtomac-bridge-no-bootopts-net.sh
+++ b/bindtomac-bridge-no-bootopts-net.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="knownfailure network"
 
 . ${KSTESTDIR}/bridge-no-bootopts-net.sh

--- a/bindtomac-bridged-bond-httpks.sh
+++ b/bindtomac-bridged-bond-httpks.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
 # FIXME: https://github.com/rhinstaller/kickstart-tests/issues/447
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network skip-on-rhel-8"
 
 . ${KSTESTDIR}/bridged-bond-httpks.sh

--- a/bindtomac-ifname-httpks.sh
+++ b/bindtomac-ifname-httpks.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/bindtomac-network-device-default-httpks.sh
+++ b/bindtomac-network-device-default-httpks.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/network-device-default-httpks.sh

--- a/bindtomac-network-device-mac-httpks.sh
+++ b/bindtomac-network-device-mac-httpks.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/bindtomac-network-device-mac-pre.sh
+++ b/bindtomac-network-device-mac-pre.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/bindtomac-network-device-mac.sh
+++ b/bindtomac-network-device-mac.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/bindtomac-network-static-2-httpks.sh
+++ b/bindtomac-network-static-2-httpks.sh
@@ -24,6 +24,8 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/network-static-2-httpks.sh

--- a/bindtomac-network-static-to-dhcp-pre-single.sh
+++ b/bindtomac-network-static-to-dhcp-pre-single.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/network-static-to-dhcp-pre-single.sh

--- a/bindtomac-onboot-activate-httpks.sh
+++ b/bindtomac-onboot-activate-httpks.sh
@@ -22,6 +22,8 @@
 # The latter is causing that kickstart network commands are not applied (ifcfg
 # files created) in initramfs.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/onboot-activate-httpks.sh

--- a/bindtomac-onboot-bootopts-pre.sh
+++ b/bindtomac-onboot-bootopts-pre.sh
@@ -24,6 +24,8 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/onboot-bootopts-pre.sh

--- a/bindtomac-team-httpks.sh
+++ b/bindtomac-team-httpks.sh
@@ -24,6 +24,8 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/team-httpks.sh

--- a/bindtomac-team-pre.sh
+++ b/bindtomac-team-pre.sh
@@ -24,6 +24,8 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/team-pre.sh

--- a/bond-ks-initramfs.sh
+++ b/bond-ks-initramfs.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE=${TESTTYPE:-"network"}
 
 . ${KSTESTDIR}/functions.sh

--- a/bond-vlan-httpks.sh
+++ b/bond-vlan-httpks.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE=${TESTTYPE:-"network"}
 
 . ${KSTESTDIR}/functions.sh

--- a/bond-vlan-pre.sh
+++ b/bond-vlan-pre.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
 # Upstream support was added in https://bugzilla.redhat.com/show_bug.cgi?id=1879480
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network skip-on-rhel"
 
 . ${KSTESTDIR}/bond-vlan-httpks.sh

--- a/bond2-httpks.sh
+++ b/bond2-httpks.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="${TESTTYPE:-"network"} coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/bond2-pre.sh
+++ b/bond2-pre.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="${TESTTYPE:-"network"} coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/bootloader-1.sh
+++ b/bootloader-1.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="bootloader storage coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/bootloader-2.sh
+++ b/bootloader-2.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="bootloader storage"
 
 . ${KSTESTDIR}/functions.sh

--- a/bootloader-3.sh
+++ b/bootloader-3.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="bootloader storage"
 
 . ${KSTESTDIR}/functions.sh

--- a/bootloader-4.sh
+++ b/bootloader-4.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="bootloader storage"
 
 . ${KSTESTDIR}/functions.sh

--- a/bootloader-5.sh
+++ b/bootloader-5.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="bootloader storage"
 
 . ${KSTESTDIR}/functions.sh

--- a/bridge-2devs-httpks.sh
+++ b/bridge-2devs-httpks.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE=${TESTTYPE:-"network"}
 
 . ${KSTESTDIR}/functions.sh

--- a/bridge-2devs-pre.sh
+++ b/bridge-2devs-pre.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE=${TESTTYPE:-"network"}
 
 . ${KSTESTDIR}/bridge-2devs.sh

--- a/bridge-2devs.sh
+++ b/bridge-2devs.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE=${TESTTYPE:-"network"}
 
 . ${KSTESTDIR}/functions.sh

--- a/bridge-httpks.sh
+++ b/bridge-httpks.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE=${TESTTYPE:-"network"}
 
 . ${KSTESTDIR}/functions.sh

--- a/bridge-no-bootopts-net.sh
+++ b/bridge-no-bootopts-net.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE=${TESTTYPE:-"network"}
 
 . ${KSTESTDIR}/functions.sh

--- a/bridged-bond-httpks.sh
+++ b/bridged-bond-httpks.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
 # FIXME: https://github.com/rhinstaller/kickstart-tests/issues/447
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE=${TESTTYPE:-"network skip-on-rhel-8"}
 
 . ${KSTESTDIR}/functions.sh

--- a/bridged-bond-pre.sh
+++ b/bridged-bond-pre.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
 # Upstream support was added in https://github.com/rhinstaller/anaconda/pull/2861
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/btrfs-1.sh
+++ b/btrfs-1.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="btrfs storage skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/btrfs-2.sh
+++ b/btrfs-2.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="btrfs storage skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/check_for_disabled_modules.sh
+++ b/check_for_disabled_modules.sh
@@ -16,6 +16,8 @@
 #
 # mlewando@redhat.com
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="ui anaconda addons"
 
 . ${KSTESTDIR}/functions.sh

--- a/clearpart-1.sh
+++ b/clearpart-1.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="clearpart storage"
 
 . ${KSTESTDIR}/functions.sh

--- a/clearpart-2.sh
+++ b/clearpart-2.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="clearpart storage"
 
 . ${KSTESTDIR}/functions.sh

--- a/clearpart-3.sh
+++ b/clearpart-3.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="clearpart storage coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/clearpart-4.sh
+++ b/clearpart-4.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="clearpart storage gh576"
 
 . ${KSTESTDIR}/functions.sh

--- a/container.sh
+++ b/container.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="bootloader packaging coverage skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/default-desktop.sh
+++ b/default-desktop.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="services coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/default-fstype.sh
+++ b/default-fstype.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="storage"
 
 . ${KSTESTDIR}/functions.sh

--- a/default-menu-auto-hide-fedora.sh
+++ b/default-menu-auto-hide-fedora.sh
@@ -19,6 +19,8 @@
 
 # This is duplicate test of RHEL test which is changing the configuration
 # option on Fedora to be able to test the functionality also there.
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="bootloader skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/default-menu-auto-hide-rhel.sh
+++ b/default-menu-auto-hide-rhel.sh
@@ -20,6 +20,8 @@
 # We have this feature on Fedora, however, only for Workstation which is not
 # used by KS tests. There is another test which works for Fedora only and
 # changing configuration file.
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="bootloader skip-on-rhel-8 skip-on-fedora"
 
 . ${KSTESTDIR}/functions.sh

--- a/default-systemd-target-gui-graphical-provides.sh
+++ b/default-systemd-target-gui-graphical-provides.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="services"
 
 . ${KSTESTDIR}/functions.sh

--- a/default-systemd-target-gui.sh
+++ b/default-systemd-target-gui.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="services"
 
 . ${KSTESTDIR}/functions.sh

--- a/default-systemd-target-skipx.sh
+++ b/default-systemd-target-skipx.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="services"
 
 . ${KSTESTDIR}/functions.sh

--- a/default-systemd-target-startxonboot.sh
+++ b/default-systemd-target-startxonboot.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="services"
 
 . ${KSTESTDIR}/functions.sh

--- a/default-systemd-target-tui-graphical-provides.sh
+++ b/default-systemd-target-tui-graphical-provides.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="services"
 
 . ${KSTESTDIR}/functions.sh

--- a/default-systemd-target-tui.sh
+++ b/default-systemd-target-tui.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="services coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/default-systemd-target-vnc-graphical-provides.sh
+++ b/default-systemd-target-vnc-graphical-provides.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="services"
 
 . ${KSTESTDIR}/functions.sh

--- a/default-systemd-target-vnc.sh
+++ b/default-systemd-target-vnc.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="services"
 
 . ${KSTESTDIR}/functions.sh

--- a/deprecated-rhel9-part1.sh
+++ b/deprecated-rhel9-part1.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Zdenek Veleba <zveleba@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="deprecated skip-on-rhel-8 skip-on-fedora"
 
 . ${KSTESTDIR}/functions.sh

--- a/deprecated-rhel9-part2.sh
+++ b/deprecated-rhel9-part2.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Zdenek Veleba <zveleba@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="deprecated skip-on-rhel-8 skip-on-fedora"
 
 . ${KSTESTDIR}/functions.sh

--- a/disklabel-default.sh
+++ b/disklabel-default.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
 # The GPT partitioning is enabled by default since Fedora 37.
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="storage disklabel skip-on-rhel-8 skip-on-rhel-9"
 
 . ${KSTESTDIR}/functions.sh

--- a/disklabel-gpt.sh
+++ b/disklabel-gpt.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
 # The inst.disklabel boot option is supported since Fedora 37.
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="storage disklabel skip-on-rhel-8 skip-on-rhel-9"
 
 . ${KSTESTDIR}/functions.sh

--- a/disklabel-mbr.sh
+++ b/disklabel-mbr.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
 # The inst.disklabel boot option is supported since Fedora 37.
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="storage disklabel skip-on-rhel-8 skip-on-rhel-9"
 
 . ${KSTESTDIR}/functions.sh

--- a/dns.sh
+++ b/dns.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/dracut-visible-warnings.sh
+++ b/dracut-visible-warnings.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="dracut skip-on-rhel-8"
 
 . ${KSTESTDIR}/functions.sh

--- a/driverdisk-disk-kargs.sh
+++ b/driverdisk-disk-kargs.sh
@@ -15,6 +15,8 @@
 #
 # Author: Will Woods <wwoods@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="driverdisk"
 
 . ${KSTESTDIR}/functions.sh

--- a/driverdisk-disk.sh
+++ b/driverdisk-disk.sh
@@ -15,6 +15,8 @@
 #
 # Author: Will Woods <wwoods@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="driverdisk"
 
 . ${KSTESTDIR}/functions.sh

--- a/encrypt-device.sh
+++ b/encrypt-device.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Anne Mulhern <amulhern@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="storage"
 
 . ${KSTESTDIR}/functions.sh

--- a/encrypt-swap.sh
+++ b/encrypt-swap.sh
@@ -15,6 +15,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="storage"
 
 . ${KSTESTDIR}/functions.sh

--- a/escrow-cert.sh
+++ b/escrow-cert.sh
@@ -18,6 +18,8 @@
 #
 # Red Hat Author(s): David Shea <dshea@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="storage"
 
 . ${KSTESTDIR}/functions.sh

--- a/fedora-live-image-build.sh
+++ b/fedora-live-image-build.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging skip-on-rhel gh740"
 
 . ${KSTESTDIR}/functions.sh

--- a/firewall-disable-with-options.sh
+++ b/firewall-disable-with-options.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network firewall"
 
 . ${KSTESTDIR}/functions.sh

--- a/firewall-disable.sh
+++ b/firewall-disable.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network firewall"
 
 . ${KSTESTDIR}/functions.sh

--- a/firewall-use-system-defaults-ignore-options.sh
+++ b/firewall-use-system-defaults-ignore-options.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network firewall"
 
 . ${KSTESTDIR}/functions.sh

--- a/firewall-use-system-defaults.sh
+++ b/firewall-use-system-defaults.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network firewall"
 
 . ${KSTESTDIR}/functions.sh

--- a/firewall.sh
+++ b/firewall.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 #                    Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network firewall coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/geolocation-off-by-default-with-ks.sh
+++ b/geolocation-off-by-default-with-ks.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network logs"
 
 . ${KSTESTDIR}/functions.sh

--- a/groups-and-envs-1.sh
+++ b/groups-and-envs-1.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
 # FIXME: times out on rhel8
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/groups-and-envs-2.sh
+++ b/groups-and-envs-2.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
 # FIXME: times out on rhel8
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/groups-and-envs-3.sh
+++ b/groups-and-envs-3.sh
@@ -19,6 +19,8 @@
 
 # FIXME: Fails on RHEL due to nonexisting @domain-client; when dropped, fails validation on
 # "Fedora Server default environment was not installed"
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/groups-ignoremissing.sh
+++ b/groups-ignoremissing.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging"
 
 . ${KSTESTDIR}/functions.sh

--- a/harddrive-install-tree-relative.sh
+++ b/harddrive-install-tree-relative.sh
@@ -19,6 +19,8 @@
 
 # FIXME: fails on RHEL 8:
 # SourceSetupError: Nothing useful found for Hard drive ISO source at partition=/dev/sdb directory=/repo/
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging skip-on-rhel"
 
 . ${KSTESTDIR}/harddrive-install-tree.sh

--- a/harddrive-install-tree.sh
+++ b/harddrive-install-tree.sh
@@ -19,6 +19,8 @@
 
 # FIXME: fails on RHEL 8:
 # SourceSetupError: Nothing useful found for Hard drive ISO source at partition=/dev/sdb directory=/repo/
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE=${TESTTYPE:-"packaging skip-on-rhel"}
 
 . ${KSTESTDIR}/functions.sh

--- a/harddrive-iso.sh
+++ b/harddrive-iso.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE=${TESTTYPE:-"packaging"}
 
 . ${KSTESTDIR}/harddrive-install-tree.sh

--- a/hello-world.sh
+++ b/hello-world.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
 # FIXME: %pre script uses python3, which does not exist in RHEL8 env; times out there
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="addon coverage skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/hmc.sh
+++ b/hmc.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="manual payload"
 
 . ${KSTESTDIR}/functions.sh

--- a/hostname-bootopts.sh
+++ b/hostname-bootopts.sh
@@ -24,6 +24,8 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/hostname.sh
+++ b/hostname.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/https-repo.sh
+++ b/https-repo.sh
@@ -19,6 +19,8 @@
 
 # FIXME: https://download.devel.redhat.com does not have a recognized certificate
 # once there is a solution, create fragments/platform/rhel8/repos/https.ks
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="method skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/ibft.sh
+++ b/ibft.sh
@@ -24,6 +24,8 @@
 #   - just use sanboot in ipxe script:
 #     sanboot iscsi:${target_ip}:::0:${wwn}
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="knownfailure iscsi"
 
 . ${KSTESTDIR}/functions.sh

--- a/ifname-httpks.sh
+++ b/ifname-httpks.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/ignoredisk-1.sh
+++ b/ignoredisk-1.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="ignoredisk storage"
 
 . ${KSTESTDIR}/functions.sh

--- a/ignoredisk-2.sh
+++ b/ignoredisk-2.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="ignoredisk storage"
 
 . ${KSTESTDIR}/functions.sh

--- a/image-deployment-1.sh
+++ b/image-deployment-1.sh
@@ -15,6 +15,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="manual image-deployment"
 
 . ${KSTESTDIR}/functions.sh

--- a/image-deployment-2.sh
+++ b/image-deployment-2.sh
@@ -15,6 +15,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="image-deployment"
 
 . ${KSTESTDIR}/functions.sh

--- a/initial-setup-default.sh
+++ b/initial-setup-default.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="initial-setup coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/initial-setup-disable.sh
+++ b/initial-setup-disable.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="initial-setup"
 
 . ${KSTESTDIR}/functions.sh

--- a/initial-setup-enable.sh
+++ b/initial-setup-enable.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="initial-setup"
 
 . ${KSTESTDIR}/functions.sh

--- a/initial-setup-gui.sh
+++ b/initial-setup-gui.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="initial-setup"
 
 . ${KSTESTDIR}/functions.sh

--- a/initial-setup-reconfig.sh
+++ b/initial-setup-reconfig.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="initial-setup"
 
 . ${KSTESTDIR}/functions.sh

--- a/iscsi-bind.sh
+++ b/iscsi-bind.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="knownfailure iscsi"
 
 . ${KSTESTDIR}/iscsi.sh

--- a/iscsi.sh
+++ b/iscsi.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE=${TESTTYPE:-"knownfailure iscsi"}
 
 . ${KSTESTDIR}/functions.sh

--- a/keyboard-bootopt-only.sh
+++ b/keyboard-bootopt-only.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
 # On RHEL, boot option is not enough for unattended installation
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="keyboard i18n skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/keyboard-convert-vc.sh
+++ b/keyboard-convert-vc.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="keyboard i18n"
 
 . ${KSTESTDIR}/functions.sh

--- a/keyboard-convert-x-override-bootopt.sh
+++ b/keyboard-convert-x-override-bootopt.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="keyboard i18n"
 
 . ${KSTESTDIR}/functions.sh

--- a/keyboard-generic-argument.sh
+++ b/keyboard-generic-argument.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="keyboard i18n"
 
 . ${KSTESTDIR}/functions.sh

--- a/keyboard.sh
+++ b/keyboard.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="keyboard i18n coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/ks-include.sh
+++ b/ks-include.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): David Shea <dshea@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="kickstart"
 
 . ${KSTESTDIR}/functions.sh

--- a/lang.sh
+++ b/lang.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="language i18n coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/liveimg.sh
+++ b/liveimg.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
 #TESTTYPE="method"
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="knownfailure"
 
 . ${KSTESTDIR}/functions.sh

--- a/lvm-1.sh
+++ b/lvm-1.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="lvm storage coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/lvm-2.sh
+++ b/lvm-2.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="lvm storage"
 
 . ${KSTESTDIR}/functions.sh

--- a/lvm-cache-1.sh
+++ b/lvm-cache-1.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
 # blivet crashes with BlockDev.LVMError: https://bugzilla.redhat.com/show_bug.cgi?id=1886767
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="lvm storage knownfailure"
 
 . ${KSTESTDIR}/functions.sh

--- a/lvm-cache-2.sh
+++ b/lvm-cache-2.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
 # blivet crashes with BlockDev.LVMError: https://bugzilla.redhat.com/show_bug.cgi?id=1886767
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="lvm storage knownfailure"
 
 . ${KSTESTDIR}/functions.sh

--- a/lvm-luks-1.sh
+++ b/lvm-luks-1.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
 # Check the results on the running VM.
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="manual storage lvm luks"
 
 . ${KSTESTDIR}/functions.sh

--- a/lvm-luks-2.sh
+++ b/lvm-luks-2.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
 # Check the results on the running VM.
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="manual storage lvm luks"
 
 . ${KSTESTDIR}/functions.sh

--- a/lvm-luks-3.sh
+++ b/lvm-luks-3.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
 # Check the results on the running VM.
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="manual storage lvm luks"
 
 . ${KSTESTDIR}/functions.sh

--- a/lvm-luks-4.sh
+++ b/lvm-luks-4.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
 # Check the results on the running VM.
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="manual storage lvm luks"
 
 . ${KSTESTDIR}/functions.sh

--- a/lvm-raid-1.sh
+++ b/lvm-raid-1.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vratislav Podzimek <vpodzime@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="lvm storage"
 
 . ${KSTESTDIR}/functions.sh

--- a/lvm-thinp-1.sh
+++ b/lvm-thinp-1.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="lvm storage coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/lvm-thinp-2.sh
+++ b/lvm-thinp-2.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="lvm storage"
 
 . ${KSTESTDIR}/functions.sh

--- a/module-1.sh
+++ b/module-1.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging modularity skip-on-rhel gh769"
 
 . ${KSTESTDIR}/functions.sh

--- a/module-2.sh
+++ b/module-2.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging modularity skip-on-rhel gh769"
 
 . ${KSTESTDIR}/functions.sh

--- a/module-3.sh
+++ b/module-3.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging modularity skip-on-rhel gh769"
 
 . ${KSTESTDIR}/functions.sh

--- a/module-4.sh
+++ b/module-4.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging modularity skip-on-rhel gh769"
 
 . ${KSTESTDIR}/functions.sh

--- a/module-enable-one-module-multiple-streams.sh
+++ b/module-enable-one-module-multiple-streams.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="knownfailure packaging modularity skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/module-enable-one-stream-install-different-stream.sh
+++ b/module-enable-one-stream-install-different-stream.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging modularity knownfailure"
 
 . ${KSTESTDIR}/functions.sh

--- a/module-ignoremissing.sh
+++ b/module-ignoremissing.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging modularity"
 
 . ${KSTESTDIR}/functions.sh

--- a/module-install-no-stream-no-profile.sh
+++ b/module-install-no-stream-no-profile.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="knownfailure packaging modularity skip-on-rhel"
 # there are currently no modules with a default streams in Fedora
 

--- a/module-install-one-module-multiple-streams-and-profiles.sh
+++ b/module-install-one-module-multiple-streams-and-profiles.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="knownfailure packaging modularity skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/module-install-one-module-multiple-streams.sh
+++ b/module-install-one-module-multiple-streams.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="knownfailure packaging modularity skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/mountpoint-assignment-1.sh
+++ b/mountpoint-assignment-1.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="mount storage coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/mountpoint-assignment-2.sh
+++ b/mountpoint-assignment-2.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="mount storage"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-addr-gen-mode-dhcpall.sh
+++ b/network-addr-gen-mode-dhcpall.sh
@@ -22,6 +22,8 @@
 # The latter is causing that kickstart network commands are not applied (ifcfg
 # files created) in initramfs.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-addr-gen-mode.sh
+++ b/network-addr-gen-mode.sh
@@ -22,6 +22,8 @@
 # The latter is causing that kickstart network commands are not applied (ifcfg
 # files created) in initramfs.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-autoconnections-dhcpall-httpks.sh
+++ b/network-autoconnections-dhcpall-httpks.sh
@@ -22,6 +22,8 @@
 # The latter is causing that kickstart network commands are not applied (ifcfg
 # files created) in initramfs.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-autoconnections-httpks.sh
+++ b/network-autoconnections-httpks.sh
@@ -22,6 +22,8 @@
 # The latter is causing that kickstart network commands are not applied (ifcfg
 # files created) in initramfs.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-bootopts-bond-dhcp-httpks.sh
+++ b/network-bootopts-bond-dhcp-httpks.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE=${TESTTYPE:-"network"}
 
 . ${KSTESTDIR}/functions.sh

--- a/network-bootopts-bond-ks-override.sh
+++ b/network-bootopts-bond-ks-override.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE=${TESTTYPE:-"network"}
 
 . ${KSTESTDIR}/functions.sh

--- a/network-bootopts-bootif-httpks.sh
+++ b/network-bootopts-bootif-httpks.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-bootopts-bridge-dhcp-httpks.sh
+++ b/network-bootopts-bridge-dhcp-httpks.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE=${TESTTYPE:-"network"}
 
 . ${KSTESTDIR}/functions.sh

--- a/network-bootopts-noautodefault.sh
+++ b/network-bootopts-noautodefault.sh
@@ -22,6 +22,8 @@
 # The latter is causing that kickstart network commands are not applied (ifcfg
 # files created) in initramfs.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-bootopts-static-legacy-httpks.sh
+++ b/network-bootopts-static-legacy-httpks.sh
@@ -26,6 +26,8 @@
 
 # This test is relevant only for RHEL7, the legacy options are not supported
 # in Fedora (as of now).
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="knownfailure network"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-bootopts-static-mac.sh
+++ b/network-bootopts-static-mac.sh
@@ -24,6 +24,8 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-bootopts-static-unspec-bootif.sh
+++ b/network-bootopts-static-unspec-bootif.sh
@@ -24,6 +24,8 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-bootopts-static-unspec-single.sh
+++ b/network-bootopts-static-unspec-single.sh
@@ -24,6 +24,8 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-bootopts-static.sh
+++ b/network-bootopts-static.sh
@@ -24,6 +24,8 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-bootopts-team-dhcp-httpks.sh
+++ b/network-bootopts-team-dhcp-httpks.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE=${TESTTYPE:-"network"}
 
 . ${KSTESTDIR}/functions.sh

--- a/network-bootopts-vlan-static-httpks.sh
+++ b/network-bootopts-vlan-static-httpks.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE=${TESTTYPE:-"network"}
 
 . ${KSTESTDIR}/functions.sh

--- a/network-device-bootif-httpks.sh
+++ b/network-device-bootif-httpks.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-device-default-httpks.sh
+++ b/network-device-default-httpks.sh
@@ -22,6 +22,8 @@
 #      code actually ignores the command without --device specified
 #      (and no ksdevice set), so it will be applied in anaconda.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE=${TESTTYPE:-"network"}
 
 . ${KSTESTDIR}/functions.sh

--- a/network-device-default-ksdevice-httpks.sh
+++ b/network-device-default-ksdevice-httpks.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-device-default-ksdevice-pre.sh
+++ b/network-device-default-ksdevice-pre.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-device-default-pre-hostname.sh
+++ b/network-device-default-pre-hostname.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-device-default.sh
+++ b/network-device-default.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-device-mac-httpks.sh
+++ b/network-device-mac-httpks.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-device-mac-pre.sh
+++ b/network-device-mac-pre.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-device-mac.sh
+++ b/network-device-mac.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-missing-ifcfg-httpks.sh
+++ b/network-missing-ifcfg-httpks.sh
@@ -24,6 +24,8 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-noipv4-httpks.sh
+++ b/network-noipv4-httpks.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-noipv4-pre.sh
+++ b/network-noipv4-pre.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-options-pre.sh
+++ b/network-options-pre.sh
@@ -24,6 +24,8 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE=${TESTTYPE:-"network"}
 
 . ${KSTESTDIR}/functions.sh

--- a/network-prefixdevname.sh
+++ b/network-prefixdevname.sh
@@ -24,6 +24,8 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE=${TESTTYPE:-"network skip-on-fedora"}
 
 . ${KSTESTDIR}/functions.sh

--- a/network-static-2-httpks.sh
+++ b/network-static-2-httpks.sh
@@ -24,6 +24,8 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="${TESTTYPE:-"network"} coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-static-2-pre.sh
+++ b/network-static-2-pre.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-static-httpks.sh
+++ b/network-static-httpks.sh
@@ -22,6 +22,8 @@
 # The latter is causing that kickstart network commands are not applied (ifcfg
 # files created) in initramfs.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-static-to-dhcp-pre-single.sh
+++ b/network-static-to-dhcp-pre-single.sh
@@ -24,6 +24,8 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE=${TESTTYPE:-"network"}
 
 . ${KSTESTDIR}/functions.sh

--- a/network-static-to-dhcp-pre.sh
+++ b/network-static-to-dhcp-pre.sh
@@ -24,6 +24,8 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-static.sh
+++ b/network-static.sh
@@ -24,6 +24,8 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh

--- a/nfs.sh
+++ b/nfs.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): David Shea <dshea@redhat.com>
 
 # requires special setup (NFS server) which we don't have in our test environments
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="method packaging knownfailure"
 
 . ${KSTESTDIR}/functions.sh

--- a/nosave-1.sh
+++ b/nosave-1.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="logs coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/nosave-2.sh
+++ b/nosave-2.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="logs"
 
 . ${KSTESTDIR}/functions.sh

--- a/nosave-3.sh
+++ b/nosave-3.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="logs"
 
 . ${KSTESTDIR}/functions.sh

--- a/ntp-nontp-without-chrony-gui.sh
+++ b/ntp-nontp-without-chrony-gui.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="time"
 
 . ${KSTESTDIR}/functions.sh

--- a/ntp-nontp-without-chrony.sh
+++ b/ntp-nontp-without-chrony.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="time"
 
 . ${KSTESTDIR}/functions.sh

--- a/ntp-pools.sh
+++ b/ntp-pools.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
 # Fails in rhel8 with "Unknown command: timesource"
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="time coverage skip-on-rhel-8"
 
 . ${KSTESTDIR}/functions.sh

--- a/ntp-with-nontp-gui.sh
+++ b/ntp-with-nontp-gui.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="time"
 
 . ${KSTESTDIR}/functions.sh

--- a/ntp-with-nontp.sh
+++ b/ntp-with-nontp.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="time"
 
 . ${KSTESTDIR}/functions.sh

--- a/ntp-without-chrony-gui.sh
+++ b/ntp-without-chrony-gui.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="time"
 
 . ${KSTESTDIR}/functions.sh

--- a/ntp-without-chrony.sh
+++ b/ntp-without-chrony.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="time"
 
 . ${KSTESTDIR}/functions.sh

--- a/onboot-activate-httpks.sh
+++ b/onboot-activate-httpks.sh
@@ -22,6 +22,8 @@
 # The latter is causing that kickstart network commands are not applied (ifcfg
 # files created) in initramfs.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE=${TESTTYPE:-"network"}
 
 . ${KSTESTDIR}/functions.sh

--- a/onboot-activate.sh
+++ b/onboot-activate.sh
@@ -24,6 +24,8 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="network coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/onboot-bootopts-pre.sh
+++ b/onboot-bootopts-pre.sh
@@ -24,6 +24,8 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE=${TESTTYPE:-"network"}
 
 . ${KSTESTDIR}/functions.sh

--- a/packages-and-groups-1.sh
+++ b/packages-and-groups-1.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging"
 
 . ${KSTESTDIR}/functions.sh

--- a/packages-and-groups-ignoremissing.sh
+++ b/packages-and-groups-ignoremissing.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/packages-default.sh
+++ b/packages-default.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/packages-excludedocs.sh
+++ b/packages-excludedocs.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging"
 
 . ${KSTESTDIR}/functions.sh

--- a/packages-ignorebroken.sh
+++ b/packages-ignorebroken.sh
@@ -16,6 +16,8 @@
 # Red Hat, Inc.
 #
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/packages-ignoremissing.sh
+++ b/packages-ignoremissing.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging"
 
 . ${KSTESTDIR}/functions.sh

--- a/packages-instlangs-1.sh
+++ b/packages-instlangs-1.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging"
 
 . ${KSTESTDIR}/functions.sh

--- a/packages-instlangs-2.sh
+++ b/packages-instlangs-2.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging"
 
 . ${KSTESTDIR}/functions.sh

--- a/packages-instlangs-3.sh
+++ b/packages-instlangs-3.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging"
 
 . ${KSTESTDIR}/functions.sh

--- a/packages-multilib.sh
+++ b/packages-multilib.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging skip-on-rhel-8 gh641"
 
 . ${KSTESTDIR}/functions.sh

--- a/packages-weakdeps.sh
+++ b/packages-weakdeps.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): David Shea <dshea@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging rhbz1960279 gh830"
 
 . ${KSTESTDIR}/functions.sh

--- a/part-luks-1.sh
+++ b/part-luks-1.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
 # Check the results on the running VM.
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="manual storage partition luks"
 
 . ${KSTESTDIR}/functions.sh

--- a/part-luks-2.sh
+++ b/part-luks-2.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
 # Check the results on the running VM.
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="manual storage partition luks"
 
 . ${KSTESTDIR}/functions.sh

--- a/part-luks-3.sh
+++ b/part-luks-3.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
 # Check the results on the running VM.
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="manual storage partition luks"
 
 . ${KSTESTDIR}/functions.sh

--- a/part-luks-4.sh
+++ b/part-luks-4.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
 # Check the results on the running VM.
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="manual storage partition luks"
 
 . ${KSTESTDIR}/functions.sh

--- a/pre-install.sh
+++ b/pre-install.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="kickstart"
 
 . ${KSTESTDIR}/functions.sh

--- a/proxy-auth.sh
+++ b/proxy-auth.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="method proxy gh680 gh841"
 
 . ${KSTESTDIR}/functions.sh

--- a/proxy-cmdline.sh
+++ b/proxy-cmdline.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): David Shea <dshea@redhat.com>
 #                    Jiri Konecny <jkonecny@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="method proxy"
 
 . ${KSTESTDIR}/functions.sh

--- a/proxy-kickstart.sh
+++ b/proxy-kickstart.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): David Shea <dshea@redhat.com>
 #                    Jiri Konecny <jkonecny@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="method proxy gh680 gh841"
 
 . ${KSTESTDIR}/functions.sh

--- a/raid-1.sh
+++ b/raid-1.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="raid storage coverage gh777"
 
 . ${KSTESTDIR}/functions.sh

--- a/raid-ddf.sh
+++ b/raid-ddf.sh
@@ -19,6 +19,8 @@
 
 # This test covers https://bugzilla.redhat.com/show_bug.cgi?id=2063791
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="raid storage skip-on-fedora rhbz2122327"
 
 . ${KSTESTDIR}/functions.sh

--- a/raid-luks-1.sh
+++ b/raid-luks-1.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
 # Check the results on the running VM.
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="manual storage raid luks"
 
 . ${KSTESTDIR}/functions.sh

--- a/raid-luks-2.sh
+++ b/raid-luks-2.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
 # Check the results on the running VM.
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="manual storage raid luks"
 
 . ${KSTESTDIR}/functions.sh

--- a/raid-luks-3.sh
+++ b/raid-luks-3.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
 # Check the results on the running VM.
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="manual storage raid luks"
 
 . ${KSTESTDIR}/functions.sh

--- a/raid-luks-4.sh
+++ b/raid-luks-4.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
 # Check the results on the running VM.
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="manual storage raid luks"
 
 . ${KSTESTDIR}/functions.sh

--- a/reboot-initial-setup-gui.sh
+++ b/reboot-initial-setup-gui.sh
@@ -15,6 +15,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="reboot initial-setup smoke"
 
 . ${KSTESTDIR}/functions.sh

--- a/reboot-initial-setup-tui.sh
+++ b/reboot-initial-setup-tui.sh
@@ -16,6 +16,8 @@
 # Red Hat, Inc.
 #
 # The fix requires https://github.com/rhinstaller/anaconda/commit/6b80b7b.
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="reboot initial-setup smoke skip-on-rhel-8"
 
 . ${KSTESTDIR}/functions.sh

--- a/reboot.sh
+++ b/reboot.sh
@@ -15,6 +15,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="reboot"
 
 . ${KSTESTDIR}/functions.sh

--- a/repo-addrepo-hd-iso.sh
+++ b/repo-addrepo-hd-iso.sh
@@ -16,6 +16,8 @@
 # Red Hat, Inc.
 #
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging repo harddrive"
 
 . ${KSTESTDIR}/functions.sh

--- a/repo-addrepo-hd-tree.sh
+++ b/repo-addrepo-hd-tree.sh
@@ -17,6 +17,8 @@
 #
 
 # FIXME: Fails on RHEL 8: "Nothing useful found for Hard drive ISO source"
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging repo harddrive skip-on-rhel-8 gh790"
 
 . ${KSTESTDIR}/functions.sh

--- a/repo-addrepo.sh
+++ b/repo-addrepo.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging repo"
 
 . ${KSTESTDIR}/functions.sh

--- a/repo-baseurl.sh
+++ b/repo-baseurl.sh
@@ -16,6 +16,8 @@
 # Red Hat, Inc.
 #
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging repo gh841"
 
 . ${KSTESTDIR}/functions.sh

--- a/repo-enable.sh
+++ b/repo-enable.sh
@@ -16,6 +16,8 @@
 # Red Hat, Inc.
 #
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging repo"
 
 . ${KSTESTDIR}/functions.sh

--- a/repo-exclude.sh
+++ b/repo-exclude.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): David Shea <dshea@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging repo"
 
 . ${KSTESTDIR}/functions.sh

--- a/repo-include.sh
+++ b/repo-include.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): David Shea <dshea@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging repo gh670"
 
 . ${KSTESTDIR}/functions.sh

--- a/repo-install.sh
+++ b/repo-install.sh
@@ -16,6 +16,8 @@
 # Red Hat, Inc.
 #
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging repo"
 
 . ${KSTESTDIR}/functions.sh

--- a/repo-metalink.sh
+++ b/repo-metalink.sh
@@ -16,6 +16,8 @@
 # Red Hat, Inc.
 #
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging repo skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/repo-mirrorlist.sh
+++ b/repo-mirrorlist.sh
@@ -16,6 +16,8 @@
 # Red Hat, Inc.
 #
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging repo skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/reqpart.sh
+++ b/reqpart.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="storage coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/rootpw-allow-ssh.sh
+++ b/rootpw-allow-ssh.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="users skip-on-rhel-8"
 
 . ${KSTESTDIR}/functions.sh

--- a/rootpw-basic.sh
+++ b/rootpw-basic.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="users coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/rootpw-crypted.sh
+++ b/rootpw-crypted.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="users"
 
 . ${KSTESTDIR}/functions.sh

--- a/rootpw-lock-no-password.sh
+++ b/rootpw-lock-no-password.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="users"
 
 . ${KSTESTDIR}/functions.sh

--- a/rootpw-lock.sh
+++ b/rootpw-lock.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="users coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/rpm-ostree.sh
+++ b/rpm-ostree.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="payload ostree skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/selinux-contexts.sh
+++ b/selinux-contexts.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Vladimir Slavik <vslavik@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="security selinux"
 
 . ${KSTESTDIR}/functions.sh

--- a/selinux-disabled.sh
+++ b/selinux-disabled.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="selinux"
 
 . ${KSTESTDIR}/functions.sh

--- a/selinux-enforcing.sh
+++ b/selinux-enforcing.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="selinux coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/selinux-permissive.sh
+++ b/selinux-permissive.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="selinux"
 
 . ${KSTESTDIR}/functions.sh

--- a/services.sh
+++ b/services.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="services coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/snapshot-post.sh
+++ b/snapshot-post.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 
 # FIXME: Anaconda crashes with "Logical volume testvg/testLV contains a filesystem in use"
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="snapshot lvm storage coverage knownfailure"
 
 . ${KSTESTDIR}/functions.sh

--- a/snapshot-pre.sh
+++ b/snapshot-pre.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="snapshot lvm storage"
 
 . ${KSTESTDIR}/functions.sh

--- a/team-httpks.sh
+++ b/team-httpks.sh
@@ -24,6 +24,8 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE=${TESTTYPE:-"network"}
 
 . ${KSTESTDIR}/functions.sh

--- a/team-pre.sh
+++ b/team-pre.sh
@@ -24,6 +24,8 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE=${TESTTYPE:-"network"}
 
 . ${KSTESTDIR}/team.sh

--- a/team.sh
+++ b/team.sh
@@ -24,6 +24,8 @@
 # injected in initrd) network devices are not found in sysfs in the time of
 # parsing the kickstart.
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE=${TESTTYPE:-"network"}
 
 . ${KSTESTDIR}/functions.sh

--- a/timezoneLOCAL.sh
+++ b/timezoneLOCAL.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="time"
 
 . ${KSTESTDIR}/functions.sh

--- a/timezoneUTC.sh
+++ b/timezoneUTC.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="time"
 
 . ${KSTESTDIR}/functions.sh

--- a/tmpfs-fixed_size.sh
+++ b/tmpfs-fixed_size.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="storage"
 
 . ${KSTESTDIR}/functions.sh

--- a/ui_cmdline.sh
+++ b/ui_cmdline.sh
@@ -15,6 +15,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="ui"
 
 . ${KSTESTDIR}/functions.sh

--- a/ui_graphical_interactive.sh
+++ b/ui_graphical_interactive.sh
@@ -15,6 +15,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="ui smoke"
 
 . ${KSTESTDIR}/functions.sh

--- a/ui_graphical_noninteractive.sh
+++ b/ui_graphical_noninteractive.sh
@@ -17,6 +17,8 @@
 #
 
 # Anaconda raises the noninteractive error for the progress spoke.
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="ui knownfailure"
 
 . ${KSTESTDIR}/functions.sh

--- a/ui_text_interactive.sh
+++ b/ui_text_interactive.sh
@@ -15,6 +15,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="ui smoke"
 
 . ${KSTESTDIR}/functions.sh

--- a/ui_text_noninteractive.sh
+++ b/ui_text_noninteractive.sh
@@ -15,6 +15,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="ui"
 
 . ${KSTESTDIR}/functions.sh

--- a/ui_vnc.sh
+++ b/ui_vnc.sh
@@ -15,6 +15,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="ui"
 
 . ${KSTESTDIR}/functions.sh

--- a/unified-cdrom.sh
+++ b/unified-cdrom.sh
@@ -25,6 +25,8 @@
 # which will be the want used for booting in our case.
 #
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="skip-on-fedora manual"
 
 . ${KSTESTDIR}/functions.sh

--- a/unified-cmdline.sh
+++ b/unified-cmdline.sh
@@ -19,6 +19,8 @@
 
 #TESTTYPE="packaging"
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="skip-on-fedora manual"
 
 . ${KSTESTDIR}/functions.sh

--- a/unified-harddrive.sh
+++ b/unified-harddrive.sh
@@ -19,6 +19,8 @@
 
 #TESTTYPE="packaging skip-on-fedora"
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="skip-on-fedora manual"
 
 . ${KSTESTDIR}/functions.sh

--- a/unified-nfs.sh
+++ b/unified-nfs.sh
@@ -19,6 +19,8 @@
 
 #TESTTYPE="packaging skip-on-fedora"
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="skip-on-fedora manual"
 
 . ${KSTESTDIR}/functions.sh

--- a/unified.sh
+++ b/unified.sh
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 
 # times out
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging skip-on-fedora manual"
 
 . ${KSTESTDIR}/functions.sh

--- a/url-baseurl.sh
+++ b/url-baseurl.sh
@@ -16,6 +16,8 @@
 # Red Hat, Inc.
 #
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging url gh841"
 
 . ${KSTESTDIR}/functions.sh

--- a/url-metalink.sh
+++ b/url-metalink.sh
@@ -16,6 +16,8 @@
 # Red Hat, Inc.
 #
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging url skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/url-mirrorlist.sh
+++ b/url-mirrorlist.sh
@@ -16,6 +16,8 @@
 # Red Hat, Inc.
 #
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="packaging url skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/user-locked-root-locked-admin.sh
+++ b/user-locked-root-locked-admin.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="users"
 
 . ${KSTESTDIR}/functions.sh

--- a/user-multiple-wheel-no-root.sh
+++ b/user-multiple-wheel-no-root.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="users"
 
 . ${KSTESTDIR}/functions.sh

--- a/user-multiple.sh
+++ b/user-multiple.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="users coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/user-no-wheel-no-root.sh
+++ b/user-no-wheel-no-root.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="users knownfailure"
 
 . ${KSTESTDIR}/functions.sh

--- a/user-single.sh
+++ b/user-single.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="users"
 
 . ${KSTESTDIR}/functions.sh

--- a/user-wheel-no-root.sh
+++ b/user-wheel-no-root.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE="users"
 
 . ${KSTESTDIR}/functions.sh

--- a/vlan-httpks.sh
+++ b/vlan-httpks.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE=${TESTTYPE:-"network"}
 
 . ${KSTESTDIR}/functions.sh

--- a/vlan-pre.sh
+++ b/vlan-pre.sh
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
 TESTTYPE=${TESTTYPE:-"network"}
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
The TESTTYPE variable is not actually sourced but parsed by kickstart-tests tooling. In run_kickstart_tests.sh and generate-testcases.py.

In the future we will move this kind of metadata from .sh file to a better place - most probably Permian/tclib test case metadata (https://issues.redhat.com/browse/INSTALLER-3109).

PR created by this:

```
grep -l ^TESTTYPE= *.sh | xargs sed -i '/^TESTTYPE=.*/i # Ignore unused variable parsed out by tooling scripts as test tags metadata\n# shellcheck disable=SC2034'
```