### PR TITLE
Fix proxy-auth and proxy-kickstart tests

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -13,7 +13,6 @@ fedora_skip_array=(
   gh576       # clearpart-4 test is flaky on all scenarios
   gh595       # proxy-cmdline failing on all scenarios
   gh641       # packages-multilib failing on systemd conflict
-  gh680       # proxy-kickstart and proxy-auth failing
   gh774       # autopart-luks-1 failing
   gh777       # raid-1-reqpart failing
   gh910       # stage2-from-ks test needs to be fixed for daily-iso
@@ -65,7 +64,6 @@ rhel10_skip_array=(
   gh804       # tests requiring dvd iso failing
   gh1090      # raid-1-reqpart failing
   gh1104      # network-prefixdevname failing
-  gh1108      # proxy-auth, proxy-kickstart failing
   gh1107      # rpm-ostree-container failing
   gh1110      # storage-multipath-autopart failing
   gh1178      # tests using ext2 failing

--- a/proxy-auth.ks.in
+++ b/proxy-auth.ks.in
@@ -28,17 +28,34 @@ if [[ ! -f /mnt/sysroot/etc/yum.repos.d/addon.repo ]]; then
 fi
 
 # Check that the proxy configuration was written to the repo file
-grep -q 'proxy=http://anaconda:qweqwe@PROXY-ADDON' /mnt/sysroot/etc/yum.repos.d/addon.repo
-if [[ $? -ne 0 ]]; then
+# The repo configuration has a different format on RHEL-10+/Fedora 40+
+os_name="@KSTEST_OS_NAME@"
+os_version="@KSTEST_OS_VERSION@"
+os_major=${os_version%%.*}
+
+if [ "${os_name}" == "rhel" ] && [ ${os_major} -lt 10 ]; then
+    grep -q 'proxy=http://anaconda:qweqwe@PROXY-ADDON' /mnt/sysroot/etc/yum.repos.d/addon.repo
+    proxy_rc=$?
+else
+    grep -qP 'proxy\s?=\s?http://PROXY-ADDON' /mnt/sysroot/etc/yum.repos.d/addon.repo && \
+    grep -qP 'proxy_username\s?=\s?anaconda' /mnt/sysroot/etc/yum.repos.d/addon.repo && \
+    grep -qP 'proxy_password\s?=\s?qweqwe' /mnt/sysroot/etc/yum.repos.d/addon.repo
+    proxy_rc=$?
+fi
+if [[ ${proxy_rc} -ne 0 ]]; then
     echo 'addon.repo does not contain proxy information' >> /mnt/sysroot/root/RESULT
+    echo "/etc/yum.repos.d/addon.repo content:" >> /mnt/sysroot/root/RESULT
+    cat /mnt/sysroot/etc/yum.repos.d/addon.repo >> /mnt/sysroot/root/RESULT
+    echo >> /mnt/sysroot/root/RESULT
+
 fi
 
 # Check that the installed repo file is usable
 # Find if this is using yum or dnf
 if [[ -f /mnt/sysroot/usr/bin/dnf ]]; then
-	BIN="dnf"
+    BIN="dnf"
 else
-	BIN="yum"
+    BIN="yum"
 fi
 
 # Clean packages to force package download
@@ -46,8 +63,8 @@ chroot /mnt/sysroot $BIN clean packages
 
 # Download package to test if the installed repository is usable
 chroot /mnt/sysroot \
-    $BIN --disablerepo=\* --enablerepo=addon --downloadonly --nogpgcheck -y \
-         reinstall mandatory-package-from-addon 2>/dev/null | \
+    $BIN reinstall --disablerepo=\* --enablerepo=addon --downloadonly --nogpgcheck -y \
+        mandatory-package-from-addon 2>/dev/null | \
         grep -q 'mandatory-package-from-addon'
 if [[ $? -ne 0 ]]; then
     echo 'unable to query addon repo' >> /mnt/sysroot/root/RESULT

--- a/proxy-auth.sh
+++ b/proxy-auth.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="method proxy gh680 gh1108"
+TESTTYPE="method proxy"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/functions-proxy.sh
@@ -29,6 +29,8 @@ prepare() {
     local tmp_dir=$2
     local httpd_url=""
     local proxy_url=""
+    httpd_url=$(cat ${tmpdir}/httpd_url)
+    proxy_url=$(cat ${tmpdir}/proxy_url)
     mkdir "${tmp_dir}/http"
 
     # Create the addon repository.

--- a/proxy-kickstart.ks.in
+++ b/proxy-kickstart.ks.in
@@ -29,25 +29,28 @@ if [[ ! -f /mnt/sysroot/etc/yum.repos.d/addon.repo ]]; then
 fi
 
 # Check that the proxy configuration was written to the repo file
-grep -q 'proxy=PROXY-ADDON' /mnt/sysroot/etc/yum.repos.d/addon.repo
+grep -qP 'proxy\s?=\s?PROXY-ADDON' /mnt/sysroot/etc/yum.repos.d/addon.repo
 if [[ $? -ne 0 ]]; then
     echo 'addon.repo does not contain proxy information' >> /mnt/sysroot/root/RESULT
+    echo "/etc/yum.repos.d/addon.repo content:" >> /mnt/sysroot/root/RESULT
+    cat /mnt/sysroot/etc/yum.repos.d/addon.repo >> /mnt/sysroot/root/RESULT
+    echo >> /mnt/sysroot/root/RESULT
 fi
 
 # Check that the installed repo file is usable
 # Find if this is using yum or dnf
 if [[ -f /mnt/sysroot/usr/bin/dnf ]]; then
-	BIN="dnf"
+    BIN="dnf"
 else
-	BIN="yum"
+    BIN="yum"
 fi
 
 # Clean packages to force package download
 chroot /mnt/sysroot $BIN clean packages
 # Download package to test if the installed repository is usable
 chroot /mnt/sysroot \
-    $BIN --disablerepo=\* --enablerepo=addon --downloadonly --nogpgcheck -y \
-         reinstall mandatory-package-from-addon 2>/dev/null | \
+    $BIN reinstall --disablerepo=\* --enablerepo=addon --downloadonly --nogpgcheck -y \
+        mandatory-package-from-addon 2>/dev/null | \
         grep -q 'mandatory-package-from-addon'
 if [[ $? -ne 0 ]]; then
     echo 'unable to query addon repo' >> /mnt/sysroot/root/RESULT

--- a/proxy-kickstart.sh
+++ b/proxy-kickstart.sh
@@ -20,7 +20,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="method proxy gh680 gh1108"
+TESTTYPE="method proxy"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/functions-proxy.sh
@@ -30,6 +30,8 @@ prepare() {
     local tmp_dir=$2
     local httpd_url=""
     local proxy_url=""
+    httpd_url=$(cat ${tmpdir}/httpd_url)
+    proxy_url=$(cat ${tmpdir}/proxy_url)
     mkdir "${tmp_dir}/http"
 
     # Create the addon repository.
@@ -52,7 +54,7 @@ prepare() {
     # Substitute variables in the kickstart file.
     sed -e  "/^repo/ s|HTTP-ADDON-REPO|${httpd_local_url}|" \
         -re "/^(repo|url)/ s|PROXY-ADDON|${proxy_url}|" \
-        -e  "/'proxy=/ s|PROXY-ADDON|${proxy_url%%/*}|" \
+        -e  "/'proxy\\\\s\?=/ s|PROXY-ADDON|${proxy_url%/*}|" \
         "${ks}" > "${tmp_dir}/ks.cfg"
 
     echo "${tmp_dir}/ks.cfg"


### PR DESCRIPTION
This covers issue #1108.

The change of dnf command/options order is necessary to work around https://bugzilla.redhat.com/show_bug.cgi?id=2280877 (DNF5 seems to have a bit of inconsistency in how it handles the options order, at least in some cases, compared to DNF4).