### PR TITLE
Disable raid-ddf temporarily on rhel (gh#969)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -44,6 +44,7 @@ rhel8_skip_array=(
   gh595       # proxy-cmdline failing on all scenarios
   gh774       # autopart-luks-1 failing
   gh830       # packages-weakdeps failing
+  gh969       # raid-ddf failing
 )
 
 rhel9_skip_array=(
@@ -55,6 +56,7 @@ rhel9_skip_array=(
   gh641       # packages-multilib failing on systemd conflict
   gh774       # autopart-luks-1 failing
   gh790       # repo-addrepo-hd-tree failing
+  gh969       # raid-ddf failing
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/raid-ddf.sh
+++ b/raid-ddf.sh
@@ -21,7 +21,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="raid storage skip-on-fedora rhbz2122327"
+TESTTYPE="raid storage skip-on-fedora rhbz2122327 gh969"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Disable raid-ddf test on rhel until gh969 is fixed.