### PR TITLE
Update encrypt-devices test (gh#898)

### DIFF
--- a/encrypt-device.ks.in
+++ b/encrypt-device.ks.in
@@ -11,7 +11,7 @@ part pv.68 --asprimary --fstype="lvmpv" --ondisk=vda --size=7691
 part /boot --asprimary --fstype="ext4" --ondisk=vda --size=500
 volgroup vg01 --pesize=4096 pv.68
 logvol /  --fstype="ext4" --size=5000 --encrypted --name=root_lv --vgname=vg01 --passphrase=OntarioIsAProvince --label=root
-logvol /var  --fstype="ext4" --size=1000 --name=var_lv --vgname=vg01
+logvol /var  --fstype="ext4" --size=1200 --name=var_lv --vgname=vg01
 logvol swap  --fstype="swap" --size=1024 --name=swap_lv --vgname=vg01
 logvol /home  --fstype="ext4" --grow --size=1 --name=home_lv --vgname=vg01
 


### PR DESCRIPTION
On RHEL 8 with the default package selection, DNF started to require additional space on /var.

"At least 40MB more space needed on the /var filesystem."