### PR TITLE
Fix list of modules to activate in image-deployment-2

### DIFF
--- a/image-deployment-2.sh
+++ b/image-deployment-2.sh
@@ -33,7 +33,7 @@ prepare_updates() {
 
 [Anaconda]
 # List of enabled Anaconda DBus modules.
-kickstart_modules =
+activatable_modules =
      org.fedoraproject.Anaconda.Modules.Network
      org.fedoraproject.Anaconda.Modules.Payloads
      org.fedoraproject.Anaconda.Modules.Storage


### PR DESCRIPTION
- Required by https://github.com/rhinstaller/anaconda/pull/4764
- Fixes https://github.com/rhinstaller/kickstart-tests/issues/986