### PR TITLE
Re-enable stage2-from-ks on rhel9 (rhbz#2153361)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -50,7 +50,6 @@ rhel9_skip_array=(
   gh641       # packages-multilib failing on systemd conflict
   gh774       # autopart-luks-1 failing
   gh790       # repo-addrepo-hd-tree failing
-  rhbz2153361 # stage2-from-ks should be fixed in RHEL 9.2
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml


### PR DESCRIPTION
The issue is fixed on rhel9.
On daily-iso we are waiting for https://github.com/rhinstaller/anaconda/pull/4559