### PR TITLE
Do not use ELN for default ostreecontainer URL

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -22,7 +22,6 @@ fedora_skip_array=(
   gh975       # packages-default failing
   gh1023      # rpm-ostree failing
   gh1060      # vnc tests too flaky
-  gh1230      # rpm-ostree-conainer-{luks,bootc} failing
   gh1237      # container failing
   gh1250      # rpm-ostree-container-luks fails to boot
 )

--- a/rpm-ostree-container-bootc.sh
+++ b/rpm-ostree-container-bootc.sh
@@ -18,7 +18,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="payload ostree bootc reboot skip-on-rhel-8 skip-on-rhel-10 gh1230"
+TESTTYPE="payload ostree bootc reboot skip-on-rhel-8 skip-on-rhel-10"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/rpm-ostree-container-luks.sh
+++ b/rpm-ostree-container-luks.sh
@@ -18,7 +18,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="payload ostree bootc luks reboot skip-on-rhel-8 skip-on-rhel-10 gh1230 gh1250"
+TESTTYPE="payload ostree bootc luks reboot skip-on-rhel-8 skip-on-rhel-10 gh1250"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/scripts/defaults.sh
+++ b/scripts/defaults.sh
@@ -12,4 +12,4 @@ export KSTEST_METALINK='https://mirrors.fedoraproject.org/metalink?repo=fedora-$
 export KSTEST_MIRRORLIST='https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=x86_64'
 export KSTEST_MODULAR_URL='http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Modular/x86_64/os/'
 export KSTEST_FTP_URL='ftp://ftp.tu-chemnitz.de/pub/linux/fedora/linux/development/rawhide/Everything/x86_64/os/'
-export KSTEST_OSTREECONTAINER_URL='quay.io/centos-bootc/fedora-bootc:eln'
+export KSTEST_OSTREECONTAINER_URL='quay.io/fedora/fedora-bootc:rawhide'


### PR DESCRIPTION
ELN container image is not accessible anymore it returns 403 Unauthorized. Let's use fedora rawhide bootc image instead.

Fixes #1230.

This is fixing the issue - however, the luks test seems to have an issue with booting after the installation.