### PR TITLE
Update some manual storage tests for new minimal ESP size (500MB)

### DIFF
--- a/lvm-luks-1.ks.in
+++ b/lvm-luks-1.ks.in
@@ -12,7 +12,7 @@ clearpart --all --initlabel
 
 reqpart
 part /boot --fstype="ext4" --size=1024
-part pv.1 --fstype="lvmpv" --size=9215
+part pv.1 --fstype="lvmpv" --size=8915
 
 volgroup fedora pv.1
 

--- a/lvm-luks-2.ks.in
+++ b/lvm-luks-2.ks.in
@@ -11,7 +11,7 @@ clearpart --all --initlabel
 
 reqpart
 part /boot --fstype="ext4" --size=1024
-part pv.1 --fstype="lvmpv" --size=9215
+part pv.1 --fstype="lvmpv" --size=8915
 
 volgroup fedora pv.1
 

--- a/lvm-luks-3.ks.in
+++ b/lvm-luks-3.ks.in
@@ -11,7 +11,7 @@ clearpart --all --initlabel
 
 reqpart
 part /boot --fstype="ext4" --size=1024
-part pv.1 --fstype="lvmpv" --size=9215
+part pv.1 --fstype="lvmpv" --size=8915
 
 volgroup fedora pv.1
 

--- a/lvm-luks-4.ks.in
+++ b/lvm-luks-4.ks.in
@@ -11,7 +11,7 @@ clearpart --all --initlabel
 
 reqpart
 part /boot --fstype="ext4" --size=1024
-part pv.1 --fstype="lvmpv" --size=9215
+part pv.1 --fstype="lvmpv" --size=8915
 
 volgroup fedora pv.1
 

--- a/part-luks-1.ks.in
+++ b/part-luks-1.ks.in
@@ -10,7 +10,7 @@ clearpart --all --initlabel
 # Test LUKS 1 with default values.
 
 reqpart
-part / --fstype="ext4" --size=8191 --encrypted --passphrase="passphrase" --luks-version=luks1
+part / --fstype="ext4" --size=7891 --encrypted --passphrase="passphrase" --luks-version=luks1
 part /boot --fstype="ext4" --size=1024
 part swap --fstype="swap" --size=1024
 

--- a/part-luks-2.ks.in
+++ b/part-luks-2.ks.in
@@ -10,7 +10,7 @@ clearpart --all --initlabel
 # Test LUKS 2 with default values.
 
 reqpart
-part / --fstype="ext4" --size=8191 --encrypted --passphrase="passphrase" --luks-version=luks2
+part / --fstype="ext4" --size=7891 --encrypted --passphrase="passphrase" --luks-version=luks2
 part /boot --fstype="ext4" --size=1024
 part swap --fstype="swap" --size=1024
 

--- a/part-luks-3.ks.in
+++ b/part-luks-3.ks.in
@@ -10,7 +10,7 @@ clearpart --all --initlabel
 # Test LUKS 2 with pbkdf2 and the --pbkdf-time option.
 
 reqpart
-part / --fstype="ext4" --size=8191 --encrypted --passphrase="passphrase" --luks-version=luks2 --pbkdf=pbkdf2 --pbkdf-time=10
+part / --fstype="ext4" --size=7891 --encrypted --passphrase="passphrase" --luks-version=luks2 --pbkdf=pbkdf2 --pbkdf-time=10
 part /boot --fstype="ext4" --size=1024
 part swap --fstype="swap" --size=1024
 

--- a/part-luks-4.ks.in
+++ b/part-luks-4.ks.in
@@ -10,7 +10,7 @@ clearpart --all --initlabel
 # Test LUKS 2 with argon2i and options --pbkdf-iterations and --pbkdf-memory.
 
 reqpart
-part / --fstype="ext4" --size=8191 --encrypted --passphrase="passphrase" --luks-version=luks2 --pbkdf=argon2i --pbkdf-iterations=4 --pbkdf-memory=64
+part / --fstype="ext4" --size=7891 --encrypted --passphrase="passphrase" --luks-version=luks2 --pbkdf=argon2i --pbkdf-iterations=4 --pbkdf-memory=64
 part /boot --fstype="ext4" --size=1024
 part swap --fstype="swap" --size=1024
 

