### PR TITLE
Prepare kickstart tests to handle the switch from VNC to RDP

### DIFF
--- a/default-systemd-target-rdp-graphical-provides.ks.in
+++ b/default-systemd-target-rdp-graphical-provides.ks.in
@@ -1,0 +1,36 @@
+#version=DEVEL
+#test name: default-systemd-target-rdp-graphical-provides
+#
+# Test multi-user.target is set as the default systemd target if:
+# - the installation runs in remote desktop mode
+# - the installation transaction contains a package providing service(graphical-login)
+# Text mode overrides the provides & for this RDP installation is considered to be
+# similar to textmode, as while controlled remotely over RDP, the installation run
+# itself runs in text mode.
+
+%ksappend repos/default.ks
+
+%ksappend common/common_no_payload.ks
+
+# the gdm package provides service(graphical-login)
+%packages
+gdm
+%end
+
+%post
+
+# the support script should run the installation in RDP mode via boot options
+cat /proc/cmdline | grep inst.rdp
+if [[ $? != 0 ]]; then
+    echo "*** inst.rdp not used to enable remote desktop mode" >> /root/RESULT
+    echo "*** /proc/cmdline:" >> /root/RESULT
+    cat /proc/cmdline >> /root/RESULT
+fi
+
+systemctl get-default | grep multi-user.target
+if [[ $? != 0 ]]; then
+    echo "*** multi-user.target should be set for remote desktop (RDP) installs even if package with service(graphical-login) is installed" >> /root/RESULT
+fi
+
+%ksappend validation/success_if_result_empty.ks
+%end

--- a/default-systemd-target-rdp-graphical-provides.sh
+++ b/default-systemd-target-rdp-graphical-provides.sh
@@ -1,0 +1,41 @@
+#
+# Copyright (C) 2024  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
+TESTTYPE="services skip-on-fedora skip-on-rhel-8 skip-on-rhel-9"
+
+. ${KSTESTDIR}/functions.sh
+. ${KSTESTDIR}/validate-lib-services.sh
+
+kernel_args() {
+    echo ${DEFAULT_BOOTOPTS} inst.rdp inst.rdp.username=user inst.rdp.password=12345
+}
+
+validate() {
+    # check output kickstart via validation library function
+    validate_skipx_in_ks $1
+    if [[ $? != 0 ]]; then
+        cat ${1}/RESULT
+        return 1
+    fi
+
+    validate_RESULT ${disksdir}
+    return $?
+}

--- a/default-systemd-target-rdp.ks.in
+++ b/default-systemd-target-rdp.ks.in
@@ -1,0 +1,29 @@
+#version=DEVEL
+#test name: default-systemd-target-rdp
+#
+# Test multi-user.target should be set by default as the default systemd target
+# for remote desktop installs. While controlled remotely over RDP the installation itself runs
+# in text mode and should behave as such.
+
+%ksappend repos/default.ks
+
+%ksappend common/common_no_payload.ks
+%ksappend payload/default_packages.ks
+
+%post
+
+# the support script should run the installation in RDP mode via boot options
+cat /proc/cmdline | grep inst.rdp
+if [[ $? != 0 ]]; then
+    echo "*** inst.rdp not used to enable remote desktop mode" >> /root/RESULT
+    echo "*** /proc/cmdline:" >> /root/RESULT
+    cat /proc/cmdline >> /root/RESULT
+fi
+
+systemctl get-default | grep multi-user.target
+if [[ $? != 0 ]]; then
+    echo "*** multi-user.target should be set as the default systemd target for remote desktop (RDP) installs" >> /root/RESULT
+fi
+
+%ksappend validation/success_if_result_empty.ks
+%end

--- a/default-systemd-target-rdp.sh
+++ b/default-systemd-target-rdp.sh
@@ -1,0 +1,41 @@
+#
+# Copyright (C) 2024  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
+TESTTYPE="services skip-on-fedora skip-on-rhel-8 skip-on-rhel-9"
+
+. ${KSTESTDIR}/functions.sh
+. ${KSTESTDIR}/validate-lib-services.sh
+
+kernel_args() {
+    echo ${DEFAULT_BOOTOPTS} inst.rdp inst.rdp.username=user inst.rdp.password=12345
+}
+
+validate() {
+    # check output kickstart via validation library function
+    validate_skipx_in_ks $1
+    if [[ $? != 0 ]]; then
+        cat ${1}/RESULT
+        return 1
+    fi
+
+    validate_RESULT ${disksdir}
+    return $?
+}

--- a/post-nochroot-lib-ui.sh
+++ b/post-nochroot-lib-ui.sh
@@ -24,3 +24,12 @@ function check_vnc_server_is_running() {
         echo "*** the VNC server is not running" >> ${RESULT_FILE}
     fi
 }
+
+# Check that the RDP server is running.
+function check_rdp_server_is_running() {
+    grep -q "GNOME remote desktop is now running." /tmp/anaconda.log
+
+    if [[ $? -ne 0 ]]; then
+        echo "*** the RDP server is not running" >> ${RESULT_FILE}
+    fi
+}

--- a/ui_rdp.ks.in
+++ b/ui_rdp.ks.in
@@ -1,0 +1,32 @@
+#version=DEVEL
+#test name: ui_rdp
+
+# Use defaults.
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
+%ksappend payload/default_packages.ks
+
+%post --nochroot
+
+# the support script should run the installation in RDP mode via boot options
+cat /proc/cmdline | grep inst.rdp
+if [[ $? != 0 ]]; then
+    echo "*** inst.rdp not used to enable remote desktop mode" >> /mnt/sysroot/root/RESULT
+    echo "*** /proc/cmdline:" >> /mnt/sysroot/root/RESULT
+    cat /proc/cmdline >> /mnt/sysroot/root/RESULT
+fi
+
+@KSINCLUDE@ post-nochroot-lib-ui.sh
+
+# Check the installation mode.
+check_display_mode "interactive graphical mode"
+
+# Check the RDP server.
+check_rdp_server_is_running
+
+%end
+
+# this needs to be separate so that checking /root/RESULT works as
+# expected due to the main %post section using --nochroot
+%ksappend validation/success_if_result_empty_standalone.ks
+

--- a/ui_rdp.sh
+++ b/ui_rdp.sh
@@ -1,0 +1,27 @@
+#
+# Copyright (C) 2024  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
+TESTTYPE="ui skip-on-fedora skip-on-rhel-8 skip-on-rhel-9"
+
+. ${KSTESTDIR}/functions.sh
+
+kernel_args() {
+    echo ${DEFAULT_BOOTOPTS} inst.rdp inst.rdp.username=user inst.rdp.password=12345
+}
+


### PR DESCRIPTION
The first commit disables VNC test on RHEL 10, while the second commit adds RDP version of the tests that are currently marked no to run on Fedora.

NOTE: Do not merge before the Wayland support PRs are merged!

Wayland PRs:
https://github.com/rhinstaller/anaconda/pull/5463
https://github.com/rhinstaller/anaconda/pull/5470
https://github.com/rhinstaller/anaconda/pull/5485
https://github.com/rhinstaller/anaconda/pull/5498