### PR TITLE
Disable tests using ext2 temporarily on rhel10 (gh#1178)

### DIFF
--- a/autopart-fstype.sh
+++ b/autopart-fstype.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage"
+TESTTYPE="autopart storage gh1178"
 
 
 . ${KSTESTDIR}/functions.sh

--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -69,6 +69,7 @@ rhel10_skip_array=(
   gh1108      # proxy-auth, proxy-kickstart failing
   gh1107      # rpm-ostree-container failing
   gh1110      # storage-multipath-autopart failing
+  gh1178      # tests using ext2 failing
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/mountpoint-assignment-1.sh
+++ b/mountpoint-assignment-1.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="mount storage coverage"
+TESTTYPE="mount storage coverage gh1178"
 
 . ${KSTESTDIR}/functions.sh

--- a/mountpoint-assignment-2.sh
+++ b/mountpoint-assignment-2.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="mount storage"
+TESTTYPE="mount storage gh1178"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Disable tests using ext2 until gh1178 is fixed.