### PR TITLE
infra: Raise kstest errors in the permian step

### DIFF
--- a/.github/workflows/scenarios-permian.yml
+++ b/.github/workflows/scenarios-permian.yml
@@ -179,6 +179,14 @@ jobs:
               }
             }'
 
+          # Permian hides the exit code of launcher, so error out this step manually based on logs
+          rc=$( awk '/Runner return code: /{ print $4 }' permian.log)
+          if [ -n "$rc" ]; then
+            exit $rc
+          else
+            exit 111
+          fi
+
       - name: Collect anaconda logs
         if: always()
         uses: actions/upload-artifact@v3
@@ -214,14 +222,3 @@ jobs:
           name: 'results-xunit-${{ matrix.scenario }}'
           path: |
             permian/xunit-*.xml
-
-      # Keep compatibility of the overall results, Permian now hides the exit code of launcher
-      - name: Pass the launch script exit code
-        working-directory: ./permian
-        run: |
-          rc=$( awk '/Runner return code: /{ print $4 }' permian.log)
-          if [ -n "$rc" ]; then
-            exit $rc
-          else
-            exit 111
-          fi


### PR DESCRIPTION
This makes it so that opening the GH web page automatically opens logs with the actual errors. Previously, it showed only a cryptic message "Runner return code: 1". and the actual errors were in a successfully completed step.

I've applied @VladimirSlavik's  https://github.com/rhinstaller/anaconda/commit/7120a788d0216e71305e5bd9da0940ed416c0c92 also here.