### PR TITLE
Disable rhel8 failing tests for coreutils-common issue (gh#1055)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -48,6 +48,7 @@ rhel8_skip_array=(
   gh969       # raid-ddf failing
   gh1018      # bridge-no-bootopts-net failing
   jiraRHEL-13151 # timezone-noncommon failing
+  gh1055      # 12 tests failing due to RHEL-25020
 )
 
 rhel9_skip_array=(

--- a/default-systemd-target-gui-graphical-provides.sh
+++ b/default-systemd-target-gui-graphical-provides.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="services"
+TESTTYPE="services gh1055"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/validate-lib-services.sh

--- a/default-systemd-target-tui-graphical-provides.sh
+++ b/default-systemd-target-tui-graphical-provides.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="services"
+TESTTYPE="services gh1055"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/validate-lib-services.sh

--- a/default-systemd-target-vnc-graphical-provides.sh
+++ b/default-systemd-target-vnc-graphical-provides.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="services gh890"
+TESTTYPE="services gh890 gh1055"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/validate-lib-services.sh

--- a/lvm-2.sh
+++ b/lvm-2.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="lvm storage"
+TESTTYPE="lvm storage gh1055"
 
 . ${KSTESTDIR}/functions.sh

--- a/reboot-initial-setup-gui.sh
+++ b/reboot-initial-setup-gui.sh
@@ -17,7 +17,7 @@
 #
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="reboot initial-setup smoke"
+TESTTYPE="reboot initial-setup smoke gh1055"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/rootpw-basic.sh
+++ b/rootpw-basic.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="users coverage"
+TESTTYPE="users coverage gh1055"
 
 . ${KSTESTDIR}/functions.sh

--- a/rootpw-crypted.sh
+++ b/rootpw-crypted.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="users"
+TESTTYPE="users gh1055"
 
 . ${KSTESTDIR}/functions.sh

--- a/rootpw-lock-no-password.sh
+++ b/rootpw-lock-no-password.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="users"
+TESTTYPE="users gh1055"
 
 . ${KSTESTDIR}/functions.sh

--- a/rootpw-lock.sh
+++ b/rootpw-lock.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="users coverage"
+TESTTYPE="users coverage gh1055"
 
 . ${KSTESTDIR}/functions.sh

--- a/user-locked-root-locked-admin.sh
+++ b/user-locked-root-locked-admin.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="users"
+TESTTYPE="users gh1055"
 
 . ${KSTESTDIR}/functions.sh

--- a/user-multiple-wheel-no-root.sh
+++ b/user-multiple-wheel-no-root.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="users"
+TESTTYPE="users gh1055"
 
 . ${KSTESTDIR}/functions.sh

--- a/user-wheel-no-root.sh
+++ b/user-wheel-no-root.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="users"
+TESTTYPE="users gh1055"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Disable failing rhel8 tests until gh#1055 is fixed.

Caused by RHEL-25020

This will fix also daily build of rhel8 boot iso: https://github.com/rhinstaller/kickstart-tests/actions/workflows/daily-boot-iso-rhel8.yml (failing on these tests being in `coverage` group).