### PR TITLE
Ifcfg format in dns search domains

### DIFF
--- a/network-dns-search.ks.in
+++ b/network-dns-search.ks.in
@@ -22,7 +22,7 @@ check_connection_device "@KSTEST_NETDEV1@" "@KSTEST_NETDEV1@"
 
 check_connection_setting "@KSTEST_NETDEV1@" ipv4.dns-search fedoraproject.org,example.com
 check_connection_setting "@KSTEST_NETDEV1@" ipv6.dns-search whatever.nonexistent
-check_device_config_value "@KSTEST_NETDEV1@" DOMAIN fedoraproject.org,example.com ipv4 dns-search "fedoraproject.org;example.com;"
+check_device_config_value "@KSTEST_NETDEV1@" DOMAIN "fedoraproject.org example.com" ipv4 dns-search "fedoraproject.org;example.com;"
 check_device_config_value "@KSTEST_NETDEV1@" IPV6_DOMAIN whatever.nonexistent ipv6 dns-search "whatever.nonexistent;"
 
 check_connection_setting "@KSTEST_NETDEV1@" ipv4.ignore-auto-dns no

--- a/post-lib-network.sh
+++ b/post-lib-network.sh
@@ -20,13 +20,13 @@ function check_device_config_value() {
 
     if [[ -e ${ifcfg_file} ]]; then
         if [[ "${ifcfg_value}" == "__NONE" ]]; then
-            ! egrep -q '^'${ifcfg_key}'=' ${ifcfg_file}
+            ! egrep -q '^'"${ifcfg_key}"'=' "${ifcfg_file}"
             ifcfg_result=$?
         elif [[ "${ifcfg_value}" == "__ANY" ]]; then
-            egrep -q '^'${ifcfg_key}'=' ${ifcfg_file}
+            egrep -q '^'"${ifcfg_key}"'=' "${ifcfg_file}"
             ifcfg_result=$?
         else
-            egrep -q '^'${ifcfg_key}'="?'${ifcfg_value}'"?$' ${ifcfg_file}
+            egrep -q '^'"${ifcfg_key}"'="?'"${ifcfg_value}"'"?$' "${ifcfg_file}"
             ifcfg_result=$?
         fi
     fi


### PR DESCRIPTION
It's spaces, not commas. Yay. This will let the test work on rhel-8 correctly, once that is ported.