### PR TITLE
Collect virt-install log when running a test.

### DIFF
--- a/.github/workflows/scenarios-permian.yml
+++ b/.github/workflows/scenarios-permian.yml
@@ -194,7 +194,7 @@ jobs:
           name: 'logs-${{ matrix.scenario }}'
           # skip the /anaconda subdirectories, too large
           path: |
-            kickstart-tests/data/logs/kstest.log
+            kickstart-tests/data/logs/kstest*.log
             kickstart-tests/data/logs/kstest.log.json
             kickstart-tests/data/logs/kstest-*/*.log
             kickstart-tests/data/logs/kstest-*/anaconda/lorax-packages.log

--- a/containers/runner/run-kstest
+++ b/containers/runner/run-kstest
@@ -93,6 +93,7 @@ find /var/tmp/kstest-* -name "*.img" -delete
 cp $TEST_LOG ${LOGS_DIR}
 cp $TEST_LOG.json ${LOGS_DIR}
 cp /var/tmp/kstest-list ${LOGS_DIR}
+cp /var/tmp/kstest.virt-install.log ${LOGS_DIR}
 # Move to target logs directory; this sometimes fails on nested directory permission/ownership
 cp -pr /var/tmp/kstest-* ${LOGS_DIR} || true
 

--- a/scripts/run_kickstart_tests.sh
+++ b/scripts/run_kickstart_tests.sh
@@ -478,6 +478,10 @@ fi
 find /var/tmp/kstest-* -type d -print -exec chmod 755 {} + 2>/dev/null || \
     find /var/tmp/kstest-* -type d -print -exec chmod 755 {} +
 
+# Logs from remote runners are not gathered.
+echo "copying virt-install command log"
+cp ~/.cache/virt-manager/virt-install.log /var/tmp/kstest.virt-install.log
+
 # Return exit code from above.  This is structure for future improvement,
 # you can do a cleaning here.
 echo "test finished"


### PR DESCRIPTION
The log is useful when the test fails with "Problem starting virtual install".

The log will not be collected from remote runners. The remote runners functionality (TEST_REMOTES enviroment variable) is not used since a few years ago as the distribution of the tests to runners would be done on higher level now.

As can be perhaps seen from the PR, kickstart tests would deserve some logging consolidation, but it is an issue of bigger size.