### PR TITLE
Disable rpm-ostree temporarily on daily-iso (gh#942)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -30,6 +30,7 @@ daily_iso_skip_array=(
   rhbz2122327 # installation with an existing DDF RAID device fails
   gh910       # stage2-from-ks test needs to be fixed for daily-iso
   gh890       # default-systemd-target-vnc-graphical-provides flaking too much
+  gh942       # rpm-ostree failing
 )
 
 rhel8_skip_array=(

--- a/rpm-ostree.sh
+++ b/rpm-ostree.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="payload ostree skip-on-rhel"
+TESTTYPE="payload ostree skip-on-rhel gh942"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Disable rpm-ostree test on daily-iso until gh942 is fixed.