### PR TITLE
Enable rpm-ostree-container tests on rhel-10

### DIFF
--- a/rpm-ostree-container-bootc.sh
+++ b/rpm-ostree-container-bootc.sh
@@ -18,7 +18,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="payload ostree bootc reboot skip-on-rhel-8 skip-on-rhel-10"
+TESTTYPE="payload ostree bootc reboot skip-on-rhel-8"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/rpm-ostree-container-luks.sh
+++ b/rpm-ostree-container-luks.sh
@@ -18,7 +18,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="payload ostree bootc luks reboot skip-on-rhel-8 skip-on-rhel-10 gh1250"
+TESTTYPE="payload ostree bootc luks reboot skip-on-rhel-8 gh1250"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
There is no reason to have these disabled on rhel-10. I guess it's here for historical reasons.