### PR TITLE
Add a log message informing the tests have started

### DIFF
--- a/scripts/run_kickstart_tests.sh
+++ b/scripts/run_kickstart_tests.sh
@@ -304,7 +304,7 @@ if [[ "${tests}" == "" ]]; then
     exit 0
 fi
 
-echo "Running tests: ${tests}"
+echo "Selected tests: ${tests}"
 
 if [[ -z "${sed_args}" ]]; then
     echo "No substitutions provided, tests will fail; skipping."
@@ -444,7 +444,7 @@ if [[ "$TEST_REMOTES" != "" ]]; then
 
     cd ..
 
-    echo "starting tests"
+    echo "Starting the tests"
 
     # Parallel aparently tends to import environment shell variables to the
     # remote shell run environment, which can cause issues if the host that
@@ -485,6 +485,7 @@ if [[ "$TEST_REMOTES" != "" ]]; then
         ssh kstest@${remote} rm -rf /var/tmp/kstest-\*
     done
 else
+    echo "Starting the tests"
     timeout ${TIMEOUT} parallel --no-notice --jobs ${TEST_JOBS:-4} \
         PYTHONPATH=$PYTHONPATH scripts/launcher/run_one_test.py \
                                                       -i ${IMAGE} \


### PR DESCRIPTION
There is quite a long delay (~10 mins) before the result / logs of the first finished test are displayed and the last log message displayed was a bit confusing:

```
************************************************************************
You can connect to this container's libvirt with this connection string:

   qemu+tcp://10.88.0.84/session

************************************************************************
+ TEST_LOG=/var/tmp/kstest.log
+ pushd /opt/kstest/kickstart-tests
/opt/kstest/kickstart-tests /opt/kstest
+ set +e
+ scripts/run_kickstart_tests.sh -x 0 -k 1 -i /opt/kstest/data/images/boot.iso -p rhel10 container
+ tee /var/tmp/kstest.log
starting kickstart tests
Wed May 15 05:50:31 UTC 2024
Extract filename /LiveOS/rootfs.img can't be resolved
Saving list of expected tests to /var/tmp/kstest-list
Selected tests: container.sh 
INFO:apply-ksappend.py: running ksappend substitution on: container.ks.in
Saving substituted kickstarts to /var/tmp/kstest-list-substituted
```

Now it says:
```
************************************************************************
You can connect to this container's libvirt with this connection string:

   qemu+tcp://10.88.0.84/session

************************************************************************
+ TEST_LOG=/var/tmp/kstest.log
+ pushd /opt/kstest/kickstart-tests
/opt/kstest/kickstart-tests /opt/kstest
+ set +e
+ scripts/run_kickstart_tests.sh -x 0 -k 1 -i /opt/kstest/data/images/boot.iso -p rhel10 container
+ tee /var/tmp/kstest.log
starting kickstart tests
Wed May 15 05:50:31 UTC 2024
Extract filename /LiveOS/rootfs.img can't be resolved
Saving list of expected tests to /var/tmp/kstest-list
Selected tests: container.sh 
INFO:apply-ksappend.py: running ksappend substitution on: container.ks.in
Saving substituted kickstarts to /var/tmp/kstest-list-substituted
Starting the tests
```