### PR TITLE
Fix: daily-iso infra issue: "curl: (6) Could not resolve host: null"

### DIFF
--- a/containers/runner/fetch_daily_iso.sh
+++ b/containers/runner/fetch_daily_iso.sh
@@ -5,8 +5,8 @@ DAILY_ISO_TOKEN=$1
 OUTPUT_PATH=${2:-"boot.iso"}
 
 CURL="curl -u token:$(cat $DAILY_ISO_TOKEN) --show-error --fail"
-RESPONSE=$($CURL --silent https://api.github.com/repos/rhinstaller/kickstart-tests/actions/artifacts)
-ZIP=$(echo "$RESPONSE" | jq --raw-output '.artifacts | map(select(.name == "images"))[0].archive_download_url')
+RESPONSE=$($CURL --silent https://api.github.com/repos/rhinstaller/kickstart-tests/actions/artifacts?name=images)
+ZIP=$(echo "$RESPONSE" | jq --raw-output '.artifacts[0].archive_download_url')
 echo "INFO: Downloading $ZIP ..."
 $CURL -L -o images.zip "$ZIP"
 unzip images.zip


### PR DESCRIPTION
The artifacts are paginated, and it can happen when there is high traffic on the repository that 'images' artifact are hidden in some page > 1. This makes the fetching of the 'images' artifact to fail.
Use the 'name' query parameter to limit the artifacts to the ones we are interested in.

Fixes: #902