### PR TITLE
Fix and enable LVM cache tests

### DIFF
--- a/lvm-cache-1.ks.in
+++ b/lvm-cache-1.ks.in
@@ -102,16 +102,16 @@ if [ $? != 0 ]; then
 fi
 
 # verify size of root LV's cache (1500 - 8 [pmspare])
-root_cache_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/root_cache | sed -r 's/\s*([0-9]+)\..*/\1/')
-root_cache_md_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/root_cache_cmeta | sed -r 's/\s*([0-9]+)\..*/\1/')
+root_cache_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/root_cache_cpool | sed -r 's/\s*([0-9]+)\..*/\1/')
+root_cache_md_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/root_cache_cpool_cmeta | sed -r 's/\s*([0-9]+)\..*/\1/')
 root_cache_all=$(($root_cache_size + $root_cache_md_size))
 if [ "$root_cache_all" != "1492" ]; then
     echo "*** root LV's cache has incorrect size" >> /root/RESULT
 fi
 
 # verify size of home LV's cache
-home_cache_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/home_cache | sed -r 's/\s*([0-9]+)\..*/\1/')
-home_cache_md_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/home_cache_cmeta | sed -r 's/\s*([0-9]+)\..*/\1/')
+home_cache_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/home_cache_cpool | sed -r 's/\s*([0-9]+)\..*/\1/')
+home_cache_md_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/home_cache_cpool_cmeta | sed -r 's/\s*([0-9]+)\..*/\1/')
 home_cache_all=$(($home_cache_size + $home_cache_md_size))
 if [ "$home_cache_all" != "1500" ]; then
     echo "*** home LV's cache has incorrect size" >> /root/RESULT
@@ -132,38 +132,38 @@ fi
 # verify caches are using (only) the right (aka "faster") PV for both data and metadata
 fast_pv=$(pvs --noheadings -o name,size --unit m --nosuffix|egrep '3[0-9]{3}'|sed -r 's/\s+(\S+)\s+.*/\1/')
 
-root_cache_num_pvs=$(lvs -a --noheadings -o devices fedora/root_cache_cdata|wc -l)
+root_cache_num_pvs=$(lvs -a --noheadings -o devices fedora/root_cache_cpool_cdata|wc -l)
 if [ "$root_cache_num_pvs" != "1" ]; then
     echo "*** root LV's cache is using multiple PVs" >> /root/RESULT
 fi
-home_cache_num_pvs=$(lvs -a --noheadings -o devices fedora/home_cache_cdata|wc -l)
+home_cache_num_pvs=$(lvs -a --noheadings -o devices fedora/home_cache_cpool_cdata|wc -l)
 if [ "$home_cache_num_pvs" != "1" ]; then
     echo "*** home LV's cache is using multiple PVs" >> /root/RESULT
 fi
 
-root_cache_num_pvs=$(lvs -a --noheadings -o devices fedora/root_cache_cmeta|wc -l)
+root_cache_num_pvs=$(lvs -a --noheadings -o devices fedora/root_cache_cpool_cmeta|wc -l)
 if [ "$root_cache_num_pvs" != "1" ]; then
     echo "*** root LV's cache (meta) is using multiple PVs" >> /root/RESULT
 fi
-home_cache_num_pvs=$(lvs -a --noheadings -o devices fedora/home_cache_cmeta|wc -l)
+home_cache_num_pvs=$(lvs -a --noheadings -o devices fedora/home_cache_cpool_cmeta|wc -l)
 if [ "$home_cache_num_pvs" != "1" ]; then
     echo "*** home LV's cache (meta) is using multiple PVs" >> /root/RESULT
 fi
 
-root_cache_pv=$(lvs -a --noheadings -o devices fedora/root_cache_cdata|sed -r 's/\s*([^(]+)\(.*/\1/')
+root_cache_pv=$(lvs -a --noheadings -o devices fedora/root_cache_cpool_cdata|sed -r 's/\s*([^(]+)\(.*/\1/')
 if [ "$root_cache_pv" != "$fast_pv" ]; then
     echo "*** root LV's cache is using wrong PV" >> /root/RESULT
 fi
