### PR TITLE
Disable rpm-ostree temporarily on daily-iso (gh#1023)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -35,6 +35,7 @@ daily_iso_skip_array=(
   rhbz1853668 # multipath device not constructed back after installation
   gh969       # raid-ddf failing
   gh975       # packages-default failing
+  gh1023      # rpm-ostree failing
 )
 
 rhel8_skip_array=(

--- a/rpm-ostree.sh
+++ b/rpm-ostree.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="payload ostree skip-on-rhel"
+TESTTYPE="payload ostree skip-on-rhel gh1023"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Disable rpm-ostree on daily-iso until gh1023 is fixed.