### PR TITLE
Port rpm-ostree-container to rhel9

### DIFF
--- a/rpm-ostree-container-rhel9.ks.in
+++ b/rpm-ostree-container-rhel9.ks.in
@@ -1,0 +1,36 @@
+#test name: rpm-ostree-container-rhel9
+# https://github.com/rhinstaller/anaconda/pull/5399
+#
+# Test that ostreecontainer ks command works on rhel9.
+# Tests only installation of the palyload.
+# Does not test that the installation is bootable, bootloader is disabled,
+# its installation should be fixed in a follow-up bootupd work.
+
+
+%ksappend common/common.ks
+%ksappend users/default.ks
+%ksappend network/default.ks
+%ksappend l10n/default.ks
+%ksappend storage/default.ks
+
+# Disable the boot loader.
+bootloader --disabled
+
+# Set up the RPM OSTree source.
+ostreecontainer --no-signature-verification --transport=registry --url=quay.io/centos-bootc/centos-bootc:stream9
+
+%post
+
+# Check the url of the remote.
+url="$(ostree remote show-url default)"
+if [ "${url}" != "quay.io/centos-bootc/centos-bootc:stream9" ]; then
+    echo "Unexpected URL: ${url}" >> /root/RESULT
+fi
+
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+
+# Write the result into logs.
+cat /root/RESULT
+%end

--- a/rpm-ostree-container-rhel9.sh
+++ b/rpm-ostree-container-rhel9.sh
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2024  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
+
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
+TESTTYPE="payload ostree skip-on-rhel8 skip-on-fedora"
+
+. ${KSTESTDIR}/functions.sh
+
+validate() {
+    # We are not able to copy files from the system.
+    # Look for the result in the logs we have.
+    local disksdir=$1
+    cat "${disksdir}/virt-install.log" | grep -q "SUCCESS"
+
+    if [[ $? != 0 ]]; then
+        status=1
+        echo '*** The test has failed.'
+        return 1
+    fi
+
+    return 0
+}
+
+get_timeout() {
+    echo "120"
+}


### PR DESCRIPTION
The test has bootloader disabled in kickstart as it will be handled after porting bootupd support to RHEL 9.
WIP of the upstream test with bootupd support: https://github.com/rhinstaller/kickstart-tests/pull/1037 