### PR TITLE
Revert "Disable dracut-visible-warnings on daily-iso temporarily (gh#…

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -30,7 +30,6 @@ daily_iso_skip_array=(
   rhbz2122327 # installation with an existing DDF RAID device fails
   rhbz2153361 # stage2-from-ks should be fixed in RHEL 9.2
   gh874       # network-bootopts-noautodefault failing
-  gh875       # dracut-visible-warnings failing
 )
 
 rhel8_skip_array=(

--- a/dracut-visible-warnings.sh
+++ b/dracut-visible-warnings.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="dracut skip-on-rhel-8 gh875"
+TESTTYPE="dracut skip-on-rhel-8"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
…875)"

This reverts commit 7da84800badc6f4a20ceb2e7698c4c88a3f6f77e.

The https://bugzilla.redhat.com/show_bug.cgi?id=2165433 is fixed.