### PR TITLE
Use nightly compose for daily tests and as default on rhel

### DIFF
--- a/.github/workflows/scenarios-permian.yml
+++ b/.github/workflows/scenarios-permian.yml
@@ -128,11 +128,11 @@ jobs:
         run: |
           set -eux
           if [ "${{ matrix.scenario }}" == "rhel8" ]; then
-            echo "installation_tree=http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8.8.0/compose/BaseOS/x86_64/os" >> $GITHUB_OUTPUT
-            echo "modular_url=http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8.8.0/compose/AppStream/x86_64/os" >> $GITHUB_OUTPUT
+            echo "installation_tree=http://download.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.8.0/compose/BaseOS/x86_64/os" >> $GITHUB_OUTPUT
+            echo "modular_url=http://download.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.8.0/compose/AppStream/x86_64/os" >> $GITHUB_OUTPUT
           elif [ "${{ matrix.scenario }}" == "rhel9" ]; then
-            echo "installation_tree=http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9/latest-RHEL-9.2.0/compose/BaseOS/x86_64/os" >> $GITHUB_OUTPUT
-            echo "modular_url=http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9/latest-RHEL-9.2.0/compose/AppStream/x86_64/os" >> $GITHUB_OUTPUT
+            echo "installation_tree=http://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.2.0/compose/BaseOS/x86_64/os" >> $GITHUB_OUTPUT
+            echo "modular_url=http://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.2.0/compose/AppStream/x86_64/os" >> $GITHUB_OUTPUT
           else
             echo "Installation tree location for ${{ matrix.scenario }} not configured"
             if [ -z "${{ steps.boot_iso_from_scenario.outputs.boot_iso }}" ]; then

--- a/scripts/defaults-rhel8.sh
+++ b/scripts/defaults-rhel8.sh
@@ -1,6 +1,6 @@
 # Default settings for testing RHEL 8. This requires being inside the Red Hat VPN.
 
 source network-device-names.cfg
-export KSTEST_URL='http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8.8.0/compose/BaseOS/x86_64/os/'
-export KSTEST_MODULAR_URL='http://download.eng.bos.redhat.com/rhel-8/development/RHEL-8/latest-RHEL-8.8.0/compose/AppStream/x86_64/os/'
+export KSTEST_URL='http://download.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.8.0/compose/BaseOS/x86_64/os/'
+export KSTEST_MODULAR_URL='http://download.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.8.0/compose/AppStream/x86_64/os/'
 export KSTEST_FTP_URL='ftp://ftp.tu-chemnitz.de/pub/linux/fedora/linux/development/rawhide/Everything/$basearch/os/'

--- a/scripts/defaults-rhel9.sh
+++ b/scripts/defaults-rhel9.sh
@@ -1,7 +1,6 @@
 # Default settings for testing RHEL 9. This requires being inside the Red Hat VPN.
 
 source network-device-names.cfg
-export KSTEST_URL='http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9/latest-RHEL-9.2.0/compose/BaseOS/x86_64/os/'
-export KSTEST_MODULAR_URL='http://download.eng.bos.redhat.com/rhel-9/development/RHEL-9/latest-RHEL-9.2.0/compose/AppStream/x86_64/os/'
+export KSTEST_URL='http://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.2.0/compose/BaseOS/x86_64/os/'
+export KSTEST_MODULAR_URL='http://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.2.0/compose/AppStream/x86_64/os/'
 export KSTEST_FTP_URL='ftp://ftp.tu-chemnitz.de/pub/linux/fedora/linux/development/rawhide/Everything/$basearch/os/'
-


### PR DESCRIPTION
Development compose has not been built successfully for some month and nightly is ahead now.

https://issues.redhat.com/browse/ENGCMP-2777
https://issues.redhat.com/browse/ENGCMP-2780
https://issues.redhat.com/browse/RHELBLD-11909