### PR TITLE
Disable dracut-visible-warnigs tests temporarily (gh#988)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -35,6 +35,7 @@ daily_iso_skip_array=(
   rhbz1853668 # multipath device not constructed back after installation
   gh969       # raid-ddf failing
   gh975       # packages-default failing
+  gh988       # dracut-visible-warnings failing
 )
 
 rhel8_skip_array=(

--- a/dracut-visible-warnings.sh
+++ b/dracut-visible-warnings.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="dracut skip-on-rhel-8"
+TESTTYPE="dracut skip-on-rhel-8 gh988"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Disable dracut-visible-warnings until gh988 is fixed.