### PR TITLE
Revert "Disable autopart-hibernation on all scenarios temporarily (gh…

### DIFF
--- a/autopart-hibernation.sh
+++ b/autopart-hibernation.sh
@@ -18,7 +18,7 @@
 # Red Hat Author(s): Ondřej Zobal <ozobal@redhat.com>
 
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage skip-on-rhel-8 skip-on-rhel-9 gh891"
+TESTTYPE="autopart storage skip-on-rhel-8 skip-on-rhel-9"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -29,7 +29,6 @@ daily_iso_skip_array=(
   gh777       # raid-1 failing
   rhbz2122327 # installation with an existing DDF RAID device fails
   rhbz2153361 # stage2-from-ks should be fixed in RHEL 9.2
-  gh891       # autopart-hibernation failing
   gh890       # default-systemd-target-vnc-graphical-provides flaking too much
 )
 
@@ -40,7 +39,6 @@ rhel8_skip_array=(
   gh595       # proxy-cmdline failing on all scenarios
   gh774       # autopart-luks-1 failing
   gh830       # packages-weakdeps failing
-  gh891       # autopart-hibernation failing
 )
 
 rhel9_skip_array=(
@@ -53,7 +51,6 @@ rhel9_skip_array=(
   gh774       # autopart-luks-1 failing
   gh790       # repo-addrepo-hd-tree failing
   rhbz2153361 # stage2-from-ks should be fixed in RHEL 9.2
-  gh891       # autopart-hibernation failing
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml


### PR DESCRIPTION
…#891)"

This reverts commit f3512d2768d3bd111ee83508b67936ca9efd7d23.

The test was fixed on daily-iso and disabled on rhel in https://github.com/rhinstaller/kickstart-tests/pull/896