### PR TITLE
Revert "Disable vnc tests temporarily on daily-iso (gh#978)"

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -35,7 +35,6 @@ daily_iso_skip_array=(
   rhbz1853668 # multipath device not constructed back after installation
   gh969       # raid-ddf failing
   gh975       # packages-default failing
-  gh978       # vnc tests failing
 )
 
 rhel8_skip_array=(

--- a/default-systemd-target-vnc.sh
+++ b/default-systemd-target-vnc.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="services gh978"
+TESTTYPE="services"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/validate-lib-services.sh

--- a/ui_vnc.sh
+++ b/ui_vnc.sh
@@ -17,6 +17,6 @@
 #
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="ui gh978"
+TESTTYPE="ui"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
This reverts commit a86ca1ac18cb5fa8df0a04a741e1a7ea0d1d58ce.

Fixed by https://github.com/rhinstaller/anaconda/pull/4879