### PR TITLE
Consider centos os-variant as rhel platform

### DIFF
--- a/anaconda-conf.ks.in
+++ b/anaconda-conf.ks.in
@@ -22,9 +22,9 @@ fi
 %post --nochroot
 
 @KSINCLUDE@ scripts-lib.sh
+platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
 
-if is_rhel8 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@ || \
-   is_rhel9 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@ ; then
+if [ "${platform}" == "rhel8" ] || [ "${platform}" == "rhel9" ]; then
     LOG_MSG="Writing a temporary configuration loaded from"
 else
     LOG_MSG="Configuration loaded from:"

--- a/anaconda-modules.ks.in
+++ b/anaconda-modules.ks.in
@@ -11,6 +11,7 @@
 %post --nochroot
 
 @KSINCLUDE@ scripts-lib.sh
+platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
 
 # Get the activated Anaconda DBus modules.
 cat /tmp/syslog | grep "Activating service name" | \
@@ -18,8 +19,7 @@ grep "org.fedoraproject.Anaconda.Modules" | cut -d"'" -f2 \
 | sort > /tmp/generated.out
 
 # Generate the expected output.
-if is_rhel8 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@ || \
-   is_rhel9 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@ ; then
+if [ "${platform}" == "rhel8" ] || [ "${platform}" == "rhel9" ]; then
     cat > /tmp/expected.out << EOF
 org.fedoraproject.Anaconda.Modules.Localization
 org.fedoraproject.Anaconda.Modules.Network

--- a/autopart-nohome.ks.in
+++ b/autopart-nohome.ks.in
@@ -22,7 +22,9 @@ shutdown
 # Generate the autopart command.
 autopart="autopart --type=plain --nohome"
 
-if [ "@KSTEST_OS_NAME@" == "fedora" ]; then
+@KSINCLUDE@ scripts-lib.sh
+platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
+if [ "${platform:0:6}" == "fedora" ]; then
     autopart="$autopart --noboot --noswap"
 fi
 

--- a/bindtomac-bridge-2devs-httpks.ks.in
+++ b/bindtomac-bridge-2devs-httpks.ks.in
@@ -36,6 +36,7 @@ check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@ bridge0 bridge1
 
 @KSINCLUDE@ post-lib-network.sh
 @KSINCLUDE@ scripts-lib.sh
+platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
 
 # bridge0
 
@@ -76,7 +77,7 @@ check_device_config_value bridge1 ONBOOT yes connection autoconnect __NONE
 
 check_device_config_value bridge1_slave_1 ONBOOT yes connection autoconnect __NONE
 
-if is_rhel8 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@ ; then
+if [ "${platform}" == "rhel8" ]; then
     # RHEL-8-FAILURE: anaconda does not create default config file for enslaved device in RHEL8
     check_config_exists @KSTEST_NETDEV2@ no
 else

--- a/bindtomac-bridge-2devs-pre.ks.in
+++ b/bindtomac-bridge-2devs-pre.ks.in
@@ -38,6 +38,7 @@ check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@ bridge0 bridge1
 
 @KSINCLUDE@ post-lib-network.sh
 @KSINCLUDE@ scripts-lib.sh
+platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
 
 # bridge0
 
@@ -76,7 +77,7 @@ check_device_config_value bridge1 ONBOOT yes connection autoconnect __NONE
 
 check_device_config_value bridge1_slave_1 ONBOOT yes connection autoconnect __NONE
 
-if is_rhel8 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@ ; then
+if [ "${platform}" == "rhel8" ]; then
     # RHEL-8-FAILURE: anaconda does not create default config file for enslaved device in RHEL8
     check_config_exists @KSTEST_NETDEV2@ no
 else

--- a/bindtomac-bridge-httpks.ks.in
+++ b/bindtomac-bridge-httpks.ks.in
@@ -21,10 +21,11 @@ shutdown
 %post --nochroot
 
 @KSINCLUDE@ scripts-lib.sh
+platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
 @KSINCLUDE@ post-nochroot-lib-network.sh
 
 check_bridge_has_slave_nochroot bridge0 @KSTEST_NETDEV1@ yes
-if is_rhel8 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@ ; then
+if [ "${platform}" == "rhel8" ]; then
     # RHEL-8-FAILURE: generic "Wired Connection" created in initramfs (ip=dhcp)
     # would be edited for @KSTEST_NETDEV1@ in GUI which is not ideal
     check_gui_configurations bridge0

