### PR TITLE
Use Fedora Everything image instead of Fedora Server as the default i…

### DIFF
--- a/.github/workflows/test-platforms.yml
+++ b/.github/workflows/test-platforms.yml
@@ -229,7 +229,7 @@ jobs:
             ${{ github.workspace }}/kickstart-tests/containers/runner/fetch_daily_iso.sh $GITHUB_TOKEN $BOOT_ISO_PATH
             echo "boot_iso=\"bootIso\":{\"x86_64\":\"${BOOT_ISO_URL}\"}," >> $GITHUB_OUTPUT
           elif [ "${{ matrix.platform }}" == "rawhide" ]; then
-            curl -L https://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Server/x86_64/os/images/boot.iso --output $BOOT_ISO_PATH
+            curl -L https://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/images/boot.iso --output $BOOT_ISO_PATH
             echo "boot_iso=\"bootIso\":{\"x86_64\":\"${BOOT_ISO_URL}\"}," >> $GITHUB_OUTPUT
           else
             echo "Boot.iso for ${{ matrix.platform }} can't be fetched."

--- a/containers/runner/launch
+++ b/containers/runner/launch
@@ -111,8 +111,8 @@ if ! [ -e data/images/boot.iso ]; then
         echo "INFO: data/images/boot.iso does not exist, downloading daily iso..."
         $PWD/containers/runner/fetch_daily_iso.sh ${DAILY_ISO_TOKEN} data/images/boot.iso
     else
-        echo "INFO: data/images/boot.iso does not exist, downloading current Fedora Rawhide Server image..."
-        curl -L https://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Server/x86_64/os/images/boot.iso --output data/images/boot.iso
+        echo "INFO: data/images/boot.iso does not exist, downloading current Fedora Rawhide Everything image..."
+        curl -L https://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/images/boot.iso --output data/images/boot.iso
     fi
 fi
 


### PR DESCRIPTION
…mage

Fedora Everyting is a generic 'fedora' variant from Anaconda profile configuration point of view, which we should test by default rather than Fedora Server which is a 'fedora-server' profile configuration inherited from 'fedora'. Specifically, 'fedora-server' is overriding default btrfs autopartitioning by lvm.

See https://github.com/rhinstaller/kickstart-tests/issues/1120