### PR TITLE
Disable image-deployment-2 temporarily on rhel8 (gh#986)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -45,6 +45,7 @@ rhel8_skip_array=(
   gh774       # autopart-luks-1 failing
   gh830       # packages-weakdeps failing
   gh969       # raid-ddf failing
+  gh986       # image-deployment-2 failing
 )
 
 rhel9_skip_array=(

--- a/image-deployment-2.sh
+++ b/image-deployment-2.sh
@@ -17,7 +17,7 @@
 #
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="image-deployment"
+TESTTYPE="image-deployment gh986"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Disable image-deployment-2 on rhel8 until gh986 is fixed.