### PR TITLE
Enable rpm-ostree test again

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -30,7 +30,6 @@ daily_iso_skip_array=(
   rhbz2122327 # installation with an existing DDF RAID device fails
   gh910       # stage2-from-ks test needs to be fixed for daily-iso
   gh890       # default-systemd-target-vnc-graphical-provides flaking too much
-  gh942       # rpm-ostree failing
   gh871       # basic-ftp failing due to mirror
 )
 

--- a/rpm-ostree.sh
+++ b/rpm-ostree.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="payload ostree skip-on-rhel gh942"
+TESTTYPE="payload ostree skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
It's working again now. Probably because of changes done by Fedora rel-engs when trying to resolve this:

https://pagure.io/fedora-infrastructure/issue/11317

Closes https://github.com/rhinstaller/kickstart-tests/issues/942