### PR TITLE
Disable dracut-visible-warnings on daily-iso temporarily (gh#875)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -30,6 +30,7 @@ daily_iso_skip_array=(
   rhbz2122327 # installation with an existing DDF RAID device fails
   rhbz2153361 # stage2-from-ks should be fixed in RHEL 9.2
   gh874       # network-bootopts-noautodefault failing
+  gh875       # dracut-visible-warnings failing
 )
 
 rhel8_skip_array=(

--- a/dracut-visible-warnings.sh
+++ b/dracut-visible-warnings.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="dracut skip-on-rhel-8"
+TESTTYPE="dracut skip-on-rhel-8 gh875"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Disable dracut-visible-warnings on daily-iso until gh#875 is fixed.