### PR TITLE
Revert "Disable tests without appstream on rhel8 temporarily (gh#841)"

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -37,7 +37,6 @@ rhel8_skip_array=(
   gh595       # proxy-cmdline failing on all scenarios
   gh774       # autopart-luks-1 failing
   gh830       # packages-weakdeps failing
-  gh841       # 4 tests disabled due to dnf rhbz#2152846
 )
 
 rhel9_skip_array=(

--- a/proxy-auth.sh
+++ b/proxy-auth.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="method proxy gh680 gh841"
+TESTTYPE="method proxy gh680"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/functions-proxy.sh

--- a/proxy-kickstart.sh
+++ b/proxy-kickstart.sh
@@ -20,7 +20,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="method proxy gh680 gh841"
+TESTTYPE="method proxy gh680"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/functions-proxy.sh

--- a/repo-baseurl.sh
+++ b/repo-baseurl.sh
@@ -18,7 +18,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging repo gh841"
+TESTTYPE="packaging repo"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/url-baseurl.sh
+++ b/url-baseurl.sh
@@ -18,6 +18,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging url gh841"
+TESTTYPE="packaging url"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
This reverts commit 09da2eef14c9f75f842f22ee5e2890b9a3b18138.

https://bugzilla.redhat.com/show_bug.cgi?id=2152846 is fixed in tested compose.