### PR TITLE
Skip modularity tests on fedora

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -16,7 +16,6 @@ fedora_skip_array=(
   gh641       # packages-multilib failing on systemd conflict
   gh680       # proxy-kickstart and proxy-auth failing
   gh740       # fedora-live-image-build fails on comps changes
-  gh769       # nodejs:16 and swig:4 missing in module-X tests
   gh774       # autopart-luks-1 failing
   gh777       # raid-1-reqpart failing
   gh910       # stage2-from-ks test needs to be fixed for daily-iso

--- a/module-1.sh
+++ b/module-1.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging modularity skip-on-rhel gh769"
+TESTTYPE="packaging modularity skip-on-rhel skip-on-fedora"
 
 . ${KSTESTDIR}/functions.sh

--- a/module-2.sh
+++ b/module-2.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging modularity skip-on-rhel gh769"
+TESTTYPE="packaging modularity skip-on-rhel skip-on-fedora"
 
 . ${KSTESTDIR}/functions.sh

--- a/module-3.sh
+++ b/module-3.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging modularity skip-on-rhel gh769"
+TESTTYPE="packaging modularity skip-on-rhel skip-on-fedora"
 
 . ${KSTESTDIR}/functions.sh

--- a/module-4.sh
+++ b/module-4.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging modularity skip-on-rhel gh769"
+TESTTYPE="packaging modularity skip-on-rhel skip-on-fedora"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
These are already not running as they are disabled, and modularity is deprecated on Fedora-41. So let's just stop running these to clean up the disabled stack.

https://github.com/pykickstart/pykickstart/pull/491

Fixes: #769