### PR TITLE
containers: Install python3-pip in the runner container

### DIFF
--- a/containers/runner/Dockerfile
+++ b/containers/runner/Dockerfile
@@ -15,6 +15,7 @@ RUN dnf -y update && \
     parallel \
     python3-libvirt \
     createrepo_c \
+    python3-pip \
     python3-rpmfluff \
     squid \
     make \


### PR DESCRIPTION
I want to run pylint tests inside the container, as that contains all dependencies. Without these pylint detects tons of import errors.
