### PR TITLE
Use centos 10 in place of rhel 10 temporarily for rhel10 --platform

### DIFF
--- a/scripts/defaults-rhel10.sh
+++ b/scripts/defaults-rhel10.sh
@@ -3,7 +3,7 @@
 # This is a reasonable default used until the new release is detected by osinfo library.
 export KSTEST_OSINFO_NAME=fedora-eln
 source network-device-names.cfg
-export KSTEST_URL='http://download.eng.bos.redhat.com/rhel-10/nightly/RHEL-10-Public-Beta/latest-RHEL-10.0/compose/BaseOS/x86_64/os/'
-export KSTEST_MODULAR_URL='http://download.eng.bos.redhat.com/rhel-10/nightly/RHEL-10-Public-Beta/latest-RHEL-10.0/compose/AppStream/x86_64/os/'
+export KSTEST_URL='http://composes.stream.centos.org/stream-10/development/latest-CentOS-Stream/compose/BaseOS/x86_64/os/'
+export KSTEST_MODULAR_URL='http://composes.stream.centos.org/stream-10/development/latest-CentOS-Stream/compose/AppStream/x86_64/os/'
 export KSTEST_FTP_URL='ftp://ftp.tu-chemnitz.de/pub/linux/fedora/linux/development/rawhide/Everything/$basearch/os/'
 export KSTEST_OSTREECONTAINER_URL='quay.io/centos-bootc/centos-bootc:stream10'


### PR DESCRIPTION
The main reason is making /test-os-variants usable for PRs on tests.
It will affect also daily runs, but actually it will be nice to see results of all tests on centos 10 image. We can switch it back to rhel 10 later by updating the GH workflow.