--- a/raid-luks-1.ks.in
+++ b/raid-luks-1.ks.in
@@ -12,8 +12,8 @@ clearpart --all --initlabel
 reqpart
 part /boot --fstype="ext4" --size=1024
 part swap --fstype="swap" --size=2048
-part raid.1 --fstype="mdmember" --ondisk=vda --size=7167
-part raid.2 --fstype="mdmember" --ondisk=vdb --size=7167
+part raid.1 --fstype="mdmember" --ondisk=vda --size=6867
+part raid.2 --fstype="mdmember" --ondisk=vdb --size=6867
 
 raid / --device=root --fstype="ext4" --level=RAID1 --encrypted --passphrase="passphrase" --luks-version=luks1 raid.1 raid.2
 

--- a/raid-luks-2.ks.in
+++ b/raid-luks-2.ks.in
@@ -12,8 +12,8 @@ clearpart --all --initlabel
 reqpart
 part /boot --fstype="ext4" --size=1024
 part swap --fstype="swap" --size=2048
-part raid.1 --fstype="mdmember" --ondisk=vda --size=7167
-part raid.2 --fstype="mdmember" --ondisk=vdb --size=7167
+part raid.1 --fstype="mdmember" --ondisk=vda --size=6867
+part raid.2 --fstype="mdmember" --ondisk=vdb --size=6867
 
 raid / --device=root --fstype="ext4" --level=RAID1 --encrypted --passphrase="passphrase" --luks-version=luks2 raid.1 raid.2
 

--- a/raid-luks-3.ks.in
+++ b/raid-luks-3.ks.in
@@ -12,8 +12,9 @@ clearpart --all --initlabel
 reqpart
 part /boot --fstype="ext4" --size=1024
 part swap --fstype="swap" --size=2048
-part raid.1 --fstype="mdmember" --ondisk=vda --size=7167
-part raid.2 --fstype="mdmember" --ondisk=vdb --size=7167
+part raid.1 --fstype="mdmember" --ondisk=vda --size=6867
+part raid.2 --fstype="mdmember" --ondisk=vdb --size=6867
+
 
 raid / --device=root --fstype="ext4" --level=RAID1 --encrypted --passphrase="passphrase" --luks-version=luks2 --pbkdf=pbkdf2 --pbkdf-time=10 raid.1 raid.2
 

--- a/raid-luks-4.ks.in
+++ b/raid-luks-4.ks.in
@@ -12,8 +12,8 @@ clearpart --all --initlabel
 reqpart
 part /boot --fstype="ext4" --size=1024
 part swap --fstype="swap" --size=2048
-part raid.1 --fstype="mdmember" --ondisk=vda --size=7167
-part raid.2 --fstype="mdmember" --ondisk=vdb --size=7167
+part raid.1 --fstype="mdmember" --ondisk=vda --size=6867
+part raid.2 --fstype="mdmember" --ondisk=vdb --size=6867
 
 raid / --device=root --fstype="ext4" --level=RAID1 --encrypted --passphrase="passphrase" --luks-version=luks2 --pbkdf=argon2i --pbkdf-iterations=4 --pbkdf-memory=64 raid.1 raid.2
 


### PR DESCRIPTION
Related to this change:
https://github.com/rhinstaller/anaconda/commit/c253390b23475970f1d696b4fb9d719a0c316559

Minimum size increased by 300MB.

The reason why the tests are manual (and therefore rot a bit not being run daily) are that libvirt has troubles getting the RESULT from the installer image, therefore manual check is needed.

From my local testing seems we can make part-luks-* automatic, I'll follow on it.
I've checked the patch locally, I guess the CI will fail, maybe except for part-luks-*.

Should fix: https://github.com/rhinstaller/kickstart-tests/issues/1000