### PR TITLE
Revert "Disable network-bootopts-bond-bootif temporarily on rhel9 (RH…

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -62,7 +62,6 @@ rhel9_skip_array=(
   gh969       # raid-ddf failing
   gh970       # selinux-contexts failing
   jiraRHEL-13150 # timezone-noncommon failing
-  RHEL-4766   # network-bootopts-bond-bootif should be fixed in RHEL 9.4
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/network-bootopts-bond-bootif.sh
+++ b/network-bootopts-bond-bootif.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"network skip-on-rhel-8 RHEL-4766"}
+TESTTYPE=${TESTTYPE:-"network skip-on-rhel-8"}
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
…EL-4766)"

The bug has been fixed.

This reverts commit 8df45873c74a91bd293b4b3c005fb4fd21cd5c9e.