### PR TITLE
Get list of installer image packages when probing boot.iso

### DIFF
--- a/containers/runner/README.md
+++ b/containers/runner/README.md
@@ -162,6 +162,6 @@ If you want to keep virtual machine of a finished test alive for further investi
 
 If you want to prevent killing virtual machine of a test on a failure detected in the log before the installation finishes (eg `Traceback` indicated in the log) it is possible to configure monitored messages in the [log monitor](/scripts/launcher/lib/log_monitor/log_handler.py) file.
 
-You can run the tests in dry-run mode using `--dry-run` option. It can be used to see which tests would be actually run and the kickstarts with substitutions applied.
+You can run the tests in dry-run mode using `--dry-run` option. It can be used to see which tests would be actually run and the kickstarts with substitutions applied. Or to get the list of packages composing the installer image.
 
 We are tracking the test suite issues and flakes in the repository issues. There is a [script](/scripts/classify-failures) to detect such known issues from test logs.

--- a/scripts/run_kickstart_tests.sh
+++ b/scripts/run_kickstart_tests.sh
@@ -182,7 +182,10 @@ ISO_OS_NAME=$(echo "${output}" | grep 'NAME=')
 ISO_OS_NAME="${ISO_OS_NAME##NAME=}"
 ISO_OS_VERSION=$(echo "${output}" | grep 'VERSION=')
 ISO_OS_VERSION="${ISO_OS_VERSION##VERSION=}"
-
+ISO_PACKAGES=$(echo "${output}" | grep 'PACKAGES=')
+ISO_PACKAGES="${ISO_PACKAGES##PACKAGES=}"
+echo Saving list of installer image packages to /var/tmp/kstest-image-packages.log
+echo $ISO_PACKAGES | tr ' ' '\n' | tee /var/tmp/kstest-image-packages.log
 
 # Append sed args to substitute
 sed_args=" -e s#@KSTEST_OS_NAME@#${ISO_OS_NAME}# -e s#@KSTEST_OS_VERSION@#${ISO_OS_VERSION}#"


### PR DESCRIPTION
You can see the change in action in the /test-os-variants workflow of this PR, step "Run kickstart tests in container" (near "Saving list of installer image packages to /var/tmp/kstest-image-packages.log")
or in logs / artefacts of the workflow (eg logs-daily-iso) where you can find kstest-image-packages.log. 