### PR TITLE
Disable bridge-no-bootopts-net test temporarily on rhel8 (gh1018)

### DIFF
--- a/bridge-no-bootopts-net.sh
+++ b/bridge-no-bootopts-net.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"network"}
+TESTTYPE=${TESTTYPE:-"network gh1018"}
 
 . ${KSTESTDIR}/functions.sh
 

--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -45,6 +45,7 @@ rhel8_skip_array=(
   gh774       # autopart-luks-1 failing
   gh830       # packages-weakdeps failing
   gh969       # raid-ddf failing
+  gh1018      # bridge-no-bootopts-net failing
 )
 
 rhel9_skip_array=(


### PR DESCRIPTION
Disable bridge-no-bootopts-net test on rhel8 until gh1018 is fixed.