--- a/bond-ks-initramfs.ks.in
+++ b/bond-ks-initramfs.ks.in
@@ -18,8 +18,9 @@ network --device bond0 --bootproto dhcp --bondslaves=@KSTEST_NETDEV1@,@KSTEST_NE
 # We will copy /root/RESULT to /mnt/sysimage/root/RESULT at the beginning of the %post (--nochroot) checks
 @KSINCLUDE@ post-lib-network.sh
 @KSINCLUDE@ scripts-lib.sh
+platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
 
-if is_rhel8 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@ ; then
+if [ "${platform}" == "rhel8" ]; then
     # Ifcfg files for the kickstart configuration are created in initramfs
     check_config_exists bond0 yes
     check_config_exists bond0_slave_1 yes
@@ -59,9 +60,10 @@ check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@ bond0
 
 @KSINCLUDE@ post-lib-network.sh
 @KSINCLUDE@ scripts-lib.sh
+platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
 
 check_device_config_value bond0 ONBOOT yes connection autoconnect __NONE
-if is_rhel8 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@ ; then
+if [ "${platform}" == "rhel8" ]; then
     check_device_config_value bond0_slave_1 ONBOOT yes connection autoconnect __NONE
     check_device_config_value bond0_slave_1 SLAVE yes connection slave-type bond
     check_device_config_value bond0_slave_2 ONBOOT yes connection autoconnect __NONE

--- a/bridge-2devs-httpks.ks.in
+++ b/bridge-2devs-httpks.ks.in
@@ -36,6 +36,7 @@ check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@ bridge0 bridge1
 
 @KSINCLUDE@ post-lib-network.sh
 @KSINCLUDE@ scripts-lib.sh
+platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
 
 # bridge0
 
@@ -77,7 +78,7 @@ check_device_config_value bridge1 ONBOOT yes connection autoconnect __NONE
 
 check_device_config_value bridge1_slave_1 ONBOOT yes connection autoconnect __NONE
 
-if is_rhel8 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@ ; then
+if [ "${platform}" == "rhel8" ]; then
     # RHEL-8-FAILURE: anaconda does not create default config file for enslaved device in RHEL8
     check_config_exists @KSTEST_NETDEV2@ no
 else

--- a/bridge-2devs-pre.ks.in
+++ b/bridge-2devs-pre.ks.in
@@ -38,6 +38,7 @@ check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@ bridge0 bridge1
 
 @KSINCLUDE@ post-lib-network.sh
 @KSINCLUDE@ scripts-lib.sh
+platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
 
 # bridge0
 
@@ -76,7 +77,7 @@ check_device_config_value bridge1 ONBOOT yes connection autoconnect __NONE
 
 check_device_config_value bridge1_slave_1 ONBOOT yes connection autoconnect __NONE
 
-if is_rhel8 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@ ; then
+if [ "${platform}" == "rhel8" ]; then
     # RHEL-8-FAILURE: anaconda does not create default config file for enslaved device in RHEL8
     check_config_exists @KSTEST_NETDEV2@ no
 else

--- a/bridge-2devs.ks.in
+++ b/bridge-2devs.ks.in
@@ -36,6 +36,7 @@ check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@ bridge0 bridge1
 
 @KSINCLUDE@ post-lib-network.sh
 @KSINCLUDE@ scripts-lib.sh
+platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
 
 # bridge0
 
@@ -75,7 +76,7 @@ check_device_config_value bridge1 ONBOOT yes connection autoconnect __NONE
 
 check_device_config_value bridge1_slave_1 ONBOOT yes connection autoconnect __NONE
 
-if is_rhel8 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@ ; then
+if [ "${platform}" == "rhel8" ]; then
     # RHEL-8-FAILURE: anaconda does not create default config file for enslaved device in RHEL8
     check_config_exists @KSTEST_NETDEV2@ no
 else

--- a/bridge-httpks.ks.in
+++ b/bridge-httpks.ks.in
@@ -21,10 +21,11 @@ shutdown
 %post --nochroot
 
 @KSINCLUDE@ scripts-lib.sh
+platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
 @KSINCLUDE@ post-nochroot-lib-network.sh
 
 check_bridge_has_slave_nochroot bridge0 @KSTEST_NETDEV1@ yes
-if is_rhel8 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@ ; then
+if [ "${platform}" == "rhel8" ]; then
     # RHEL-8-FAILURE: generic "Wired Connection" created in initramfs (ip=dhcp)
     # would be edited for @KSTEST_NETDEV1@ in GUI which is not ideal
     check_gui_configurations bridge0

