### PR TITLE
Replace sshpass with except (gh#1109)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -70,7 +70,6 @@ rhel10_skip_array=(
   gh1106      # packages-and-groups-1 failing
   gh1105      # preexisting btrfs failing
   gh1108      # proxy-auth, proxy-kickstart failing
-  gh1109      # rootps-allow-ssh failing
   gh1107      # rpm-ostree-container failing
   gh1110      # storage-multipath-autopart failing
 )

--- a/rootpw-allow-ssh.ks.in
+++ b/rootpw-allow-ssh.ks.in
@@ -12,7 +12,7 @@
 rootpw --plaintext --allow-ssh qweqwe
 
 %packages
-sshpass
+expect
 %end
 
 # Reboot the installed system.
@@ -30,8 +30,20 @@ touch /root/.hushlogin
 # Write the code to run after reboot.
 cat > /usr/libexec/kickstart-test.sh << 'EOF'
 
-# Ssh login silently
-sshpass -p qweqwe ssh -q -o strictHostKeyChecking=no root@localhost
+# Ssh login interactively
+# If the script asks for password the second time, error out
+# If the connection gets closed it means success
+expect -c "
+   set timeout 5
+   spawn ssh -o strictHostKeyChecking=no root@localhost -t \"cat /etc/os-release\"
+   expect {
+      -re \"^.*sword: \" {send \"qweqwe\r\"}
+   }
+   expect {
+      -re \"Connection to .* closed.\" {exit 0}
+      -re \"^.*sword: \" {exit 1}
+   }
+" > /dev/null
 login_result=$?
 
 if [[ ${login_result} != 0 ]]; then

--- a/rootpw-allow-ssh.sh
+++ b/rootpw-allow-ssh.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="users skip-on-rhel-8 gh1109"
+TESTTYPE="users skip-on-rhel-8"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
sshpass is not shipped in rhel10 thus use simple except script to interactively pass password into ssh.