### PR TITLE
Disable selinux-contexts temporarily on rhel9 (gh#970)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -57,6 +57,7 @@ rhel9_skip_array=(
   gh774       # autopart-luks-1 failing
   gh790       # repo-addrepo-hd-tree failing
   gh969       # raid-ddf failing
+  gh970       # selinux-contexts failing
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/selinux-contexts.sh
+++ b/selinux-contexts.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="security selinux"
+TESTTYPE="security selinux gh970"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Disable selinux-contexts test on rhel-9 until gh970 is fixed.