--- a/bridge-no-bootopts-net.ks.in
+++ b/bridge-no-bootopts-net.ks.in
@@ -34,11 +34,12 @@ check_gui_configurations @KSTEST_NETDEV1@ bridge0
 
 @KSINCLUDE@ post-lib-network.sh
 @KSINCLUDE@ scripts-lib.sh
+platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
 
 check_device_connected bridge0 yes
 check_device_connected @KSTEST_NETDEV1@ yes
 
-if is_rhel8 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@ ; then
+if [ "${platform}" == "rhel8" ]; then
     # RHEL-8-FAILURE: in rhel 8 the ifcfg is generated in initramfs by Anaconda
     check_device_config_value bridge0_slave_1 BRIDGE bridge0 connection master bridge0
     check_device_config_value bridge0_slave_1 BRIDGE bridge0 connection slave-type bridge

--- a/default-fstype.ks.in
+++ b/default-fstype.ks.in
@@ -29,8 +29,11 @@ cp /.buildstamp /mnt/sysroot
 
 %post
 
+@KSINCLUDE@ scripts-lib.sh
+platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
+
 expected_fstype="ext4"
-if [ "@KSTEST_OS_NAME@" == "rhel" ] || grep -qi '^variant=server' /.buildstamp; then
+if [ "${platform:0:4}" == "rhel" ] || grep -qi '^variant=server' /.buildstamp; then
     expected_fstype="xfs"
 fi
 

--- a/dns.ks.in
+++ b/dns.ks.in
@@ -12,8 +12,10 @@
 %post
 
 @KSINCLUDE@ post-lib-network.sh
+@KSINCLUDE@ scripts-lib.sh
+platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
 
-if [ "@KSTEST_OS_NAME@" == "rhel" ]; then
+if [ "${platform:0:4}" == "rhel" ]; then
     # rhbz#1989472
     check_resolv_conf_is_by_nm
 else

--- a/network-addr-gen-mode.ks.in
+++ b/network-addr-gen-mode.ks.in
@@ -52,11 +52,12 @@ check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@ @KSTEST_NETDEV3@ @KST
 
 @KSINCLUDE@ post-lib-network.sh
 @KSINCLUDE@ scripts-lib.sh
+platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
 
 check_device_config_value @KSTEST_NETDEV1@ IPV6_ADDR_GEN_MODE eui64 ipv6 addr-gen-mode eui64
 check_connection_setting "@KSTEST_NETDEV1@" ipv6.addr-gen-mode eui64
 check_device_config_value @KSTEST_NETDEV2@ IPV6_ADDR_GEN_MODE __NONE ipv6 addr-gen-mode eui64
-if is_rhel8 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@ ; then
+if [ "${platform}" == "rhel8" ]; then
     # In rhel8 ifcfg from kickstart is generated in initramfs
     check_connection_setting "System @KSTEST_NETDEV2@" ipv6.addr-gen-mode default-or-eui64
 else

--- a/network-autoconnections-dhcpall-httpks.ks.in
+++ b/network-autoconnections-dhcpall-httpks.ks.in
@@ -26,9 +26,10 @@ shutdown
 # We will copy /root/RESULT to /mnt/sysimage/root/RESULT at the beginning of the %post (--nochroot) checks
 @KSINCLUDE@ post-lib-network.sh
 @KSINCLUDE@ scripts-lib.sh
+platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
 
 check_config_exists @KSTEST_NETDEV1@ no
-if is_rhel8 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@ ; then
+if [ "${platform}" == "rhel8" ]; then
     check_config_exists @KSTEST_NETDEV2@ yes
 else
     check_config_exists @KSTEST_NETDEV2@ no
@@ -38,7 +39,7 @@ check_device_connected @KSTEST_NETDEV1@ yes
 check_device_connected @KSTEST_NETDEV2@ yes
 check_device_connected @KSTEST_NETDEV3@ yes
 
-if is_rhel8 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@ ; then
+if [ "${platform}" == "rhel8" ]; then
     check_number_of_connections 2
 else
     # includes "lo" connection
@@ -47,7 +48,7 @@ fi
 
 check_connection_device "Wired Connection" @KSTEST_NETDEV1@
 check_connection_device "Wired Connection" @KSTEST_NETDEV2@
-if is_rhel8 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@ ; then
+if [ "${platform}" == "rhel8" ]; then
     check_connection_device "System @KSTEST_NETDEV2@"
 fi
 check_connection_device "Wired Connection" @KSTEST_NETDEV3@
@@ -76,6 +77,7 @@ check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@ @KSTEST_NETDEV3@
 
 @KSINCLUDE@ post-lib-network.sh
 @KSINCLUDE@ scripts-lib.sh
+platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
 
 check_device_config_value @KSTEST_NETDEV1@ ONBOOT yes connection autoconnect __NONE
 check_device_config_value @KSTEST_NETDEV2@ ONBOOT yes connection autoconnect __NONE
@@ -89,7 +91,7 @@ check_device_connected @KSTEST_NETDEV3@ yes
 check_connection_device "Wired Connection" @KSTEST_NETDEV2@
 check_connection_device @KSTEST_NETDEV2@
 
-if is_rhel8 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@ ; then
+if [ "${platform}" == "rhel8" ]; then
     check_number_of_connections 4
 else
     # includes "lo" connection

--- a/network-autoconnections-httpks.ks.in
+++ b/network-autoconnections-httpks.ks.in
@@ -27,11 +27,12 @@ shutdown
 # We will copy /root/RESULT to /mnt/sysimage/root/RESULT at the beginning of the %post (--nochroot) checks
 @KSINCLUDE@ post-lib-network.sh
 @KSINCLUDE@ scripts-lib.sh
+platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
 # Note: up to RHEL8.2 the file was created by dracut network module
 # check_config_exists @KSTEST_NETDEV1@ yes
 check_config_exists @KSTEST_NETDEV1@ no
 # In RHEL8 ifcfg files are created from kickstart already in initramfs
-if is_rhel8 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@ ; then
+if [ "${platform}" == "rhel8" ]; then
     check_config_exists @KSTEST_NETDEV2@ yes
 else
     check_config_exists @KSTEST_NETDEV2@ no
@@ -40,7 +41,7 @@ check_config_exists @KSTEST_NETDEV3@ no
 
 check_device_connected @KSTEST_NETDEV1@ yes
 check_connection_device @KSTEST_NETDEV1@ @KSTEST_NETDEV1@
-if is_rhel8 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@ ; then
+if [ "${platform}" == "rhel8" ]; then
     check_connection_device "System @KSTEST_NETDEV2@"
 fi
 
@@ -53,7 +54,7 @@ check_connection_setting "@KSTEST_NETDEV1@" 802-3-ethernet.mac-address --
 detect_nm_has_autoconnections_off
 nm_has_autoconnections_off=$?
 if [[ $nm_has_autoconnections_off -eq 0 ]]; then
-    if is_rhel8 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@ ; then
+    if [ "${platform}" == "rhel8" ]; then
         check_number_of_connections 2
     else
         # includes "lo" connection
@@ -94,6 +95,7 @@ check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@ @KSTEST_NETDEV3@
 
 @KSINCLUDE@ post-lib-network.sh
 @KSINCLUDE@ scripts-lib.sh
+platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
 
 check_device_config_value @KSTEST_NETDEV1@ ONBOOT yes connection autoconnect __NONE
 check_device_config_value @KSTEST_NETDEV2@ ONBOOT yes connection autoconnect __NONE
@@ -103,7 +105,7 @@ detect_nm_has_autoconnections_off
 nm_has_autoconnections_off=$?
 if [[ $nm_has_autoconnections_off -eq 0 ]]; then
     check_device_config_value @KSTEST_NETDEV3@ ONBOOT no connection autoconnect false
-    if is_rhel8 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@ ; then
+    if [ "${platform}" == "rhel8" ]; then
         check_number_of_connections 3
     else
         # includes "lo" connection

--- a/network-options-pre.ks.in
+++ b/network-options-pre.ks.in
@@ -37,6 +37,8 @@ check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@ @KSTEST_NETDEV3@ @KST
 %post
 
 @KSINCLUDE@ post-lib-network.sh
+@KSINCLUDE@ scripts-lib.sh
+platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
 
 check_device_config_value @KSTEST_NETDEV1@ DEFROUTE yes ipv4 never-default __NONE
 check_device_config_value @KSTEST_NETDEV2@ DEFROUTE no ipv4 never-default true
@@ -47,7 +49,7 @@ check_device_connected @KSTEST_NETDEV4@ yes
 check_device_config_value @KSTEST_NETDEV3@ MTU 9000 ethernet mtu 9000
 
 # It is not working on rhel yet (RHEL-30406)
-if [ "@KSTEST_OS_NAME@" == "rhel" ]; then
+if [ "${platform:0:4}" == "rhel" ]; then
     check_device_config_value @KSTEST_NETDEV4@ DHCP_VENDOR_CLASS_IDENTIFIER __NONE ipv4 dhcp-vendor-class-identifier __NONE
 else
     check_device_config_value @KSTEST_NETDEV4@ DHCP_VENDOR_CLASS_IDENTIFIER RHEL ipv4 dhcp-vendor-class-identifier RHEL

