### PR TITLE
Fix conf entries in image-2 more

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -46,7 +46,6 @@ rhel8_skip_array=(
   gh774       # autopart-luks-1 failing
   gh830       # packages-weakdeps failing
   gh969       # raid-ddf failing
-  gh986       # image-deployment-2 failing
 )
 
 rhel9_skip_array=(

--- a/image-deployment-2-rhel8.ks.in
+++ b/image-deployment-2-rhel8.ks.in
@@ -1,0 +1,58 @@
+#version=DEVEL
+#test name: image-deployment-2-rhel8
+
+# Test that we can disable modules and installation tasks
+# that are not suitable for the image deployment. Use the
+# package installation in this test, because it is easier
+# to test for now.
+
+# Use defaults for network, bootloader and storage.
+%ksappend network/default.ks
+%ksappend bootloader/default.ks
+%ksappend storage/default.ks
+
+# Install RPM packages.
+%ksappend repos/default.ks
+%ksappend payload/default_packages.ks
+
+# Run the installation in the cmdline mode.
+cmdline
+shutdown
+
+%post --nochroot
+
+# Get the activated Anaconda DBus modules.
+less /tmp/syslog | grep "Activating service name" | \
+grep "org.fedoraproject.Anaconda.Modules" | cut -d"'" -f2 \
+| sort > /tmp/generated.out
+
+# Generate the expected output.
+cat > /tmp/expected.out <<EOF
+org.fedoraproject.Anaconda.Modules.Network
+org.fedoraproject.Anaconda.Modules.Payloads
+org.fedoraproject.Anaconda.Modules.Storage
+EOF
+
+# Check the output
+diff /tmp/expected.out /tmp/generated.out
+
+if [[ $? != 0 ]]; then
+    echo "*** unexpected modules were activated:" >> /mnt/sysroot/root/RESULT
+    cat /tmp/generated.out >> /mnt/sysroot/root/RESULT
+fi
+
+%end
+
+%post --nochroot
+
+# Get the network installation tasks.
+cat /tmp/anaconda.log | grep "installation: Task started:" \
+| grep -i -e "firewall" -e "network"
+
+if [[ $? == 0 ]]; then
+    echo "*** unexpected installation tasks" >> /mnt/sysroot/root/RESULT
+fi
+
+%end
+
+%ksappend validation/success_if_result_empty_standalone.ks

--- a/image-deployment-2-rhel8.sh
+++ b/image-deployment-2-rhel8.sh
@@ -1,0 +1,60 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
+TESTTYPE="image-deployment skip-on-fedora skip-on-rhel-9"
+
+. ${KSTESTDIR}/functions.sh
+
+prepare_updates() {
+    local tmp_dir="${1}"
+    local updates_dir="${tmp_dir}/updates"
+    local updates_img="${tmp_dir}/updates.img"
+    local conf_dir="${updates_dir}/etc/anaconda/conf.d/"
+
+    # Define a configuration snippet.
+    mkdir -p "${conf_dir}"
+    cat > "${conf_dir}/10-bare-metal.conf" <<EOF
+
+[Anaconda]
+# List of enabled Anaconda DBus modules.
+kickstart_modules =
+     org.fedoraproject.Anaconda.Modules.Network
+     org.fedoraproject.Anaconda.Modules.Payloads
+     org.fedoraproject.Anaconda.Modules.Storage
+
+[Installation Target]
+# Should we install the network configuration?
+can_configure_network = False
+
+EOF
+
+    # Apply the provided updates image if any.
+    apply_updates_image "${UPDATES}" "${updates_dir}"
+
+    # Create a new updates image.
+    create_updates_image "${updates_dir}" "${updates_img}"
+
+    # Provide the image. The function prints the URL.
+    upload_updates_image "${tmp_dir}" "${updates_img}"
+}
+
+cleanup() {
+    local tmp_dir="${1}"
+    stop_httpd "${tmp_dir}"
+}

--- a/image-deployment-2.sh
+++ b/image-deployment-2.sh
@@ -17,7 +17,7 @@
 #
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="image-deployment gh986"
+TESTTYPE="image-deployment skip-on-rhel-8"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
The test had to be duplicated because RHEL 8 must use the conf key that is removed on Fedora and deprecated on RHEL 9.

Closes #986