### PR TITLE
Replace kacst glob with the existing google-noto* packages glob

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -69,7 +69,6 @@ rhel10_skip_array=(
   gh804       # tests requiring dvd iso failing
   gh1090      # raid-1-reqpart failing
   gh1104      # network-prefixdevname failing
-  gh1106      # packages-and-groups-1 failing
   gh1105      # preexisting btrfs failing
   gh1108      # proxy-auth, proxy-kickstart failing
   gh1109      # rootps-allow-ssh failing

--- a/packages-and-groups-1.ks.in
+++ b/packages-and-groups-1.ks.in
@@ -19,7 +19,7 @@ tmux
 -tmux
 
 # (3) Test that you can add packages with a glob.
-kacst*
+google-noto*
 
 # (4) Test that you can remove packages with a glob.
 -grub2-efi*
@@ -50,10 +50,10 @@ if [[ $? == 0 ]]; then
     echo '*** tmux package should not have been installed' >> /root/RESULT
 fi
 
-# Testing #3 - kacst font stuff should be installed.
-count=$(rpm -qa kacst\* | wc -l)
+# Testing #3 - google-noto font stuff should be installed.
+count=$(rpm -qa google-noto\* | wc -l)
 if [[ $count -lt 5 ]]; then
-    echo '*** kacst* glob was not installed' >> /root/RESULT
+    echo '*** google-noto* glob was not installed' >> /root/RESULT
 fi
 
 # Testing #4 - grub2-efi stuff should not be installed.

--- a/packages-and-groups-1.sh
+++ b/packages-and-groups-1.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging gh1106"
+TESTTYPE="packaging"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
kacst is not packaged / gragged anymore in RHEL10. [1]

[1] https://bugs.documentfoundation.org/show_bug.cgi?id=152376

Fixes: #1106