### PR TITLE
Disable default-systemd-target-vnc-graphical-provides temporarily (gh…

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -30,6 +30,7 @@ daily_iso_skip_array=(
   rhbz2122327 # installation with an existing DDF RAID device fails
   rhbz2153361 # stage2-from-ks should be fixed in RHEL 9.2
   gh891       # autopart-hibernation failing
+  gh890       # default-systemd-target-vnc-graphical-provides flaking too much
 )
 
 rhel8_skip_array=(

--- a/default-systemd-target-vnc-graphical-provides.sh
+++ b/default-systemd-target-vnc-graphical-provides.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="services"
+TESTTYPE="services gh890"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/validate-lib-services.sh


### PR DESCRIPTION
…#890)

Disable default-systemd-target-vnc-graphical-provides on daily-iso until gh#890 is fixed.