### PR TITLE
Revert "Disable dracut-visible-warnigs tests temporarily (gh#988)"

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -35,7 +35,6 @@ daily_iso_skip_array=(
   rhbz1853668 # multipath device not constructed back after installation
   gh969       # raid-ddf failing
   gh975       # packages-default failing
-  gh988       # dracut-visible-warnings failing
 )
 
 rhel8_skip_array=(

--- a/dracut-visible-warnings.sh
+++ b/dracut-visible-warnings.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="dracut skip-on-rhel-8 gh988"
+TESTTYPE="dracut skip-on-rhel-8"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
This reverts commit da5622d7eb4c3d7f19d3215057540d0e851d470b.

rhbz#2224009 causing the fail of the test has been fixed in GLib.