-home_cache_pv=$(lvs -a --noheadings -o devices fedora/home_cache_cdata|sed -r 's/\s*([^(]+)\(.*/\1/')
+home_cache_pv=$(lvs -a --noheadings -o devices fedora/home_cache_cpool_cdata|sed -r 's/\s*([^(]+)\(.*/\1/')
 if [ "$home_cache_pv" != "$fast_pv" ]; then
     echo "*** home LV's cache is using wrong PV" >> /root/RESULT
 fi
 
-root_cache_pv=$(lvs -a --noheadings -o devices fedora/root_cache_cmeta|sed -r 's/\s*([^(]+)\(.*/\1/')
+root_cache_pv=$(lvs -a --noheadings -o devices fedora/root_cache_cpool_cmeta|sed -r 's/\s*([^(]+)\(.*/\1/')
 if [ "$root_cache_pv" != "$fast_pv" ]; then
     echo "*** root LV's cache (meta) is using wrong PV" >> /root/RESULT
 fi
-home_cache_pv=$(lvs -a --noheadings -o devices fedora/home_cache_cmeta|sed -r 's/\s*([^(]+)\(.*/\1/')
+home_cache_pv=$(lvs -a --noheadings -o devices fedora/home_cache_cpool_cmeta|sed -r 's/\s*([^(]+)\(.*/\1/')
 if [ "$home_cache_pv" != "$fast_pv" ]; then
     echo "*** home LV's cache (meta) is using wrong PV" >> /root/RESULT
 fi

--- a/lvm-cache-1.sh
+++ b/lvm-cache-1.sh
@@ -17,10 +17,9 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-# blivet crashes with BlockDev.LVMError: https://bugzilla.redhat.com/show_bug.cgi?id=1886767
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="lvm storage knownfailure"
+TESTTYPE="lvm storage"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/lvm-cache-2.ks.in
+++ b/lvm-cache-2.ks.in
@@ -104,16 +104,16 @@ if [ $? != 0 ]; then
 fi
 
 # verify size of root LV's cache (1000 - 8 [pmspare])
-root_cache_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/root_cache | sed -r 's/\s*([0-9]+)\..*/\1/')
-root_cache_md_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/root_cache_cmeta | sed -r 's/\s*([0-9]+)\..*/\1/')
+root_cache_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/root_cache_cpool | sed -r 's/\s*([0-9]+)\..*/\1/')
+root_cache_md_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/root_cache_cpool_cmeta | sed -r 's/\s*([0-9]+)\..*/\1/')
 root_cache_all=$(($root_cache_size + $root_cache_md_size))
 if [ "$root_cache_all" != "992" ]; then
     echo "*** root LV's cache has incorrect size" >> /root/RESULT
 fi
 
 # verify size of home LV's cache
-home_cache_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/home_cache | sed -r 's/\s*([0-9]+)\..*/\1/')
-home_cache_md_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/home_cache_cmeta | sed -r 's/\s*([0-9]+)\..*/\1/')
+home_cache_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/home_cache_cpool | sed -r 's/\s*([0-9]+)\..*/\1/')
+home_cache_md_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/home_cache_cpool_cmeta | sed -r 's/\s*([0-9]+)\..*/\1/')
 home_cache_all=$(($home_cache_size + $home_cache_md_size))
 if [ "$home_cache_all" != "1000" ]; then
     echo "*** home LV's cache has incorrect size" >> /root/RESULT
@@ -134,38 +134,38 @@ fi
 # verify caches are using (only) the right (aka "faster") PV for both data and metadata
 fast_pv=$(pvs --noheadings -o name,size --unit m --nosuffix|egrep '3[0-9]{3}'|sed -r 's/\s+(\S+)\s+.*/\1/')
 
