### PR TITLE
New test - rpm-ostree-container-bootc + related improvements

### DIFF
--- a/containers/runner/launch
+++ b/containers/runner/launch
@@ -140,6 +140,16 @@ if [ "${CRUN%podman*}" != "$CRUN" ] && [ $(id -u) -ne 0 ]; then
     PODMAN_SELINUX_FIX="--security-opt label=disable"
 fi
 
+# Build up a list of KSTEST_* environment variables to be passed into the container
+TEST_ENV_VARS=$(printenv | while read line; do
+    key="$(echo $line | cut -d'=' -f1)"
+    val="$(echo $line | cut -d'=' -f2-)"
+
+    if [[ "${key}" =~ ^KSTEST_ ]]; then
+        echo -n " --env ${key}=${val//&/\\&}"
+    fi
+    done)
+
 # Run container against the local repository, to test changes easily
 # Expose the container's libvirt to the host; check "podman ps" for the port, and use e.g.:
 # virsh -c qemu+tcp://localhost:<port>/session list
@@ -149,5 +159,7 @@ $CRUN run -it --rm --device=/dev/kvm --publish 127.0.0.1::16509 $PODMAN_SELINUX_
     --env KSTESTS_TEST="$KSTESTS_TEST" --env TESTTYPE="${TESTTYPE:-}" --env SKIP_TESTTYPES="${SKIP_TESTTYPES:-}" \
     --env KSTESTS_RUN_TIMEOUT="${TIMEOUT:-}" \
     --env TEST_JOBS="$TEST_JOBS" --env PLATFORM="${PLATFORM:-}" --env TEST_RETRY="${TEST_RETRY:-}" ${UPDATES_IMG_ARGS:-} ${CONTAINER_RUN_ARGS:-} \
+    --env KSTESTS_KEEP=${KSTESTS_KEEP:-1} \
+    ${TEST_ENV_VARS} \
     ${VAR_TMP:-} -v "$PWD/data:/opt/kstest/data:z" -v "$BASEDIR:/kickstart-tests:ro,z" ${DEFAULTS_SH_ARGS:-} \
     $CONTAINER $RUN_COMMAND

--- a/containers/runner/run-kstest
+++ b/containers/runner/run-kstest
@@ -88,8 +88,10 @@ ${KSTESTS_DIR}/scripts/log2json --scenario $SCENARIO --output $TEST_LOG.json $TE
 # Fixup permissions
 chmod -R a+rw /var/tmp/kstest-*
 # Clean up (artifacts from broken test)
-find /var/tmp/kstest-* -name "*.iso" -delete
-find /var/tmp/kstest-* -name "*.img" -delete
+if [ "$KSTESTS_KEEP" != "2" ]; then
+    find /var/tmp/kstest-* -name "*.iso" -delete
+    find /var/tmp/kstest-* -name "*.img" -delete
+fi
 cp $TEST_LOG ${LOGS_DIR}
 cp $TEST_LOG.json ${LOGS_DIR}
 cp /var/tmp/kstest-list ${LOGS_DIR}

--- a/rpm-ostree-container-bootc.ks.in
+++ b/rpm-ostree-container-bootc.ks.in
@@ -1,0 +1,42 @@
+#test name: rpm-ostree-container-bootc
+# for bootc/bootupd, remote and stateroot ostreecontainer options
+# depends on the referenced ostree container being bootable
+
+# Use the default settings.
+%ksappend common/common_no_payload.ks
+
+# The RPM OSTree source is set up by the test script
+
+# Reboot the installed system.
+reboot
+
+# Validate on the first boot.
+%ksappend validation/success_on_first_boot.ks
+
+%post
+# Checks in %post
+# Check of the remote URL is appended by the test script
+
+# Checks after boot
+cat >> /opt/kickstart-tests/kickstart-test.sh << 'EOF'
+
+# propagate any errors from %post validations
+if [ -e /root/RESULT ]; then
+    cat /root/RESULT
+fi
+
+# Check that state root 'test-stateroot' exists
+if [ ! -d /ostree/deploy/test-stateroot ]; then
+    echo "Couldn't find 'test-stateroot' stateroot"
+fi
+
+# Check that bootupd information is present
+if [ ! -e /boot/bootupd-state.json ]; then
+    echo "/boot/bootupd-state.json not found on installed system after booting"
+fi
+
+bootupctl --help &> /dev/null || echo "bootupctl command not available after booting"
+bootc --help &> /dev/null || echo "bootc command not available after booting"
+
+EOF
+%end

