### PR TITLE
Update the issue link for repo-addrepo-hd-tree disabled on rhel10

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -78,7 +78,7 @@ rhel10_skip_array=(
   skip-on-rhel
   skip-on-rhel-10
   gh640       # authselect-not-set failing
-  gh790       # repo-addrepo-hd-tree failing
+  gh804       # repo-addrepo-hd-tree failing
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/repo-addrepo-hd-tree.sh
+++ b/repo-addrepo-hd-tree.sh
@@ -19,7 +19,7 @@
 # FIXME: Fails on RHEL 8: "Nothing useful found for Hard drive ISO source"
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging repo harddrive skip-on-rhel-8 gh790"
+TESTTYPE="packaging repo harddrive skip-on-rhel-8 gh790 gh804"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
It is a different issue then on rhel9.