### PR TITLE
Revert "Disable repo-include test temporarily (gh#670)"

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -35,7 +35,6 @@ rhel8_skip_array=(
   skip-on-rhel-8
   gh576       # clearpart-4 test is flaky on all scenarios
   gh595       # proxy-cmdline failing on all scenarios
-  gh670       # repo-include failing on rhel
   gh774       # autopart-luks-1 failing
   gh830       # packages-weakdeps failing
   gh841       # 4 tests disabled due to dnf rhbz#2152846
@@ -48,7 +47,6 @@ rhel9_skip_array=(
   gh595       # proxy-cmdline failing on all scenarios
   rhbz1960279 # packages-weakdeps: "gnupg2 --recommends has changed, test needs to be updated"
   gh641       # packages-multilib failing on systemd conflict
-  gh670       # repo-include failing on rhel
   gh774       # autopart-luks-1 failing
   gh790       # repo-addrepo-hd-tree failing
 )

--- a/repo-include.sh
+++ b/repo-include.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging repo gh670"
+TESTTYPE="packaging repo"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
This reverts commit 52959ae41fdbf88a7996321f6669d709aecac92a.

https://bugzilla.redhat.com/show_bug.cgi?id=2158210 and
https://bugzilla.redhat.com/show_bug.cgi?id=2014103
are fixed in nightly composes.