### PR TITLE
Disable initial-setup tests on rhel10

### DIFF
--- a/initial-setup-disable.sh
+++ b/initial-setup-disable.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="initial-setup"
+TESTTYPE="initial-setup skip-on-rhel-10"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/validate-lib-initial-setup.sh

--- a/initial-setup-enable.sh
+++ b/initial-setup-enable.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="initial-setup"
+TESTTYPE="initial-setup skip-on-rhel-10"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/validate-lib-initial-setup.sh

--- a/initial-setup-gui.sh
+++ b/initial-setup-gui.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="initial-setup"
+TESTTYPE="initial-setup skip-on-rhel-10"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/validate-lib-initial-setup.sh

--- a/initial-setup-reconfig.sh
+++ b/initial-setup-reconfig.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="initial-setup"
+TESTTYPE="initial-setup skip-on-rhel-10"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/validate-lib-initial-setup.sh

--- a/reboot-initial-setup-gui.sh
+++ b/reboot-initial-setup-gui.sh
@@ -17,7 +17,7 @@
 #
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="reboot initial-setup smoke"
+TESTTYPE="reboot initial-setup smoke skip-on-rhel-10"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/reboot-initial-setup-tui.sh
+++ b/reboot-initial-setup-tui.sh
@@ -18,7 +18,7 @@
 # The fix requires https://github.com/rhinstaller/anaconda/commit/6b80b7b.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="reboot initial-setup smoke skip-on-rhel-8"
+TESTTYPE="reboot initial-setup smoke skip-on-rhel-8 skip-on-rhel-10"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Disable inital-setup-* on rhel10 until gh1111 is fixed.