### PR TITLE
Use more RAM for stage2 test getting stage2 via http (gh1033)

### DIFF
--- a/stage2-from-ks.sh
+++ b/stage2-from-ks.sh
@@ -30,5 +30,5 @@ stage2_from_ks() {
 
 # The test needs more RAM because installer image is downloaded from network
 get_required_ram() {
-    echo "2572"
+    echo "2750"
 }


### PR DESCRIPTION
The size of the image has grown by ~100MB recently. The officialy required RAM size is 3GiB, but let's try to be lower here so that we minimize the risk of runnig out of test runner resources (default test is using 2GB of ram and the number of tests run in parallel is counted by this value). Also we will be warned about eventual following image size increase earlier this way.