### PR TITLE
Add dnf5-unstable repo temporarily

### DIFF
--- a/.github/workflows/daily-boot-iso-rawhide.yml
+++ b/.github/workflows/daily-boot-iso-rawhide.yml
@@ -57,9 +57,11 @@ jobs:
           . /etc/os-release
           # The download.fedoraproject.org automatic redirector often selects download-ib01.f.o. for GitHub's cloud, which is too unreliable; use a mirror
           # The --volid argument can cause different network interface naming: https://github.com/rhinstaller/kickstart-tests/issues/448
+          # FIXME: remove the dnf5-unstable when the stuff goes into stable repo
           lorax -p Fedora -v \$VERSION_ID -r \$VERSION_ID --volid Fedora-S-dvd-x86_64-rawh \
             -s http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/ \
             -s https://download.copr.fedorainfracloud.org/results/rpmsoftwaremanagement/dnf-nightly/fedora-rawhide-x86_64/ \
+            -s https://download.copr.fedorainfracloud.org/results/rpmsoftwaremanagement/dnf5-unstable/fedora-rawhide-x86_64/ \
             -s https://download.copr.fedorainfracloud.org/results/@rhinstaller/Anaconda/fedora-rawhide-x86_64/ \
             -s https://copr-be.cloud.fedoraproject.org/results/@storage/blivet-daily/fedora-rawhide-x86_64/ \
             -s https://copr-be.cloud.fedoraproject.org/results/@storage/udisks-daily/fedora-rawhide-x86_64/ \


### PR DESCRIPTION
dnf.conf was moved from dnf-data to dnf5 so we need to add the dnf5-unstable repository until dnf5 is stable

https://github.com/rhinstaller/kickstart-tests/actions/runs/5182410192/jobs/9339168075