### PR TITLE
Update prefixdevname test for fedora

### DIFF
--- a/network-prefixdevname.ks.in
+++ b/network-prefixdevname.ks.in
@@ -1,4 +1,5 @@
 #test name: network-prefixdevname
+# Tests the prefixdevname feature (rhbz#2267227)
 %ksappend repos/default.ks
 
 %include /tmp/ksinclude
@@ -24,6 +25,8 @@ shutdown
 
 @KSINCLUDE@ post-nochroot-lib-network.sh
 
+pass_autoconnections_info_to_chroot
+
 check_gui_configurations kstest0 kstest1 kstest2 kstest3 team0
 
 %end
@@ -37,7 +40,13 @@ check_device_connected kstest0 yes
 check_device_config_value kstest0 ONBOOT yes connection autoconnect __NONE
 
 # Device not activated in initramfs should be renamed as well (#1643515)
-check_device_connected kstest1 no
+detect_nm_has_autoconnections_off
+nm_has_autoconnections_off=$?
+if [[ $nm_has_autoconnections_off -eq 0 ]]; then
+    check_device_connected kstest1 no
+else
+    check_device_connected kstest1 yes
+fi
 
 # Virtual (team) devices created in installer should not be renamed (#1644294)
 check_device_config_value team0 ONBOOT no connection autoconnect false

--- a/network-prefixdevname.sh
+++ b/network-prefixdevname.sh
@@ -26,7 +26,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"network skip-on-fedora"}
+TESTTYPE=${TESTTYPE:-"network"}
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
The Travis ci test should start passing when https://bugzilla.redhat.com/show_bug.cgi?id=2267227 is in rawhide.