### PR TITLE
Switch rhel10 platform to centos images (gh#1190)

### DIFF
--- a/scripts/defaults-rhel10.sh
+++ b/scripts/defaults-rhel10.sh
@@ -3,7 +3,7 @@
 # This is a reasonable default used until the new release is detected by osinfo library.
 export KSTEST_OSINFO_NAME=fedora-eln
 source ./network-device-names.cfg
-export KSTEST_URL='http://download.eng.bos.redhat.com/rhel-10/nightly/RHEL-10-Public-Beta/latest-RHEL-10.0/compose/BaseOS/x86_64/os/'
-export KSTEST_MODULAR_URL='http://download.eng.bos.redhat.com/rhel-10/nightly/RHEL-10-Public-Beta/latest-RHEL-10.0/compose/AppStream/x86_64/os/'
+export KSTEST_URL='http://composes.stream.centos.org/stream-10/development/latest-CentOS-Stream/compose/BaseOS/x86_64/os/'
+export KSTEST_MODULAR_URL='http://composes.stream.centos.org/stream-10/development/latest-CentOS-Stream/compose/AppStream/x86_64/os/'
 export KSTEST_FTP_URL='ftp://ftp.tu-chemnitz.de/pub/linux/fedora/linux/development/rawhide/Everything/x86_64/os/'
 export KSTEST_OSTREECONTAINER_URL='quay.io/centos-bootc/centos-bootc:stream10'


### PR DESCRIPTION
Latest rhel10 nightly is broken
https://github.com/rhinstaller/kickstart-tests/issues/1190