### PR TITLE
Enhance manual test execution

### DIFF
--- a/containers/runner/launch
+++ b/containers/runner/launch
@@ -142,6 +142,16 @@ if [ "${CRUN%podman*}" != "$CRUN" ] && [ $(id -u) -ne 0 ]; then
     PODMAN_SELINUX_FIX="--security-opt label=disable"
 fi
 
+# Build up a list of KSTEST_* environment variables to be passed into the container
+TEST_ENV_VARS=$(printenv | while read line; do
+    key="$(echo $line | cut -d'=' -f1)"
+    val="$(echo $line | cut -d'=' -f2-)"
+
+    if [[ "${key}" =~ ^KSTEST_ ]]; then
+        echo -n " --env ${key}=${val//&/\\&}"
+    fi
+    done)
+
 # Run container against the local repository, to test changes easily
 # Expose the container's libvirt to the host; check "podman ps" for the port, and use e.g.:
 # virsh -c qemu+tcp://localhost:<port>/session list
@@ -152,5 +162,7 @@ $CRUN run -it --rm --device=/dev/kvm --publish 127.0.0.1::16509 $PODMAN_SELINUX_
     --env KSTESTS_TEST="$KSTESTS_TEST" --env TESTTYPE="${TESTTYPE:-}" --env SKIP_TESTTYPES="${SKIP_TESTTYPES:-}" \
     --env KSTESTS_RUN_TIMEOUT="${TIMEOUT:-}" \
     --env TEST_JOBS="$TEST_JOBS" --env PLATFORM="${PLATFORM:-}" --env TEST_RETRY="${TEST_RETRY:-}" ${UPDATES_IMG_ARGS:-} ${CONTAINER_RUN_ARGS:-} \
+    --env KSTESTS_KEEP=${KSTESTS_KEEP:-1} \
+    ${TEST_ENV_VARS} \
     ${VAR_TMP:-} -v "$PWD/data:/opt/kstest/data:z" -v "$BASEDIR:/kickstart-tests:ro,z" ${DEFAULTS_SH_ARGS:-} \
     $CONTAINER $RUN_COMMAND

--- a/containers/runner/run-kstest
+++ b/containers/runner/run-kstest
@@ -93,8 +93,10 @@ ${KSTESTS_DIR}/scripts/log2json --scenario $SCENARIO --output $TEST_LOG.json $TE
 # Fixup permissions
 chmod -R a+rw /var/tmp/kstest-*
 # Clean up (artifacts from broken test)
-find /var/tmp/kstest-* -name "*.iso" -delete
-find /var/tmp/kstest-* -name "*.img" -delete
+if [ "$KSTESTS_KEEP" != "2" ]; then
+    find /var/tmp/kstest-* -name "*.iso" -delete
+    find /var/tmp/kstest-* -name "*.img" -delete
+fi
 cp $TEST_LOG ${LOGS_DIR}
 cp $TEST_LOG.json ${LOGS_DIR}
 cp /var/tmp/kstest-list ${LOGS_DIR}


### PR DESCRIPTION
- pass KSTEST_* variables into the container env
- ensure disk images are kept with $KSTESTS_KEEP == 2