### PR TITLE
Use both UUID and path for checking fsoptions presence in fstab

### DIFF
--- a/lvm-1.ks.in
+++ b/lvm-1.ks.in
@@ -41,12 +41,16 @@ fi
 # verify root entry in /etc/fstab is correct
 root_lv_entry="$(grep ^$root_lv\\s\\+/\\s /etc/fstab)"
 root_uuid_entry="$(grep ^$root_uuid\\s\\+/\\s /etc/fstab)"
-if [ -z "$root_lv_entry" -a -z "$root_uuid_entry" ] ; then
+if [ "$root_lv_entry" ] ; then
+    if [ -z "$(echo $root_lv_entry | grep loud,noatime)" ]; then
+        echo "*** root lv did not preserve --fsoptions" >> /root/RESULT
+    fi
+elif [ "$root_uuid_entry" ]; then
+    if [ -z "$(echo $root_uuid_entry | grep loud,noatime)" ]; then
+        echo "*** root lv did not preserve --fsoptions" >> /root/RESULT
+    fi
+else
     echo "*** root lv is not the root entry in /etc/fstab" >> /root/RESULT
-fi
-
-if [ -z "$(echo $root_lv_entry | grep loud,noatime)" ]; then
-    echo "*** root lv did not preserve --fsoptions" >> /root/RESULT
 fi
 
 # verify size of root lv


### PR DESCRIPTION
Blivet recently started using UUID instead of path for LVM (it already uses UUID for other devices) so the check for the options presence needs to be adjusted.

Fixes: #918