### PR TITLE
Fix and enable multilib tests (gh#641)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -12,7 +12,6 @@ fedora_skip_array=(
   skip-on-fedora
   gh576       # clearpart-4 test is flaky on all scenarios
   gh595       # proxy-cmdline failing on all scenarios
-  gh641       # packages-multilib failing on systemd conflict
   gh680       # proxy-kickstart and proxy-auth failing
   gh740       # fedora-live-image-build fails on comps changes
   gh774       # autopart-luks-1 failing
@@ -53,7 +52,6 @@ rhel9_skip_array=(
   gh576       # clearpart-4 test is flaky on all scenarios
   gh595       # proxy-cmdline failing on all scenarios
   gh604       # packages-weakdeps: "gnupg2 --recommends has changed, test needs to be updated"
-  gh641       # packages-multilib failing on systemd conflict
   gh774       # autopart-luks-1 failing
   gh804       # tests requiring dvd iso failing
 )

--- a/packages-multilib.ks.in
+++ b/packages-multilib.ks.in
@@ -7,6 +7,7 @@
 %ksappend common/common_no_payload.ks
 
 %packages --multilib
+-fwupd
 %end
 
 %post

--- a/packages-multilib.sh
+++ b/packages-multilib.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging skip-on-rhel-8 gh641"
+TESTTYPE="packaging skip-on-rhel-8"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Skip package that has conflicting architectures.

This also depends on https://github.com/rhinstaller/anaconda/pull/5657