### PR TITLE
Fix and enable DDF RAID tests

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -33,7 +33,6 @@ daily_iso_skip_array=(
   gh890       # default-systemd-target-vnc-graphical-provides flaking too much
   gh871       # basic-ftp failing due to mirror
   rhbz1853668 # multipath device not constructed back after installation
-  gh969       # raid-ddf failing
   gh975       # packages-default failing
   gh1023      # rpm-ostree failing
 )
@@ -45,7 +44,6 @@ rhel8_skip_array=(
   gh595       # proxy-cmdline failing on all scenarios
   gh774       # autopart-luks-1 failing
   gh830       # packages-weakdeps failing
-  gh969       # raid-ddf failing
   gh1018      # bridge-no-bootopts-net failing
 )
 
@@ -58,7 +56,6 @@ rhel9_skip_array=(
   gh641       # packages-multilib failing on systemd conflict
   gh774       # autopart-luks-1 failing
   gh790       # repo-addrepo-hd-tree failing
-  gh969       # raid-ddf failing
   gh970       # selinux-contexts failing
 )
 

--- a/raid-ddf.sh
+++ b/raid-ddf.sh
@@ -21,7 +21,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="raid storage skip-on-fedora gh969"
+TESTTYPE="raid storage"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-ddf.sh
+++ b/raid-ddf.sh
@@ -39,3 +39,21 @@ additional_runner_args() {
     echo "--wait $(get_timeout)"
 }
 
+validate() {
+    disksdir=$1
+    args=$(for d in ${disksdir}/disk-*img; do echo -a ${d}; done)
+
+    # There should be a /root/RESULT file with results in it.  Check
+    # its contents and decide whether the test finally succeeded or
+    # not.
+    result=$(run_with_timeout ${COPY_FROM_IMAGE_TIMEOUT} "virt-cat ${args} -m /dev/disk/by-label/rootfs /root/RESULT")
+    if [[ $? != 0 ]]; then
+        status=1
+        echo '*** /root/RESULT does not exist in VM image.'
+    elif [[ "${result}" != SUCCESS* ]]; then
+        status=1
+        echo "${result}"
+    fi
+
+    return ${status}
+}


### PR DESCRIPTION
The issue with `validate` is the only problem I found with this test, otherwise it seems to be working OK on both Fedora and RHEL.