### PR TITLE
Fix kickstart tests with deprecated timezone options

### DIFF
--- a/container.ks.in
+++ b/container.ks.in
@@ -19,7 +19,8 @@ bootloader --disabled
 # Disable the NTP service.
 keyboard us
 lang en_US.UTF-8
-timezone Etc/UTC --utc --nontp
+timezone Etc/UTC --utc
+timesource --ntp-disable
 
 # Create only / with the ext4 filesystem type.
 autopart --type=plain --fstype=ext4 --nohome --noboot --noswap

--- a/fragments/platform/fedora_rawhide/timezone/ntp_disabled.ks
+++ b/fragments/platform/fedora_rawhide/timezone/ntp_disabled.ks
@@ -1,0 +1,5 @@
+# Set up the timezone.
+timezone --utc Europe/Prague
+
+# Disable NTP.
+timesource --ntp-disable

--- a/fragments/platform/fedora_rawhide/timezone/ntp_enabled.ks
+++ b/fragments/platform/fedora_rawhide/timezone/ntp_enabled.ks
@@ -1,0 +1,5 @@
+# Set up the timezone.
+timezone --utc Europe/Prague
+
+# Enable NTP.
+timesource --ntp-server ntp.cesnet.cz

--- a/fragments/platform/rhel8/timezone/ntp_disabled.ks
+++ b/fragments/platform/rhel8/timezone/ntp_disabled.ks
@@ -1,0 +1,2 @@
+# Set up the timezone and disable NTP.
+timezone --utc --nontp Europe/Prague

--- a/fragments/platform/rhel8/timezone/ntp_enabled.ks
+++ b/fragments/platform/rhel8/timezone/ntp_enabled.ks
@@ -1,0 +1,2 @@
+# Set up the timezone and enable NTP.
+timezone --utc --ntpservers=ntp.cesnet.cz Europe/Prague

--- a/fragments/platform/rhel9/timezone/ntp_disabled.ks
+++ b/fragments/platform/rhel9/timezone/ntp_disabled.ks
@@ -1,0 +1,5 @@
+# Set up the timezone.
+timezone --utc Europe/Prague
+
+# Disable NTP.
+timesource --ntp-disable

--- a/fragments/platform/rhel9/timezone/ntp_enabled.ks
+++ b/fragments/platform/rhel9/timezone/ntp_enabled.ks
@@ -1,0 +1,5 @@
+# Set up the timezone.
+timezone --utc Europe/Prague
+
+# Enable NTP.
+timesource --ntp-server ntp.cesnet.cz

--- a/ntp-nontp-without-chrony-gui.ks.in
+++ b/ntp-nontp-without-chrony-gui.ks.in
@@ -3,9 +3,9 @@
 %ksappend repos/default.ks
 network --bootproto=dhcp
 
-# test timezone in GUI mode
-# with --nontp and -chrony
-timezone --utc --nontp Europe/Prague
+# test timezone in GUI mode with NTP disabled and no chrony
+%ksappend timezone/ntp_disabled.ks
+graphical
 
 bootloader --timeout=1
 zerombr

--- a/ntp-nontp-without-chrony.ks.in
+++ b/ntp-nontp-without-chrony.ks.in
@@ -3,10 +3,9 @@
 %ksappend repos/default.ks
 network --bootproto=dhcp
 
-# test timezone in text mode
-# --nontp and -chrony
+# test timezone in text mode with NTP disabled and no chrony
+%ksappend timezone/ntp_disabled.ks
 text
-timezone --utc --nontp Europe/Prague
 
 bootloader --timeout=1
 zerombr

--- a/ntp-with-nontp-gui.ks.in
+++ b/ntp-with-nontp-gui.ks.in
@@ -3,9 +3,9 @@
 %ksappend repos/default.ks
 network --bootproto=dhcp
 
-# test timezone in GUI mode
-# with --nontp
-timezone --utc --nontp Europe/Prague
+# test timezone in GUI mode with NTP disabled
+%ksappend timezone/ntp_disabled.ks
+graphical
 
 bootloader --timeout=1
 zerombr

--- a/ntp-with-nontp.ks.in
+++ b/ntp-with-nontp.ks.in
@@ -3,10 +3,9 @@
 %ksappend repos/default.ks
 network --bootproto=dhcp
 
-# test timezone in text mode
-# with --nontp
+# test timezone in text mode with NTP disabled
+%ksappend timezone/ntp_disabled.ks
 text
-timezone --utc --nontp Europe/Prague
 
 bootloader --timeout=1
 zerombr

--- a/ntp-without-chrony-gui.ks.in
+++ b/ntp-without-chrony-gui.ks.in
@@ -3,9 +3,9 @@
 %ksappend repos/default.ks
 network --bootproto=dhcp
 
-# test timezone in GUI mode
-# with --chrony
-timezone --utc --ntpservers=ntp.cesnet.cz Europe/Prague
+# test timezone in GUI mode without chrony
+%ksappend timezone/ntp_enabled.ks
+graphical
 
 bootloader --timeout=1
 zerombr

--- a/ntp-without-chrony.ks.in
+++ b/ntp-without-chrony.ks.in
@@ -3,10 +3,9 @@
 %ksappend repos/default.ks
 network --bootproto=dhcp
 
-# test timezone in test mode
-# with --chrony
+# test timezone in TUI mode without chrony
+%ksappend timezone/ntp_enabled.ks
 text
-timezone --utc --ntpservers=ntp.cesnet.cz Europe/Prague
 
 bootloader --timeout=1
 zerombr


### PR DESCRIPTION
Anaconda removed support for the timezone --isUtc, --ntpservers and --nontp kickstart options. These options were fully deprecated in Fedora 40. See: https://github.com/rhinstaller/anaconda/pull/5437

**TODO:**

- [x] Test with Fedora.
- [x] Test with RHEL 9.
- [x] Test with RHEL 8.