### PR TITLE
Revert "Disable groups-and-envs-1 on fedora until gh#1222 is fixed"

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -22,7 +22,6 @@ fedora_skip_array=(
   gh975       # packages-default failing
   gh1023      # rpm-ostree failing
   gh1060      # vnc tests too flaky
-  gh1222      # groups-and-envs-1 failing
 )
 
 daily_iso_skip_array=(

--- a/groups-and-envs-1.sh
+++ b/groups-and-envs-1.sh
@@ -20,6 +20,6 @@
 # FIXME: times out on rhel8
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging skip-on-rhel gh1222"
+TESTTYPE="packaging skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
This reverts commit 04dbaa768184f86cec19de6040f39218f8ce3bcc.