--- a/repo-install.ks.in
+++ b/repo-install.ks.in
@@ -15,10 +15,10 @@ repo --name=test05 --baseurl=EMPTY_REPO_URL --includepkgs=p1,p2 --excludepkgs=p3
 %post
 
 @KSINCLUDE@ scripts-lib.sh
+platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
 
 # Define patterns for repo options.
-if is_rhel8 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@ || \
-   is_rhel9 @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@ ; then
+if [ "${platform}" == "rhel8" ] || [ "${platform}" == "rhel9" ]; then
     cost='^cost=25$'
     sslverify='^sslverify=0$'
     includepkgs='^includepkgs=p1,p2$'

--- a/reqpart.ks.in
+++ b/reqpart.ks.in
@@ -28,8 +28,11 @@ cp /.buildstamp /mnt/sysroot
 
 %post
 
+@KSINCLUDE@ scripts-lib.sh
+platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
+
 expected_fstype="ext4"
-if [ "@KSTEST_OS_NAME@" == "rhel" ] || grep -qi '^variant=server' /.buildstamp; then
+if [ "${platform:0:4}" == "rhel" ] || grep -qi '^variant=server' /.buildstamp; then
     expected_fstype="xfs"
 fi
 

--- a/scripts-lib.sh
+++ b/scripts-lib.sh
@@ -21,29 +21,3 @@ function get_platform {
 
    echo ${platform}
 }
-
-
-# is_rhel8 KSTESTS_OS_NAME KSTESTS_OS_VERSION
-# Are we testing rhel 8 (based on the name and version detected from boot.iso) ?
-function is_rhel8 {
-   local os_name=$1
-   local os_version=$2
-   if [ "$(get_platform ${os_name} ${os_version})" == "rhel8" ] ; then
-       return 0
-   else
-       return 1
-   fi
-}
-
-
-# is_rhel9 KSTESTS_OS_NAME KSTESTS_OS_VERSION
-# Are we testing rhel 9 (based on the name and version detected from boot.iso) ?
-function is_rhel9 {
-   local os_name=$1
-   local os_version=$2
-   if [ "$(get_platform ${os_name} ${os_version})" == "rhel9" ] ; then
-       return 0
-   else
-       return 1
-   fi
-}

--- a/scripts-lib.sh
+++ b/scripts-lib.sh
@@ -1,23 +1,47 @@
 # Common functions for %post or %pre kickstart section
 
+# get_platform KSTEST_OS_NAME KSTEST_OS_VERSION
+# Get the platform (fragments platform / --platform launch script option).
+# For fedora return only "fedora" prefix (only fedora_rawhide platform is supported currently).
+function get_platform {
+   local os_name=$1
+   local os_version=$2
+   local platform=""
+
+   if [ ${os_name} == "rhel" ] || [ ${os_name} == "centos" ] ; then
+       platform=rhel
+       os_major=$(echo "${os_version}" | grep -oE "^[[:digit:]]+")
+       if [ -n "${os_major}" ] ; then
+           platform="rhel${os_major}"
+       fi
+   fi
+   if [ ${os_name} == "fedora" ] ; then
+       platform=fedora
+   fi
+
+   echo ${platform}
+}
+
+
 # is_rhel8 KSTESTS_OS_NAME KSTESTS_OS_VERSION
 # Are we testing rhel 8 (based on the name and version detected from boot.iso) ?
 function is_rhel8 {
    local os_name=$1
    local os_version=$2
-   if [ ${os_name} == "rhel" ] && [ ${os_version:0:1} == "8" ] ; then
+   if [ "$(get_platform ${os_name} ${os_version})" == "rhel8" ] ; then
        return 0
    else
        return 1
    fi
 }
 
+
 # is_rhel9 KSTESTS_OS_NAME KSTESTS_OS_VERSION
 # Are we testing rhel 9 (based on the name and version detected from boot.iso) ?
 function is_rhel9 {
    local os_name=$1
    local os_version=$2
-   if [ ${os_name} == "rhel" ] && [ ${os_version:0:1} == "9" ] ; then
+   if [ "$(get_platform ${os_name} ${os_version})" == "rhel9" ] ; then
        return 0
    else
        return 1


### PR DESCRIPTION
This should allow us to run centos images with tests for rhel10 platform.

Follow-up of https://github.com/rhinstaller/kickstart-tests/pull/1173#issuecomment-2114457383