### PR TITLE
Fix & enable LUKS tests

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -125,6 +125,33 @@ copy_file_encrypted() {
     run_with_timeout ${COPY_FROM_IMAGE_TIMEOUT} "guestfish --keys-from-stdin --ro ${disks} -i copy-out ${file} ${dir}"
 }
 
+copy_file_encrypted_raid() {
+    disks="$1"
+    file="$2"
+    dir="$3"
+
+    # we only assume 1 RAID device
+    md_device=$(run_with_timeout ${COPY_FROM_IMAGE_TIMEOUT} "guestfish --ro ${disks} launch : list-md-devices" 2>&1)
+    md_devices_count=$(wc -l <<< ${md_device})
+    echo "copy_file_encrypted_raid: md_device: ${md_device}"
+    if [ ${md_devices_count} -ne 1 ]; then
+        echo "Only 1 RAID device supported by encrypted_file_encrypted_raid()" > ${dir}/RESULT
+        echo -e "${md_devices_count} MD devices found:\n${md_device}" >> ${dir}/RESULT
+        exit 1
+    fi
+
+    # the here-string is unindented on purpose, as the passphrase can't contain leading spaces;
+    # it's not possible to use --key /dev/xyz:key:key_string, likely due to a bug?
+    run_with_timeout ${COPY_FROM_IMAGE_TIMEOUT} "guestfish --ro --keys-from-stdin ${disks}" <<< "
+launch
+# the line following after cryptsetup-open contains a LUKS passphrase
+cryptsetup-open ${md_device} encrypted-root
+passphrase
+mount /dev/mapper/encrypted-root /
+copy_out ${file} ${dir}
+"
+}
+
 copy_interesting_files_from_system() {
     local disksdir="$1"
 

--- a/lvm-luks-1.sh
+++ b/lvm-luks-1.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="manual storage lvm luks"
+TESTTYPE="storage lvm luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/lvm-luks-2.sh
+++ b/lvm-luks-2.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="manual storage lvm luks"
+TESTTYPE="storage lvm luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/lvm-luks-3.sh
+++ b/lvm-luks-3.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="manual storage lvm luks"
+TESTTYPE="storage lvm luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/lvm-luks-4.sh
+++ b/lvm-luks-4.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="manual storage lvm luks"
+TESTTYPE="storage lvm luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/part-luks-1.sh
+++ b/part-luks-1.sh
@@ -17,11 +17,9 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
-# On RHEL the test is manual because of broken reading of the results from image.
-# Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="skip-on-rhel storage partition luks"
+TESTTYPE="storage partition luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/part-luks-2.sh
+++ b/part-luks-2.sh
@@ -17,11 +17,9 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
-# On RHEL the test is manual because of broken reading of the results from image.
-# Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="skip-on-rhel storage partition luks"
+TESTTYPE="storage partition luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/part-luks-3.sh
+++ b/part-luks-3.sh
@@ -17,11 +17,9 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
-# On RHEL the test is manual because of broken reading of the results from image.
-# Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="skip-on-rhel storage partition luks"
+TESTTYPE="storage partition luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/part-luks-4.sh
+++ b/part-luks-4.sh
@@ -17,11 +17,9 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 
-# On RHEL the test is manual because of broken reading of the results from image.
-# Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="skip-on-rhel storage partition luks"
+TESTTYPE="storage partition luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-luks-1.sh
+++ b/raid-luks-1.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="manual storage raid luks"
+TESTTYPE="storage raid luks"
 
 . ${KSTESTDIR}/functions.sh
 
@@ -33,5 +33,5 @@ prepare_disks() {
 }
 
 copy_file() {
-    copy_file_encrypted "$@"
+    copy_file_encrypted_raid "$@"
 }

--- a/raid-luks-2.sh
+++ b/raid-luks-2.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="manual storage raid luks"
+TESTTYPE="storage raid luks"
 
 . ${KSTESTDIR}/functions.sh
 
@@ -33,5 +33,5 @@ prepare_disks() {
 }
 
 copy_file() {
-    copy_file_encrypted "$@"
+    copy_file_encrypted_raid "$@"
 }

--- a/raid-luks-3.sh
+++ b/raid-luks-3.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="manual storage raid luks"
+TESTTYPE="storage raid luks"
 
 . ${KSTESTDIR}/functions.sh
 
@@ -33,5 +33,5 @@ prepare_disks() {
 }
 
 copy_file() {
-    copy_file_encrypted "$@"
+    copy_file_encrypted_raid "$@"
 }

--- a/raid-luks-4.sh
+++ b/raid-luks-4.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="manual storage raid luks"
+TESTTYPE="storage raid luks"
 
 . ${KSTESTDIR}/functions.sh
 
@@ -33,5 +33,5 @@ prepare_disks() {
 }
 
 copy_file() {
-    copy_file_encrypted "$@"
+    copy_file_encrypted_raid "$@"
 }


### PR DESCRIPTION
The code copying RESULT file out of encrypted partitionings has been amended/fixed, so the LUKS tests work OK now.

The way guestfish is handled to do this task is somewhat cumbersome, but I couldn't find with a better solution. guestfish is not able to autodetect the partitioning and open/mount the LUKS container, so a series of explicit commands is needed to do so. I tried to combine this approach with --keys-from-stdin or --key <MD device>:key:passphrase, but neither option worked for me.

As I have only fairly limited experience with guestfish so far, I'm not able to tell whether my assumption on how to use the parameters is wrong, whether the options collide with 'manually' entering the commands, or this is a bug. If the latter is the case, I can create a BZ against libguestfs to cover this.
