### PR TITLE
Decrese the default timeout for a test to 30 minutes.

### DIFF
--- a/fedora-live-image-build.sh
+++ b/fedora-live-image-build.sh
@@ -28,5 +28,5 @@ TESTTYPE="packaging skip-on-rhel gh740"
 # fairly resource intensive tasks. So bump the timeout
 # to give it more time to do what's needed.
 get_timeout() {
-    echo "120"
+    echo "60"
 }

--- a/functions.sh
+++ b/functions.sh
@@ -444,7 +444,7 @@ append_additional_repo_to_kernel_args() {
 }
 
 get_timeout() {
-    echo "60"
+    echo "30"
 }
 
 stage2_from_ks() {

--- a/groups-and-envs-2.sh
+++ b/groups-and-envs-2.sh
@@ -24,7 +24,8 @@ TESTTYPE="packaging skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh
 
-# The test installs ~1366 packages for which 1h timeout is sometimes not enough
+# The test installs ~1366 packages for which the default timeout is sometimes
+# not enough
 get_timeout() {
-    echo "120"
+    echo "60"
 }


### PR DESCRIPTION
Currently a test runs usually about 10 minutes or less. The infrastructure got pretty stable (the whole suite of 237 tests runs in 1h45m) so 30 minutes should be enough. This change will also decrease overall time to run the suite by not blocking the queue with timeouting tests (usually flakes) too long.