--- a/rpm-ostree-container-bootc.sh
+++ b/rpm-ostree-container-bootc.sh
@@ -1,0 +1,106 @@
+#
+# Copyright (C) 2023  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
+TESTTYPE="payload ostree bootc reboot skip-on-rhel-8 skip-on-rhel-10"
+# skip-on-rhel"
+
+. ${KSTESTDIR}/functions.sh
+
+os_major=${KSTEST_OS_VERSION%%.*}
+if [ "${KSTEST_OS_NAME}" == "rhel" ]; then
+    container_url="quay.io/centos-bootc/centos-bootc:stream${os_major}"
+else
+    container_url="quay.io/centos-bootc/fedora-bootc:eln"
+fi
+
+copy_interesting_files_from_system() {
+    local disksdir
+    disksdir="${1}"
+
+    # Find disks.
+    local args
+    args=$(for d in ${disksdir}/disk-*img; do echo -a ${d}; done)
+
+    # Use also iscsi disk if there is any.
+    if [[ -n ${iscsi_disk_img} ]]; then
+        args="${args} -a ${disksdir}/${iscsi_disk_img}"
+    fi
+
+    # Grab files out of the installed system while it still exists.
+    # Grab these files:
+    #
+    # logs from Anaconda - whole /var/log/anaconda/ directory is copied out,
+    #                      this can be used for saving specific test output
+    # original-ks.cfg - the kickstart used for the test
+    # anaconda-ks.cfg - the kickstart saved after installation, useful for
+    #                   debugging
+    # RESULT - file from the test
+    #
+    # The location of aforementioned files is different in an ostree system
+
+    root_device=$(guestfish ${args} <<< "
+        launch
+        lvs" | \
+        grep root)
+    
+    for item in /ostree/deploy/test-stateroot/var/roothome/original-ks.cfg \
+                /ostree/deploy/test-stateroot/var/roothome/anaconda-ks.cfg \
+                /ostree/deploy/test-stateroot/var/roothome/anabot.log \
+                /ostree/deploy/test-stateroot/var/log/anaconda/ \
+                /ostree/deploy/test-stateroot/var/roothome/RESULT
+    do
+        guestfish ${args} <<< "
+            launch
+            mount ${root_device} /
+            copy-out '${item}' '${disksdir}'
+            " 2>/dev/null
+    done
+}
+
+prepare() {
+    ks=${1}
+    cat >> ${ks} << EOF1
+ostreecontainer --no-signature-verification --remote=test-remote --stateroot=test-stateroot --url=${container_url}
+
+%post
+cat >> /var/lib/extensions/kickstart-tests/usr/libexec/kickstart-test.sh << EOF2
+remote_url="\\\$(ostree remote show-url test-remote)"
+if [ \\\${?} -ne 0 ]; then
+    echo "Couldn't list remote URL for 'test-remote'" >> /root/RESULT
+fi
+
+if [ "\\\${remote_url}" != "${container_url}" ]; then
+    echo "Unexpected URL: \\\${remote_url}, expected ${container_url}" >> /root/RESULT
+fi
+EOF2
+%end
+EOF1
+    echo ${ks}
+}
+
+get_timeout() {
+   echo "80"
+}
+
+additional_runner_args() {
+   # Wait for reboot and shutdown of the VM,
+   # but exit after the specified timeout.
+   echo "--wait $(get_timeout)"
+}

--- a/scripts/run_kickstart_tests.sh
+++ b/scripts/run_kickstart_tests.sh
@@ -176,8 +176,10 @@ if [[ $? -ne 0 ]]; then
 fi
 ISO_OS_NAME=$(echo "${output}" | grep 'NAME=')
 ISO_OS_NAME="${ISO_OS_NAME##NAME=}"
+export KSTEST_OS_NAME="${ISO_OS_NAME}"
 ISO_OS_VERSION=$(echo "${output}" | grep 'VERSION=')
 ISO_OS_VERSION="${ISO_OS_VERSION##VERSION=}"
+export KSTEST_OS_VERSION="${ISO_OS_VERSION}"
 
 
 # Append sed args to substitute


### PR DESCRIPTION
The test is based on previous [work](https://github.com/rhinstaller/kickstart-tests/pull/1037) from Vladimir Slavik.