### PR TITLE
Do not run VNC tests on rhel10.

### DIFF
--- a/default-systemd-target-vnc-graphical-provides.sh
+++ b/default-systemd-target-vnc-graphical-provides.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="services gh890"
+TESTTYPE="services gh890 skip-on-rhel-10"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/validate-lib-services.sh

--- a/default-systemd-target-vnc.sh
+++ b/default-systemd-target-vnc.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="services gh1060"
+TESTTYPE="services gh1060 skip-on-rhel-10"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/validate-lib-services.sh

--- a/ui_vnc.sh
+++ b/ui_vnc.sh
@@ -17,6 +17,6 @@
 #
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="ui gh1060"
+TESTTYPE="ui gh1060 skip-on-rhel-10"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
VNC functionality is removed in RHEL 10.

Related: RHEL-38407