### PR TITLE
Add rhel10 daily testplan

### DIFF
--- a/testlib/test_plans/daily-rhel10.plan.yaml.j2
+++ b/testlib/test_plans/daily-rhel10.plan.yaml.j2
@@ -1,0 +1,15 @@
+name: daily rhel10
+description: Daily run on a RHEL 10 compose
+point_person: rvykydal@redhat.com
+artifact_type: github.scheduled.daily.kstest.rhel10
+verified_by:
+  test_cases:
+    query: '
+{% for tag in skiptags %}
+            "{{ tag }}" not in tc.tags and
+{% endfor %}
+            True'
+configurations:
+  - architecture: x86_64
+reporting:
+  - type: xunit

--- a/testlib/test_plans/daily-rhel8.plan.yaml.j2
+++ b/testlib/test_plans/daily-rhel8.plan.yaml.j2
@@ -1,5 +1,5 @@
 name: daily rhel8
-description: Daily run on current RHEL 8 development compose
+description: Daily run on a RHEL 8 compose
 point_person: rvykydal@redhat.com
 artifact_type: github.scheduled.daily.kstest.rhel8
 verified_by:

--- a/testlib/test_plans/daily-rhel9.plan.yaml.j2
+++ b/testlib/test_plans/daily-rhel9.plan.yaml.j2
@@ -1,5 +1,5 @@
 name: daily rhel9
-description: Daily run on current RHEL 9 development compose
+description: Daily run on a RHEL 9 compose
 point_person: rvykydal@redhat.com
 artifact_type: github.scheduled.daily.kstest.rhel9
 verified_by:


### PR DESCRIPTION
This piece is missing for running rhel10 tests daily. Yesterday the plan was missing so 0 tests were run: https://github.com/rhinstaller/kickstart-tests/actions/runs/8288825938/job/22684101392