### PR TITLE
Enable part-luks-* tests on fedora.

### DIFF
--- a/part-luks-1.sh
+++ b/part-luks-1.sh
@@ -17,10 +17,11 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# On RHEL the test is manual because of broken reading of the results from image.
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="manual storage partition luks"
+TESTTYPE="skip-on-rhel storage partition luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/part-luks-2.sh
+++ b/part-luks-2.sh
@@ -17,10 +17,11 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# On RHEL the test is manual because of broken reading of the results from image.
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="manual storage partition luks"
+TESTTYPE="skip-on-rhel storage partition luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/part-luks-3.sh
+++ b/part-luks-3.sh
@@ -17,10 +17,11 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# On RHEL the test is manual because of broken reading of the results from image.
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="manual storage partition luks"
+TESTTYPE="skip-on-rhel storage partition luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/part-luks-4.sh
+++ b/part-luks-4.sh
@@ -17,10 +17,11 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
+# On RHEL the test is manual because of broken reading of the results from image.
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="manual storage partition luks"
+TESTTYPE="skip-on-rhel storage partition luks"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Reading of tests results on Fedora seems to work reliably enough. On RHEL it is not the case.

Depends on https://github.com/rhinstaller/kickstart-tests/pull/1002