### PR TITLE
Disable network-bootopts-noautodefault on daily-iso temporarily (gh#874)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -29,6 +29,7 @@ daily_iso_skip_array=(
   gh777       # raid-1 failing
   rhbz2122327 # installation with an existing DDF RAID device fails
   rhbz2153361 # stage2-from-ks should be fixed in RHEL 9.2
+  gh874       # network-bootopts-noautodefault failing
 )
 
 rhel8_skip_array=(

--- a/network-bootopts-noautodefault.sh
+++ b/network-bootopts-noautodefault.sh
@@ -24,7 +24,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="network skip-on-rhel"
+TESTTYPE="network skip-on-rhel gh874"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Disable network-bootopts-noautodefault on daily-iso until gh#874 is fixed.