### PR TITLE
Do not require os detection to succeed for virt-install

### DIFF
--- a/containers/runner/launch
+++ b/containers/runner/launch
@@ -149,5 +149,6 @@ $CRUN run -it --rm --device=/dev/kvm --publish 127.0.0.1::16509 $PODMAN_SELINUX_
     --env KSTESTS_TEST="$KSTESTS_TEST" --env TESTTYPE="${TESTTYPE:-}" --env SKIP_TESTTYPES="${SKIP_TESTTYPES:-}" \
     --env KSTESTS_RUN_TIMEOUT="${TIMEOUT:-}" \
     --env TEST_JOBS="$TEST_JOBS" --env PLATFORM="${PLATFORM:-}" --env TEST_RETRY="${TEST_RETRY:-}" ${UPDATES_IMG_ARGS:-} ${CONTAINER_RUN_ARGS:-} \
+    --env VIRTINSTALL_OSINFO_DISABLE_REQUIRE=1 \
     ${VAR_TMP:-} -v "$PWD/data:/opt/kstest/data:z" -v "$BASEDIR:/kickstart-tests:ro,z" ${DEFAULTS_SH_ARGS:-} \
     $CONTAINER $RUN_COMMAND


### PR DESCRIPTION
Following the hint showed on the failure:

```
[Wed, 28 Feb 2024 12:53:17 virt-install 604] ERROR (cli:257). --os-variant/--osinfo OS name is required, but no value was set or detected.

This is now a fatal error. Specifying an OS name is required for modern, performant, and secure virtual machine defaults.

If you expected virt-install to detect an OS name from the install media, you can set a fallback OS name with:

  --osinfo detect=on,name=OSNAME

You can see a full list of possible OS name values with:

   virt-install --osinfo list

If your Linux distro is not listed, try one of generic values such as: linux2022, linux2020, linux2018, linux2016

If you just need to get the old behavior back, you can use:

  --osinfo detect=on,require=off

Or export VIRTINSTALL_OSINFO_DISABLE_REQUIRE=1
```

We are hitting the issue with new RHEL 10 isos and for F40: https://github.com/rhinstaller/anaconda/pull/5478#issuecomment-1968944621