### PR TITLE
Enable preexisting-btrfs on RHEL-10

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -66,7 +66,6 @@ rhel10_skip_array=(
   gh804       # tests requiring dvd iso failing
   gh1090      # raid-1-reqpart failing
   gh1104      # network-prefixdevname failing
-  gh1105      # preexisting btrfs failing
   gh1108      # proxy-auth, proxy-kickstart failing
   gh1107      # rpm-ostree-container failing
   gh1110      # storage-multipath-autopart failing

--- a/preexisting-btrfs.sh
+++ b/preexisting-btrfs.sh
@@ -38,7 +38,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="btrfs storage gh1105"
+TESTTYPE="btrfs storage"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
The problem is fixed in python-blivet-3.10.0-2.el10: https://issues.redhat.com/browse/RHEL-36190

Resolves: gh#1105