### PR TITLE
Add RHEL 10 platform support

### DIFF
--- a/fragments/platform/rhel10/payload/default_packages.ks
+++ b/fragments/platform/rhel10/payload/default_packages.ks
@@ -1,0 +1,3 @@
+# Default RHEL10 packages section (empty)
+%packages
+%end

--- a/fragments/platform/rhel10/payload/ostreecontainer.ks
+++ b/fragments/platform/rhel10/payload/ostreecontainer.ks
@@ -1,0 +1,1 @@
+ostreecontainer --no-signature-verification --transport=registry --url=quay.io/centos-bootc/centos-bootc:stream10

--- a/fragments/platform/rhel10/payload/unified_packages.ks
+++ b/fragments/platform/rhel10/payload/unified_packages.ks
@@ -1,0 +1,7 @@
+# RHEL 10 packages section from unified DVD.
+# The unified DVD should contain under one link both BaseOS and AppStream so install AppStream specific package.
+
+%packages
+# Anaconda package is part of the AppStream repository. It is not contained in the BaseOS.
+anaconda
+%end

--- a/fragments/platform/rhel10/repos/default.ks
+++ b/fragments/platform/rhel10/repos/default.ks
@@ -1,0 +1,3 @@
+# Default RHEL10 repositories - BeseOS + AppStream or unified repo can be used
+url --url @KSTEST_URL@
+repo --name=appstream --baseurl @KSTEST_MODULAR_URL@

--- a/fragments/platform/rhel10/repos/unified-nfs.ks
+++ b/fragments/platform/rhel10/repos/unified-nfs.ks
@@ -1,0 +1,2 @@
+# Unified ISO for RHEL-10 served on NFS server
+nfs --server NFS_SERVER --dir NFS_DIR

--- a/fragments/platform/rhel10/repos/unified.ks
+++ b/fragments/platform/rhel10/repos/unified.ks
@@ -1,0 +1,3 @@
+# Unified ISO for RHEL 10 served on http server
+# BaseOS and AppStream repositories should be loaded automatically from the unified repo
+url RHEL10_UNIFIED_REPO_URL_GOES_HERE

--- a/fragments/platform/rhel10/section-data/hello-world.ks
+++ b/fragments/platform/rhel10/section-data/hello-world.ks
@@ -1,0 +1,3 @@
+# Create a variable in the %pre section with a link to the archived repository of Hello Word.
+# The curl tool will download this archive and unpack it in the system.
+ADDON_SOURCE="https://github.com/rhinstaller/hello-world-anaconda-addon/archive/master.tar.gz"

--- a/fragments/platform/rhel10/section-data/server-dvd-link.ks
+++ b/fragments/platform/rhel10/section-data/server-dvd-link.ks
@@ -1,0 +1,7 @@
+# Create a variable in the pre/post section with link to a RHEL DVD.
+# The curl tool will download this ISO and it will be processed later in the section.
+_LINK=<ADD_LINK_TO_RHEL-10_ISO_HERE>
+ISO_LOCATION="$(curl -L $_LINK | grep -Po "RHEL-10.*?-x86_64-dvd1.iso" | head -n 1)"
+ISO_LOCATION="${_LINK}/${ISO_LOCATION}"
+
+echo $ISO_LOCATION

--- a/fragments/platform/rhel10/section-data/unified-iso.ks
+++ b/fragments/platform/rhel10/section-data/unified-iso.ks
@@ -1,0 +1,3 @@
+# Create a variable in the pre/post section with link to a RHEL-10 unified ISO
+# The curl tool will download this ISO and it will be processed later in the section.
+ISO_LOCATION=<link to a unified ISO>

--- a/fragments/platform/rhel10/timezone/ntp_disabled.ks
+++ b/fragments/platform/rhel10/timezone/ntp_disabled.ks
@@ -1,0 +1,5 @@
+# Set up the timezone.
+timezone --utc Europe/Prague
+
+# Disable NTP.
+timesource --ntp-disable

--- a/fragments/platform/rhel10/timezone/ntp_enabled.ks
+++ b/fragments/platform/rhel10/timezone/ntp_enabled.ks
@@ -1,0 +1,5 @@
+# Set up the timezone.
+timezone --utc Europe/Prague
+
+# Enable NTP.
+timesource --ntp-server ntp.cesnet.cz

--- a/fragments/platform/rhel10/validation/unified.ks
+++ b/fragments/platform/rhel10/validation/unified.ks
@@ -1,0 +1,6 @@
+# Validate installed packages on RHEL 10 system.
+
+# Check that the anaconda package was correctly installed.
+if ! rpm -q anaconda ; then
+    echo '*** anaconda package was not installed!' >> /root/RESULT
+fi

--- a/scripts/defaults-rhel10.sh
+++ b/scripts/defaults-rhel10.sh
@@ -1,0 +1,6 @@
+# Default settings for testing RHEL 10. This requires being inside the Red Hat VPN.
+
+source network-device-names.cfg
+export KSTEST_URL='http://download.eng.bos.redhat.com/rhel-10/nightly/RHEL-10-Public-Beta/latest-RHEL-10.0/compose/BaseOS/x86_64/os/'
+export KSTEST_MODULAR_URL='http://download.eng.bos.redhat.com/rhel-10/nightly/RHEL-10-Public-Beta/latest-RHEL-10.0/compose/AppStream/x86_64/os/'
+export KSTEST_FTP_URL='ftp://ftp.tu-chemnitz.de/pub/linux/fedora/linux/development/rawhide/Everything/$basearch/os/'


### PR DESCRIPTION
For RHEL 10 adds:
- default repositories
- platform ks fragments

~~With the PR it should be possible to run kstests with RHEL 10 boot.iso locally updating the KSTEST_URL - it is still empty, so marking as DRAFT.~~

PRs for adding rhel10 scenario for daily runs (https://github.com/rhinstaller/kickstart-tests/pull/1071) and workflow for test on PR on rhel-10 anaconda branch will follow.