### PR TITLE
Enable network-dns-search on RHEL

### DIFF
--- a/network-dns-search.sh
+++ b/network-dns-search.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="network skip-on-rhel"
+TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
This feature is implemented in RHEL-8.9 (bug 1656662) and RHEL-9.3 (bug 2065754).