### PR TITLE
workflows: gather input kickstart with substituions among logs

### DIFF
--- a/.github/workflows/scenarios-permian.yml
+++ b/.github/workflows/scenarios-permian.yml
@@ -203,6 +203,7 @@ jobs:
             kickstart-tests/data/logs/kstest.log.json
             kickstart-tests/data/logs/kstest-*/*.log
             kickstart-tests/data/logs/kstest-*/anaconda/lorax-packages.log
+            kickstart-tests/data/logs/kstest-*/original-ks.cfg
 
       - name: Collect json summary
         if: always()

--- a/.github/workflows/test-platforms.yml
+++ b/.github/workflows/test-platforms.yml
@@ -316,6 +316,7 @@ jobs:
             kickstart-tests/data/logs/kstest.log.json
             kickstart-tests/data/logs/kstest-*/*.log
             kickstart-tests/data/logs/kstest-*/anaconda/lorax-packages.log
+            kickstart-tests/data/logs/kstest-*/original-ks.cfg
 
       - name: Collect Permian logs
         if: always()


### PR DESCRIPTION
This can be very important to have for issue reproducing.