### PR TITLE
Disable image-deployment-2 test (gh#986)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -35,6 +35,7 @@ daily_iso_skip_array=(
   rhbz1853668 # multipath device not constructed back after installation
   gh969       # raid-ddf failing
   gh975       # packages-default failing
+  gh986       # image-deployment-2 failing
 )
 
 rhel8_skip_array=(

--- a/image-deployment-2.sh
+++ b/image-deployment-2.sh
@@ -17,7 +17,7 @@
 #
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="image-deployment"
+TESTTYPE="image-deployment gh986"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Disable image-deployment-2 test until gh986 is fixed.