### PR TITLE
Disable vnc tests temporarily on daily-iso (gh#978)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -35,6 +35,7 @@ daily_iso_skip_array=(
   rhbz1853668 # multipath device not constructed back after installation
   gh969       # raid-ddf failing
   gh975       # packages-default failing
+  gh978       # vnc tests failing
 )
 
 rhel8_skip_array=(

--- a/default-systemd-target-vnc.sh
+++ b/default-systemd-target-vnc.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="services"
+TESTTYPE="services gh978"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/validate-lib-services.sh

--- a/ui_vnc.sh
+++ b/ui_vnc.sh
@@ -17,6 +17,6 @@
 #
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="ui"
+TESTTYPE="ui gh978"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Disable vnc tests on daily-iso until gh978 is fixed.