### PR TITLE
workflows: run test-platforms status also when tests fail

### DIFF
--- a/.github/workflows/test-platforms.yml
+++ b/.github/workflows/test-platforms.yml
@@ -327,7 +327,7 @@ jobs:
 
   result:
     needs: [platform, pr-info]
-    if: needs.pr-info.outputs.allowed_user == 'true'
+    if: ${{ always() && needs.pr-info.outputs.allowed_user == 'true' }}
     name: Set result status
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
But still do not run it on any comment.

fix of commit 2d382a033660d448d7ad54f5c0c3c3eff62a1ab8