-root_cache_num_pvs=$(lvs -a --noheadings -o devices fedora/root_cache_cdata|wc -l)
+root_cache_num_pvs=$(lvs -a --noheadings -o devices fedora/root_cache_cpool_cdata|wc -l)
 if [ "$root_cache_num_pvs" != "1" ]; then
     echo "*** root LV's cache is using multiple PVs" >> /root/RESULT
 fi
-home_cache_num_pvs=$(lvs -a --noheadings -o devices fedora/home_cache_cdata|wc -l)
+home_cache_num_pvs=$(lvs -a --noheadings -o devices fedora/home_cache_cpool_cdata|wc -l)
 if [ "$home_cache_num_pvs" != "1" ]; then
     echo "*** home LV's cache is using multiple PVs" >> /root/RESULT
 fi
 
-root_cache_num_pvs=$(lvs -a --noheadings -o devices fedora/root_cache_cmeta|wc -l)
+root_cache_num_pvs=$(lvs -a --noheadings -o devices fedora/root_cache_cpool_cmeta|wc -l)
 if [ "$root_cache_num_pvs" != "1" ]; then
     echo "*** root LV's cache (meta) is using multiple PVs" >> /root/RESULT
 fi
-home_cache_num_pvs=$(lvs -a --noheadings -o devices fedora/home_cache_cmeta|wc -l)
+home_cache_num_pvs=$(lvs -a --noheadings -o devices fedora/home_cache_cpool_cmeta|wc -l)
 if [ "$home_cache_num_pvs" != "1" ]; then
     echo "*** home LV's cache (meta) is using multiple PVs" >> /root/RESULT
 fi
 
-root_cache_pv=$(lvs -a --noheadings -o devices fedora/root_cache_cdata|sed -r 's/\s*([^(]+)\(.*/\1/')
+root_cache_pv=$(lvs -a --noheadings -o devices fedora/root_cache_cpool_cdata|sed -r 's/\s*([^(]+)\(.*/\1/')
 if [ "$root_cache_pv" != "$fast_pv" ]; then
     echo "*** root LV's cache is using wrong PV" >> /root/RESULT
 fi
-home_cache_pv=$(lvs -a --noheadings -o devices fedora/home_cache_cdata|sed -r 's/\s*([^(]+)\(.*/\1/')
+home_cache_pv=$(lvs -a --noheadings -o devices fedora/home_cache_cpool_cdata|sed -r 's/\s*([^(]+)\(.*/\1/')
 if [ "$home_cache_pv" != "$fast_pv" ]; then
     echo "*** home LV's cache is using wrong PV" >> /root/RESULT
 fi
 
-root_cache_pv=$(lvs -a --noheadings -o devices fedora/root_cache_cmeta|sed -r 's/\s*([^(]+)\(.*/\1/')
+root_cache_pv=$(lvs -a --noheadings -o devices fedora/root_cache_cpool_cmeta|sed -r 's/\s*([^(]+)\(.*/\1/')
 if [ "$root_cache_pv" != "$fast_pv" ]; then
     echo "*** root LV's cache (meta) is using wrong PV" >> /root/RESULT
 fi
-home_cache_pv=$(lvs -a --noheadings -o devices fedora/home_cache_cmeta|sed -r 's/\s*([^(]+)\(.*/\1/')
+home_cache_pv=$(lvs -a --noheadings -o devices fedora/home_cache_cpool_cmeta|sed -r 's/\s*([^(]+)\(.*/\1/')
 if [ "$home_cache_pv" != "$fast_pv" ]; then
     echo "*** home LV's cache (meta) is using wrong PV" >> /root/RESULT
 fi

--- a/lvm-cache-2.sh
+++ b/lvm-cache-2.sh
@@ -17,10 +17,9 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-# blivet crashes with BlockDev.LVMError: https://bugzilla.redhat.com/show_bug.cgi?id=1886767
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="lvm storage knownfailure"
+TESTTYPE="lvm storage"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
LVM started adding _cpool to the internal cache pool LVs so the checks needs to be adjusted to this change.