### PR TITLE
Revert "Disable network-bootopts-noautodefault on daily-iso temporari…

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -29,7 +29,6 @@ daily_iso_skip_array=(
   gh777       # raid-1 failing
   rhbz2122327 # installation with an existing DDF RAID device fails
   rhbz2153361 # stage2-from-ks should be fixed in RHEL 9.2
-  gh874       # network-bootopts-noautodefault failing
 )
 
 rhel8_skip_array=(

--- a/network-bootopts-noautodefault.sh
+++ b/network-bootopts-noautodefault.sh
@@ -24,7 +24,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="network skip-on-rhel gh874"
+TESTTYPE="network skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
…ly (gh#874)"

This reverts commit ae73ad43bd22246f3c14f7838e898a1d1dfcd13d.

Works with the latest iso. Seems to be related to the https://bugzilla.redhat.com/show_bug.cgi?id=2165433 which is fixed now as well (as the https://github.com/rhinstaller/kickstart-tests/issues/875).