### PR TITLE
Disable mountpoint-assignment-2 temporarily on daily-iso (gh#1028)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -36,6 +36,7 @@ daily_iso_skip_array=(
   gh969       # raid-ddf failing
   gh975       # packages-default failing
   gh1023      # rpm-ostree failing
+  gh1028      # mountpoint-assignment-2 failing
 )
 
 rhel8_skip_array=(

--- a/mountpoint-assignment-2.sh
+++ b/mountpoint-assignment-2.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="mount storage"
+TESTTYPE="mount storage gh1028"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Disable mountpoint-assignment-2 on daily-iso until gh1028 is fixed.