### PR TITLE
Ignore all deprecated kernel drivers

### DIFF
--- a/scripts/launcher/lib/log_monitor/log_handler.py
+++ b/scripts/launcher/lib/log_monitor/log_handler.py
@@ -33,11 +33,8 @@ class VirtualLogRequestHandler(LogRequestHandler):
         # Based on the bug #1886809, it is a non critical error.
         "CRIT mdadm:DegradedArray event detected",
 
-        # Team networking is deprecated
-        "CRIT kernel:Warning: Deprecated Driver is detected: team ",
-
-        # qla4xxx driver is deprecated (gh#1077)
-        "CRIT kernel:Warning: Deprecated Driver is detected: qla4xxx ",
+        # Ignore deprecated kernel drivers
+        "CRIT kernel:Warning: Deprecated Driver is detected: ",
 
         # Ignore a call trace during debugging.
         # Ignoring permanently for gh768.


### PR DESCRIPTION
There are new deprecated kernel drivers: bnx2i and cnic. Instead of listing new drivers every time, simply ignore all kernel driver deprecation warnings.