### PR TITLE
Enable selinux-contexts on rhel9 (gh#970)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -57,7 +57,6 @@ rhel9_skip_array=(
   gh604       # packages-weakdeps: "gnupg2 --recommends has changed, test needs to be updated"
   gh641       # packages-multilib failing on systemd conflict
   gh774       # autopart-luks-1 failing
-  gh970       # selinux-contexts failing
   gh804       # tests requiring dvd iso failing
 )
 

--- a/selinux-contexts.sh
+++ b/selinux-contexts.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="security selinux gh970"
+TESTTYPE="security selinux"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
The problem we saw in the past has been resolved in kexec-tools:
https://gitlab.com/redhat/centos-stream/rpms/kexec-tools/-/commit/401619f484f2b2e943ca4ecc8fd90e02978a75c2