### PR TITLE
Fixup documentation for PR comment triggers

### DIFF
--- a/.github/workflows/test-os-variants.yml
+++ b/.github/workflows/test-os-variants.yml
@@ -1,11 +1,20 @@
 # Run kickstart tests in a PR triggered by a "/test-os-variants" command from an organization member
 #
-# /test-os-variants - execute all tests affected by the PR or smoke tests if there is no such.
-# Or specify tests by combination of test names and/or options:
-# /test-os-variants --testtype TESTTYPE --skip-testtypes TYPE[,TYPE..] TEST1 TEST2
+# To run all tests affected by the PR (or just smoke tests if the PR changes no tests)
+# use this in a PR comment:
 #
-# For dry run use:
-# /test-os-variants-dry
+#  /test-os-variants
+#
+# Alternatively it is also possible to specify tests to run or test to be skipped:
+#
+#  /test-os-variants --testtype TESTTYPE --skip-testtypes TYPE[,TYPE..] TEST1 TEST2
+#
+# Lastly there is a dry-run mode, that just indicates which tests would be run
+# (useful to check test grouping and overall infra health):
+#
+#  /test-os-variants-dry
+#
+#
 name: test-os-variants
 on:
   issue_comment:

--- a/README.rst
+++ b/README.rst
@@ -374,7 +374,7 @@ tests, and PRs usually just run a few tests so that flakes are much less likely
 to ruin the result.
 
 To test a PR on all supported os versions (including rhel) there is a
-`test-os-versions`_ workflow running the tests on a comment in a PR.
+`test-os-variants`_ workflow running the tests on a comment in a PR.
 Running it requires admin repository permissions.
 
 Service jobs


### PR DESCRIPTION
Looks like an (old ?) workflow name has been still reffered from the main README file. So fix that and also reformat the trigger documentation a bit.