### PR TITLE
Use get_platform function to account also for centos

### DIFF
--- a/proxy-auth.ks.in
+++ b/proxy-auth.ks.in
@@ -29,11 +29,11 @@ fi
 
 # Check that the proxy configuration was written to the repo file
 # The repo configuration has a different format on RHEL-10+/Fedora 40+
-os_name="@KSTEST_OS_NAME@"
-os_version="@KSTEST_OS_VERSION@"
-os_major=${os_version%%.*}
 
-if [ "${os_name}" == "rhel" ] && [ ${os_major} -lt 10 ]; then
+@KSINCLUDE@ scripts-lib.sh
+platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
+
+if [ "${platform}" == "rhel8" ] || [ "${platform}" == "rhel9" ]; then
     grep -q 'proxy=http://anaconda:qweqwe@PROXY-ADDON' /mnt/sysroot/etc/yum.repos.d/addon.repo
     proxy_rc=$?
 else


### PR DESCRIPTION
The original solution would not work for example for centos 9. We are not centos images currently, but to be more safer and consistent let's use the function which considers centos as a rhel platform.