### PR TITLE
Do not print ISO packages to terminal

### DIFF
--- a/scripts/run_kickstart_tests.sh
+++ b/scripts/run_kickstart_tests.sh
@@ -185,7 +185,7 @@ ISO_OS_VERSION="${ISO_OS_VERSION##VERSION=}"
 ISO_PACKAGES=$(echo "${output}" | grep 'PACKAGES=')
 ISO_PACKAGES="${ISO_PACKAGES##PACKAGES=}"
 echo Saving list of installer image packages to /var/tmp/kstest-image-packages.log
-echo $ISO_PACKAGES | tr ' ' '\n' | tee /var/tmp/kstest-image-packages.log
+echo $ISO_PACKAGES | tr ' ' '\n' > /var/tmp/kstest-image-packages.log
 
 # Append sed args to substitute
 sed_args=" -e s#@KSTEST_OS_NAME@#${ISO_OS_NAME}# -e s#@KSTEST_OS_VERSION@#${ISO_OS_VERSION}#"


### PR DESCRIPTION
It's making the output of the running test messy and it is not helpful most of the time. Having this in a log should be enough.

Output without this patch:
```
Using existing data/images/boot.iso
+ /usr/bin/podman run -it --rm --device=/dev/kvm --publish 127.0.0.1::16509 --env SCENARIO=unknown --env DRY_RUN= --env KSTESTS_TEST=keyboard --env TESTTYPE= --env SKIP_TESTTYPES= --env KSTESTS_RUN_TIMEOUT= --env TEST_JOBS=16 --env PLATFORM=fedora_rawhide --env TEST_RETRY= --env KSTESTS_KEEP=1 -v /var/tmp -v /var/home/jkonecny/Documents/RH/projects/kickstart-tests/data:/opt/kstest/data:z -v /var/home/jkonecny/Documents/RH/projects/kickstart-tests:/kickstart-tests:ro,z -v ./scripts/defaults-fedora_rawhide.sh:/home/kstest/.kstests.defaults.sh:ro,z quay.io/rhinstaller/kstest-runner /kickstart-tests/containers/runner/run-kstest
+ KSTESTS_REPOSITORY=https://github.com/rhinstaller/kickstart-tests
+ KSTESTS_BRANCH=master
+ KSTESTS_DIR=/opt/kstest/kickstart-tests
+ KSTESTS_TEST=keyboard
+ KSTESTS_KEEP=1
+ TIMEOUT=0
+ SCENARIO=unknown
+ UPDATES_IMAGE=
+ BOOT_ISO=boot.iso
+ ISO_DIR=/opt/kstest/data/images
+ LOGS_DIR=/opt/kstest/data/logs
+ '[' -d /kickstart-tests ']'
+ rsync -r --exclude /data/ /kickstart-tests/ /opt/kstest/kickstart-tests
skipping non-regular file "scripts/defaults-fedora_rawhide.sh"
+ UPDATES_IMAGE_ARG=
+ '[' -n '' ']'
+ PLATFORM_ARG=
+ '[' -n fedora_rawhide ']'
+ PLATFORM_ARG='-p fedora_rawhide'
+ TESTTYPE_ARG=
+ '[' -n '' ']'
+ SKIP_TESTTYPES_ARG=
+ '[' -n '' ']'
+ RETRY_ARG=
+ '[' -n '' ']'
+ DRY_RUN_ARG=
+ '[' -n '' ']'
+ mkdir -p /home/kstest/.cache/virt-manager/boot
+ mkdir -p /home/kstest/.config/libvirt
+ printf 'listen_tls = 0\nlisten_tcp = 1\nauth_tcp = "none"\n'
+ virtproxyd -f /home/kstest/.config/libvirt/virtproxyd.conf
++ ip -4 -c a show dev eth0
++ grep -Eo '[0-9.]+\.[0-9]+'
++ grep -v '\.255'
+ MY_IP=10.88.0.7
+ set +x
************************************************************************
You can connect to this container's libvirt with this connection string:

   qemu+tcp://10.88.0.7/session

************************************************************************
+ TEST_LOG=/var/tmp/kstest.log
+ pushd /opt/kstest/kickstart-tests
/opt/kstest/kickstart-tests /opt/kstest
+ set +e
+ scripts/run_kickstart_tests.sh -x 0 -k 1 -i /opt/kstest/data/images/boot.iso -p fedora_rawhide keyboard
+ tee /var/tmp/kstest.log
starting kickstart tests
Tue Jul 16 16:36:36 UTC 2024
2024-07-16 16:36:36.437+0000: 33: info : libvirt version: 9.7.0, package: 4.fc39 (Fedora Project, 2024-06-05-16:03:49, )
2024-07-16 16:36:36.437+0000: 33: info : hostname: 61e308b36644
2024-07-16 16:36:36.437+0000: 33: error : virGDBusGetSessionBus:126 : internal error: Unable to get session bus connection: Cannot autolaunch D-Bus without X11 $DISPLAY
2024-07-16 16:36:36.437+0000: 33: error : virGDBusGetSystemBus:99 : internal error: Unable to get system bus connection: Could not connect: No such file or directory
Extract filename /LiveOS/rootfs.img can't be resolved
Saving list of installer image packages to /var/tmp/kstest-image-packages.log
libgcc-14.1.1-5.el10.x86_64
fonts-filesystem-2.0.5-16.el10.noarch
redhat-text-vf-fonts-4.0.3-12.el10.noarch
google-noto-fonts-common-20240401-1.el10.noarch
google-noto-sans-vf-fonts-20240401-1.el10.noarch
linux-firmware-whence-20240624-5.el10.noarch
crypto-policies-20240522-2.git77963ab.el10.noarch
tzdata-2024a-4.el10.noarch
google-noto-sans-devanagari-vf-fonts-20240401-1.el10.noarch
xkeyboard-config-2.41-2.el10.noarch
hwdata-0.379-10.0.el10.1.noarch
google-noto-sans-bengali-vf-fonts-20240401-1.el10.noarch
google-noto-sans-hebrew-vf-fonts-20240401-1.el10.noarch
pcre2-syntax-10.42-3.el10.1.noarch
mesa-filesystem-24.1.2-1.el10.x86_64
default-fonts-he-4.1-1.el10.noarch
default-fonts-yi-4.1-1.el10.noarch
default-fonts-as-4.1-1.el10.noarch
default-fonts-bn-4.1-1.el10.noarch
default-fonts-hi-4.1-1.el10.noarch
default-fonts-mai-4.1-1.el10.noarch
default-fonts-mr-4.1-1.el10.noarch
amd-gpu-firmware-20240624-5.el10.noarch
amd-ucode-firmware-20240624-5.el10.noarch
atheros-firmware-20240624-5.el10.noarch
brcmfmac-firmware-20240624-5.el10.noarch
intel-gpu-firmware-20240624-5.el10.noarch
mt7xxx-firmware-20240624-5.el10.noarch
nvidia-gpu-firmware-20240624-5.el10.noarch
nxpwireless-firmware-20240624-5.el10.noarch
realtek-firmware-20240624-5.el10.noarch
tiwilink-firmware-20240624-5.el10.noarch
linux-firmware-20240624-5.el10.noarch
default-fonts-ast-4.1-1.el10.noarch
default-fonts-be-4.1-1.el10.noarch
default-fonts-bg-4.1-1.el10.noarch
default-fonts-br-4.1-1.el10.noarch
default-fonts-core-sans-4.1-1.el10.noarch
default-fonts-dz-4.1-1.el10.noarch
default-fonts-el-4.1-1.el10.noarch
default-fonts-eo-4.1-1.el10.noarch
default-fonts-eu-4.1-1.el10.noarch
default-fonts-ia-4.1-1.el10.noarch
default-fonts-ku-4.1-1.el10.noarch
default-fonts-nb-4.1-1.el10.noarch
default-fonts-nn-4.1-1.el10.noarch
default-fonts-nr-4.1-1.el10.noarch
default-fonts-nso-4.1-1.el10.noarch
default-fonts-ru-4.1-1.el10.noarch
default-fonts-ss-4.1-1.el10.noarch
default-fonts-tn-4.1-1.el10.noarch
default-fonts-ts-4.1-1.el10.noarch
default-fonts-uk-4.1-1.el10.noarch
default-fonts-ve-4.1-1.el10.noarch
default-fonts-vi-4.1-1.el10.noarch
default-fonts-xh-4.1-1.el10.noarch
default-fonts-zu-4.1-1.el10.noarch
google-noto-sans-arabic-vf-fonts-20240401-1.el10.noarch
default-fonts-ar-4.1-1.el10.noarch
google-noto-sans-armenian-vf-fonts-20240401-1.el10.noarch
default-fonts-hy-4.1-1.el10.noarch
google-noto-sans-canadian-aboriginal-vf-fonts-20240401-1.el10.noarch
default-fonts-iu-4.1-1.el10.noarch
google-noto-sans-cherokee-vf-fonts-20240401-1.el10.noarch
default-fonts-chr-4.1-1.el10.noarch
google-noto-sans-ethiopic-vf-fonts-20240401-1.el10.noarch
default-fonts-am-4.1-1.el10.noarch
google-noto-sans-georgian-vf-fonts-20240401-1.el10.noarch
default-fonts-ka-4.1-1.el10.noarch
google-noto-sans-gujarati-vf-fonts-20240401-1.el10.noarch
default-fonts-gu-4.1-1.el10.noarch
google-noto-sans-gurmukhi-vf-fonts-20240401-1.el10.noarch
default-fonts-pa-4.1-1.el10.noarch
google-noto-sans-kannada-vf-fonts-20240401-1.el10.noarch
default-fonts-kn-4.1-1.el10.noarch
google-noto-sans-khmer-vf-fonts-20240401-1.el10.noarch
default-fonts-km-4.1-1.el10.noarch
google-noto-sans-lao-vf-fonts-20240401-1.el10.noarch
default-fonts-lo-4.1-1.el10.noarch
google-noto-sans-meeteimayek-vf-fonts-20240401-1.el10.noarch
default-fonts-mni-4.1-1.el10.noarch
google-noto-sans-ol-chiki-vf-fonts-20240401-1.el10.noarch
default-fonts-sat-4.1-1.el10.noarch
google-noto-sans-oriya-vf-fonts-20240401-1.el10.noarch
default-fonts-or-4.1-1.el10.noarch
google-noto-sans-sinhala-vf-fonts-20240401-1.el10.noarch
default-fonts-si-4.1-1.el10.noarch
google-noto-sans-tamil-vf-fonts-20240401-1.el10.noarch
default-fonts-ta-4.1-1.el10.noarch
google-noto-sans-telugu-vf-fonts-20240401-1.el10.noarch
default-fonts-te-4.1-1.el10.noarch
google-noto-sans-thaana-vf-fonts-20240401-1.el10.noarch
default-fonts-dv-4.1-1.el10.noarch
google-noto-sans-thai-vf-fonts-20240401-1.el10.noarch
default-fonts-th-4.1-1.el10.noarch
jomolhari-fonts-0.003-42.el10.noarch
default-fonts-bo-4.1-1.el10.noarch
madan-fonts-2.000-39.el10.noarch
default-fonts-ne-4.1-1.el10.noarch
paktype-naskh-basic-fonts-6.0-13.el10.noarch
default-fonts-ur-4.1-1.el10.noarch
rit-meera-new-fonts-1.5.2-4.el10.noarch
default-fonts-ml-4.1-1.el10.noarch
sil-padauk-fonts-3.003-15.el10.noarch
default-fonts-my-4.1-1.el10.noarch
vazirmatn-vf-fonts-33.003-7.el10.noarch
default-fonts-fa-4.1-1.el10.noarch
vim-data-9.1.083-2.el10.noarch
quota-nls-4.09-6.el10.noarch
publicsuffix-list-dafsa-20240107-4.el10.noarch
ncurses-base-6.4-13.20240127.el10.noarch
mutter-common-46.3-1.el10.noarch
mobile-broadband-provider-info-20230416-6.el10.noarch
libwacom-data-2.12.2-2.el10.noarch
libssh-config-0.10.6-7.el10.noarch
libreport-filesystem-2.17.14-2.el10.noarch
libX11-common-1.8.7-7.el10.noarch
langtable-0.0.65-3.el10.noarch
kbd-misc-2.6.4-4.el10.noarch
kbd-legacy-2.6.4-4.el10.noarch
gnome-control-center-filesystem-46.2-3.el10.noarch
fuse-common-3.16.2-5.el10.x86_64
dnf-data-4.20.0-4.el10.noarch
coreutils-common-9.4-7.el10.x86_64
containers-common-0.57.3-4.el10.noarch
centos-gpg-keys-10.0-0.14.el10.noarch
centos-stream-repos-10.0-0.14.el10.noarch
centos-stream-release-10.0-0.14.el10.noarch
setup-2.14.5-3.el10.noarch
filesystem-3.18-9.el10.x86_64
efi-filesystem-5-12.el10.noarch
basesystem-11-21.el10.noarch
glibc-all-langpacks-2.39-17.el10.x86_64
glibc-gconv-extra-2.39-17.el10.x86_64
glibc-common-2.39-17.el10.x86_64
glibc-2.39-17.el10.x86_64
ncurses-libs-6.4-13.20240127.el10.x86_64
bash-5.2.26-4.el10.x86_64
zlib-ng-compat-2.1.6-3.el10.x86_64
libuuid-2.40.2-4.el10.x86_64
libstdc++-14.1.1-5.el10.x86_64
libblkid-2.40.2-4.el10.x86_64
xz-libs-5.4.6-3.el10.x86_64
libxml2-2.12.5-2.el10.x86_64
libzstd-1.5.5-6.el10.x86_64
popt-1.19-7.el10.x86_64
readline-8.2-9.el10.x86_64
sqlite-libs-3.45.1-3.el10.x86_64
bzip2-libs-1.0.8-19.el10.x86_64
libxkbcommon-1.7.0-2.el10.x86_64
expat-2.6.2-1.el10.x86_64
elfutils-libelf-0.191-5.el10.x86_64
json-c-0.17-4.el10.x86_64
keyutils-libs-1.6.3-4.el10.x86_64
libcom_err-1.47.1-1.el10.x86_64
libffi-3.4.4-8.el10.x86_64
libwayland-client-1.23.0-1.el10.x86_64
libxcrypt-4.4.36-9.el10.x86_64
nspr-4.35.0-22.el10.x86_64
libpng-1.6.40-4.el10.x86_64
pcre2-10.42-3.el10.1.x86_64
grep-3.11-9.el10.x86_64
nss-util-3.101.0-1.el10.x86_64
alsa-lib-1.2.12-1.el10.x86_64
libX11-xcb-1.8.7-7.el10.x86_64
libcap-ng-0.8.4-5.el10.x86_64
audit-libs-4.0-9.el10.x86_64
libgpg-error-1.50-1.el10.x86_64
grub2-common-2.06-120.el10.noarch
libattr-2.5.2-4.el10.x86_64
libacl-2.3.2-2.el10.x86_64
libicu-74.2-2.el10.x86_64
libedit-3.1-51.20230828cvs.el10.x86_64
fribidi-1.0.14-3.el10.x86_64
gmp-6.2.1-9.el10.x86_64
libjpeg-turbo-3.0.2-3.el10.x86_64
libnghttp2-1.61.0-1.el10.x86_64
libnl3-3.9.0-4.el10.x86_64
libogg-1.3.5-9.el10.x86_64
libseccomp-2.5.3-9.el10.x86_64
libsepol-3.7-1.el10.x86_64
libselinux-3.7-2.el10.x86_64
libmount-2.40.2-4.el10.x86_64
sed-4.9-2.el10.x86_64
findutils-4.10.0-4.el10.x86_64
libunistring-1.1-9.el10.x86_64
libidn2-2.3.7-2.el10.x86_64
opus-1.4-5.el10.x86_64
libvorbis-1.3.7-11.el10.x86_64
e2fsprogs-libs-1.47.1-1.el10.x86_64
libfdisk-2.40.2-4.el10.x86_64
alternatives-1.26-4.el10.x86_64
gdbm-libs-1.23-7.el10.x86_64
libbrotli-1.1.0-4.el10.x86_64
libsmartcols-2.40.2-4.el10.x86_64
libtasn1-4.19.0-7.el10.x86_64
p11-kit-0.25.3-9.el10.x86_64
lua-libs-5.4.6-6.el10.x86_64
p11-kit-trust-0.25.3-9.el10.x86_64
libpsl-0.21.5-4.el10.x86_64
libsemanage-3.7-1.el10.x86_64
mpfr-4.2.1-4.el10.x86_64
gawk-5.3.0-4.el10.x86_64
libwayland-cursor-1.23.0-1.el10.x86_64
libwayland-server-1.23.0-1.el10.x86_64
file-libs-5.45-6.el10.x86_64
file-5.45-6.el10.x86_64
hicolor-icon-theme-0.17-19.el10.noarch
fuse3-libs-3.16.2-5.el10.x86_64
jansson-2.14-2.el10.x86_64
lcms2-2.16-5.el10.x86_64
libXau-1.0.11-7.el10.x86_64
libxcb-1.17.0-2.el10.x86_64
libX11-1.8.7-7.el10.x86_64
libXext-1.3.6-2.el10.x86_64
libXfixes-6.0.1-4.el10.x86_64
libXi-1.8.1-6.el10.x86_64
libXinerama-1.1.5-7.el10.x86_64
libXrender-0.9.11-7.el10.x86_64
libXrandr-1.5.4-4.el10.x86_64
libXtst-1.2.4-7.el10.x86_64
libXdamage-1.1.6-4.el10.x86_64
libXcursor-1.2.1-8.el10.x86_64
libaio-0.3.111-20.el10.x86_64
libeconf-0.6.2-3.el10.x86_64
pam-libs-1.6.1-3.el10.x86_64
shadow-utils-4.15.0-3.el10.x86_64
libcap-2.69-5.el10.x86_64
systemd-libs-256-3.el10.x86_64
openssl-libs-3.2.2-6.el10.x86_64
coreutils-9.4-7.el10.x86_64
ca-certificates-2023.2.62_v7.0.401-7.el10.noarch
kmod-libs-31-6.el10.x86_64
dbus-libs-1.14.10-4.el10.x86_64
kmod-31-6.el10.x86_64
libevent-2.1.12-14.el10.x86_64
avahi-libs-0.8-27.el10.x86_64
tpm2-tss-4.1.3-2.el10.x86_64
gzip-1.13-2.el10.x86_64
libusb1-1.0.27-3.el10.x86_64
util-linux-core-2.40.2-4.el10.x86_64
daxctl-libs-78-4.el10.x86_64
composefs-libs-1.0.4-1.el10.x86_64
bubblewrap-0.9.0-2.el10.x86_64
libepoxy-1.5.10-8.el10.x86_64
libevdev-1.13.1-5.el10.x86_64
libglvnd-1.7.0-5.el10.x86_64
libpciaccess-0.16-15.el10.x86_64
libdrm-2.4.121-2.el10.x86_64
libverto-0.3.2-9.el10.x86_64
krb5-libs-1.21.2-7.el10.x86_64
libtirpc-1.3.4-1.rc2.el10.3.x86_64
libwayland-egl-1.23.0-1.el10.x86_64
libxshmfence-1.3.2-4.el10.x86_64
nettle-3.9.1-10.el10.x86_64
gnutls-3.8.5-5.el10.x86_64
glib2-2.80.4-1.el10.x86_64
libblockdev-utils-3.1.0-5.el10.x86_64
polkit-libs-124-3.el10.x86_64
json-glib-1.8.0-4.el10.x86_64
libgudev-238-6.el10.x86_64
NetworkManager-libnm-1.48.4-1.el10.1.x86_64
gsettings-desktop-schemas-46.0-5.el10.x86_64
libblockdev-3.1.0-5.el10.x86_64
graphene-1.10.6-9.el10.x86_64
libsoup3-3.4.4-5.el10.x86_64
shared-mime-info-2.3-7.el10.x86_64
gdk-pixbuf2-2.42.10-11.el10.x86_64
cups-libs-2.4.10-1.el10.x86_64
libnotify-0.8.3-4.el10.x86_64
libgusb-0.4.9-3.el10.x86_64
colord-libs-1.4.7-5.el10.x86_64
libblockdev-fs-3.1.0-5.el10.x86_64
libblockdev-loop-3.1.0-5.el10.x86_64
gobject-introspection-1.79.1-5.el10.x86_64
protobuf-c-1.5.0-4.el10.x86_64
userspace-rcu-0.14.0-6.el10.x86_64
gtk-update-icon-cache-3.24.42-2.el10.x86_64
libxmlb-0.3.15-6.el10.x86_64
geocode-glib-3.26.4-13.el10.x86_64
ModemManager-glib-1.22.0-5.el10.x86_64
avahi-glib-0.8-27.el10.x86_64
libtracker-sparql-3.7.3-3.el10.x86_64
libudisks2-2.10.1-5.el10.x86_64
ndctl-libs-78-4.el10.x86_64
cracklib-2.9.11-6.el10.x86_64
cracklib-dicts-2.9.11-6.el10.x86_64
libpwquality-1.4.5-10.el10.x86_64
libnvme-1.9-2.el10.x86_64
libblockdev-nvme-3.1.0-5.el10.x86_64
libatasmart-0.19-29.el10.x86_64
procps-ng-4.0.4-4.el10.x86_64
kbd-2.6.4-4.el10.x86_64
libXcomposite-0.4.6-4.el10.x86_64
libxkbfile-1.1.3-2.el10.x86_64
libbytesize-2.10-4.el10.x86_64
libselinux-utils-3.7-2.el10.x86_64
llvm-libs-18.1.2-5.el10.x86_64
mesa-libglapi-24.1.2-1.el10.x86_64
mesa-dri-drivers-24.1.2-1.el10.x86_64
mesa-libgbm-24.1.2-1.el10.x86_64
libglvnd-egl-1.7.0-5.el10.x86_64
mesa-libEGL-24.1.2-1.el10.x86_64
libglvnd-gles-1.7.0-5.el10.x86_64
libassuan-2.5.6-5.el10.x86_64
libgcrypt-1.11.0-1.el10.x86_64
gcr-libs-4.1.0-5.el10.x86_64
xz-5.4.6-3.el10.x86_64
libbpf-1.4.0-3.el10.x86_64
xml-common-0.6.3-64.el10.noarch
dbus-common-1.14.10-4.el10.noarch
bluez-libs-5.72-5.el10.x86_64
cpio-2.15-2.el10.x86_64
diffutils-3.10-6.el10.x86_64
dosfstools-4.2-11.el10.x86_64
efivar-libs-39-2.el10.x86_64
fdk-aac-free-2.0.0-14.el10.x86_64
fuse-libs-2.9.9-22.el10.gating_test1.x86_64
gsm-1.0.22-7.el10.x86_64
lame-libs-3.100-18.el10.x86_64
libICE-1.1.1-4.el10.x86_64
libmaxminddb-1.9.1-3.el10.x86_64
libmnl-1.0.5-6.el10.x86_64
libref_array-0.1.5-57.el10.x86_64
libtdb-1.4.10-2.el10.x86_64
libtool-ltdl-2.4.7-12.el10.x86_64
libwebp-1.3.2-5.el10.x86_64
libwinpr-3.6.2-1.el10.x86_64
libyaml-0.2.5-15.el10.x86_64
lmdb-libs-0.9.32-2.el10.x86_64
lz4-libs-1.9.4-7.el10.x86_64
libarchive-3.7.2-7.el10.x86_64
pciutils-libs-3.13.0-2.el10.x86_64
pixman-0.43.0-4.el10.x86_64
pciutils-3.13.0-2.el10.x86_64
libSM-1.2.4-4.el10.x86_64
mokutil-0.6.0-10.el10.x86_64
dbus-broker-35-6.el10.x86_64
dbus-1.14.10-4.el10.x86_64
dconf-0.40.0-13.el10.x86_64
geoclue2-2.7.0-6.el10.x86_64
geoclue2-libs-2.7.0-6.el10.x86_64
ibus-libs-1.5.30-6.el10.x86_64
iso-codes-4.16.0-4.el10.noarch
vulkan-loader-1.3.283.0-3.el10.x86_64
mesa-vulkan-drivers-24.1.2-1.el10.x86_64
libgweather-4.4.2-3.el10.x86_64
upower-libs-1.90.4-3.el10.x86_64
initscripts-rename-device-10.21-2.el10.x86_64
libsecret-0.21.2-5.el10.x86_64
lsof-4.98.0-5.el10.x86_64
quota-4.09-6.el10.x86_64
libssh-0.10.6-7.el10.x86_64
plymouth-core-libs-24.004.60-12.el10.x86_64
composefs-1.0.4-1.el10.x86_64
cxl-libs-78-4.el10.x86_64
ima-evm-utils-1.5-5.el10.x86_64
tmux-3.3a-9.20230918gitb202a2f.el10.x86_64
dbus-tools-1.14.10-4.el10.x86_64
dbus-daemon-1.14.10-4.el10.x86_64
dbus-x11-1.14.10-4.el10.x86_64
python3-pip-wheel-23.3.2-3.el10.noarch
centos-logos-100.1-1.el10.x86_64
openssl-3.2.2-6.el10.x86_64
sound-theme-freedesktop-0.8-22.el10.noarch
which-2.21-42.el10.x86_64
fuse-2.9.9-22.el10.gating_test1.x86_64
isns-utils-libs-0.101-10.el10.x86_64
rpm-sequoia-1.6.0-3.el10.x86_64
rpm-libs-4.19.1.1-2.el10.x86_64
libmodulemd-2.15.0-11.el10.x86_64
libsolv-0.7.29-6.el10.x86_64
libXv-1.0.12-4.el10.x86_64
libXxf86vm-1.1.5-7.el10.x86_64
libglvnd-glx-1.7.0-5.el10.x86_64
mesa-libGL-24.1.2-1.el10.x86_64
libva-2.22.0-1.el10.x86_64
xprop-1.2.7-2.el10.x86_64
at-spi2-core-2.52.0-2.el10.x86_64
atk-2.52.0-2.el10.x86_64
at-spi2-atk-2.52.0-2.el10.x86_64
libxkbcommon-x11-1.7.0-2.el10.x86_64
xcb-util-0.4.1-6.el10.x86_64
startup-notification-0.12-30.el10.x86_64
cyrus-sasl-lib-2.1.28-23.el10.x86_64
openldap-2.6.7-3.el10.x86_64
libcurl-8.6.0-8.el10.x86_64
curl-8.6.0-8.el10.x86_64
rpm-4.19.1.1-2.el10.x86_64
color-filesystem-1-34.el10.noarch
createrepo_c-libs-1.1.2-2.el10.x86_64
createrepo_c-1.1.2-2.el10.x86_64
libnfsidmap-2.6.4-0.rc4.el10.1.x86_64
gdbm-1.23-7.el10.x86_64
pam-1.6.1-3.el10.x86_64
authselect-1.5.0-5.el10.x86_64
authselect-libs-1.5.0-5.el10.x86_64
cryptsetup-libs-2.7.3-1.el10.x86_64
device-mapper-libs-1.02.197-2.el10.x86_64
device-mapper-1.02.197-2.el10.x86_64
elfutils-debuginfod-client-0.191-5.el10.x86_64
elfutils-libs-0.191-5.el10.x86_64
elfutils-default-yama-scope-0.191-5.el10.noarch
libutempter-1.2.1-14.el10.x86_64
systemd-pam-256-3.el10.x86_64
util-linux-2.40.2-4.el10.x86_64
systemd-256-3.el10.x86_64
policycoreutils-3.7-1.el10.x86_64
selinux-policy-40.13.4-1.el10.noarch
selinux-policy-targeted-40.13.4-1.el10.noarch
libblockdev-swap-3.1.0-5.el10.x86_64
device-mapper-event-libs-1.02.197-2.el10.x86_64
parted-3.6-5.el10.x86_64
initscripts-service-10.21-2.el10.noarch
iputils-20240117-5.el10.x86_64
iscsi-initiator-utils-iscsiuio-6.2.1.9-21.gita65a472.el10.x86_64
iscsi-initiator-utils-6.2.1.9-21.gita65a472.el10.x86_64
libblockdev-part-3.1.0-5.el10.x86_64
nvme-cli-2.9.1-2.el10.x86_64
openssh-9.6p1-1.el10.4.x86_64
libblockdev-dm-3.1.0-5.el10.x86_64
kpartx-0.9.7-10.el10.x86_64
audit-rules-4.0-9.el10.x86_64
audit-4.0-9.el10.x86_64
device-mapper-event-1.02.197-2.el10.x86_64
lvm2-libs-2.03.23-2.el10.x86_64
chrony-4.5-5.el10.x86_64
colord-1.4.7-5.el10.x86_64
iio-sensor-proxy-3.5-4.el10.x86_64
libkcapi-1.4.0-14.el10.x86_64
libkcapi-hmaccalc-1.4.0-14.el10.x86_64
mdadm-4.3-2.el10.1.x86_64
libblockdev-mdraid-3.1.0-5.el10.x86_64
rpcbind-1.2.6-4.rc2.el10.5.x86_64
wpa_supplicant-2.10-11.el10.x86_64
zram-generator-1.1.2-11.el10.x86_64
libbabeltrace-1.5.11-8.el10.x86_64
device-mapper-multipath-libs-0.9.7-10.el10.x86_64
device-mapper-multipath-0.9.7-10.el10.x86_64
libblockdev-mpath-3.1.0-5.el10.x86_64
groff-base-1.23.0-7.el10.x86_64
gettext-libs-0.22.5-2.el10.x86_64
chkconfig-1.26-4.el10.x86_64
tar-1.35-4.el10.x86_64
flac-libs-1.4.3-5.el10.x86_64
libtheora-1.1.1-38.el10.x86_64
iw-6.9-2.el10.x86_64
libibverbs-51.0-2.el10.x86_64
libpcap-1.10.4-6.el10.x86_64
boost-regex-1.83.0-4.el10.x86_64
source-highlight-3.1.9-23.el10.x86_64
attr-2.5.2-4.el10.x86_64
libksba-1.6.7-1.el10.x86_64
nss-softokn-freebl-3.101.0-1.el10.x86_64
nss-softokn-3.101.0-1.el10.x86_64
libss-1.47.1-1.el10.x86_64
e2fsprogs-1.47.1-1.el10.x86_64
keyutils-1.6.3-4.el10.x86_64
libcomps-0.1.21-2.el10.x86_64
isomd5sum-1.2.5-2.el10.x86_64
kexec-tools-2.0.28-14.el10.x86_64
graphite2-1.3.14-16.el10.x86_64
cairo-1.18.0-4.el10.x86_64
harfbuzz-8.4.0-2.el10.x86_64
freetype-2.13.2-6.el10.x86_64
fontconfig-2.15.0-5.el10.x86_64
cairo-gobject-1.18.0-4.el10.x86_64
libXft-2.3.8-7.el10.x86_64
libconfig-1.7.3-9.el10.x86_64
lldpad-1.1.0-11.git85e5583.el10.x86_64
liblerc-4.0.0-7.el10.x86_64
webrtc-audio-processing-0.3.1-12.el10.x86_64
pigz-2.8-5.el10.x86_64
mtools-4.0.43-5.el10.x86_64
ncurses-6.4-13.20240127.el10.x86_64
perl-Digest-1.20-503.el10.noarch
perl-Digest-MD5-2.59-4.el10.x86_64
perl-B-1.88-507.el10.x86_64
perl-FileHandle-2.05-507.el10.noarch
perl-Data-Dumper-2.188-504.el10.x86_64
perl-libnet-3.15-504.el10.noarch
perl-AutoLoader-5.74-507.el10.noarch
perl-URI-5.27-2.el10.noarch
perl-Text-Tabs+Wrap-2023.0511-6.el10.noarch
perl-if-0.61.000-507.el10.noarch
perl-locale-1.10-507.el10.noarch
perl-IO-Socket-IP-0.42-3.el10.noarch
perl-Time-Local-1.350-6.el10.noarch
perl-File-Path-2.18-504.el10.noarch
perl-IO-Socket-SSL-2.085-2.el10.noarch
perl-Net-SSLeay-1.94-5.el10.x86_64
perl-Pod-Escapes-1.07-504.el10.noarch
perl-Mozilla-CA-20231213-4.el10.noarch
perl-Class-Struct-0.68-507.el10.noarch
perl-Term-ANSIColor-5.01-505.el10.noarch
perl-POSIX-2.13-507.el10.x86_64
perl-IPC-Open3-1.22-507.el10.noarch
perl-File-Temp-0.231.100-504.el10.noarch
perl-Term-Cap-1.18-504.el10.noarch
perl-Pod-Simple-3.45-7.el10.noarch
perl-HTTP-Tiny-0.088-6.el10.noarch
perl-Socket-2.037-6.el10.x86_64
perl-SelectSaver-1.02-507.el10.noarch
perl-Symbol-1.09-507.el10.noarch
perl-File-stat-1.13-507.el10.noarch
perl-podlators-5.01-503.el10.noarch
perl-Pod-Perldoc-3.28.01-505.el10.noarch
perl-Fcntl-1.15-507.el10.x86_64
perl-Text-ParseWords-3.31-503.el10.noarch
perl-base-2.27-507.el10.noarch
perl-mro-1.28-507.el10.x86_64
perl-IO-1.52-507.el10.x86_64
perl-overloading-0.02-507.el10.noarch
perl-Pod-Usage-2.03-505.el10.noarch
perl-Errno-1.37-507.el10.x86_64
perl-File-Basename-2.86-507.el10.noarch
perl-Getopt-Std-1.13-507.el10.noarch
perl-MIME-Base64-3.16-504.el10.x86_64
perl-Scalar-List-Utils-1.63-504.el10.x86_64
perl-constant-1.33-504.el10.noarch
perl-Storable-3.32-503.el10.x86_64
perl-overload-1.37-507.el10.noarch
perl-parent-0.241-503.el10.noarch
perl-vars-1.05-507.el10.noarch
perl-Getopt-Long-2.57-4.el10.noarch
perl-Carp-1.54-503.el10.noarch
perl-Exporter-5.78-4.el10.noarch
perl-PathTools-3.89-503.el10.x86_64
perl-DynaLoader-1.54-507.el10.x86_64
perl-Encode-3.21-505.el10.x86_64
perl-libs-5.38.2-507.el10.x86_64
perl-interpreter-5.38.2-507.el10.x86_64
psmisc-23.6-7.el10.x86_64
iproute-6.7.0-4.el10.x86_64
fcoe-utils-1.0.34-10.gitb233050.el10.x86_64
checkpolicy-3.7-1.el10.x86_64
device-mapper-persistent-data-1.0.11-4.el10.x86_64
lvm2-2.03.23-2.el10.x86_64
libblockdev-lvm-3.1.0-5.el10.x86_64
duktape-2.7.0-8.el10.x86_64
polkit-124-3.el10.x86_64
polkit-pkla-compat-0.1-29.el10.x86_64
realmd-0.17.1-10.el10.x86_64
rtkit-0.11-64.el10.x86_64
fstrm-0.6.1-11.el10.x86_64
gettext-envsubst-0.22.5-2.el10.x86_64
gettext-runtime-0.22.5-2.el10.x86_64
grub2-tools-minimal-2.06-120.el10.x86_64
inih-58-2.el10.x86_64
xfsprogs-6.5.0-4.el10.x86_64
iniparser-4.1-17.el10.x86_64
ndctl-78-4.el10.x86_64
libblockdev-nvdimm-3.1.0-5.el10.x86_64
jbigkit-libs-2.1-30.el10.x86_64
libtiff-4.6.0-3.el10.x86_64
jitterentropy-3.5.0-4.el10.x86_64
libasyncns-0.8-29.el10.x86_64
libbasicobjects-0.1.1-57.el10.x86_64
libcbor-0.11.0-2.el10.x86_64
libfido2-1.14.0-5.el10.x86_64
grubby-8.40-76.el10.x86_64
systemd-udev-256-3.el10.x86_64
dracut-101-2.el10.x86_64
os-prober-1.81-7.el10.x86_64
grub2-tools-2.06-120.el10.x86_64
kernel-modules-core-6.10.0-0.rc5.12.el10.x86_64
kernel-core-6.10.0-0.rc5.12.el10.x86_64
kernel-modules-6.10.0-0.rc5.12.el10.x86_64
plymouth-24.004.60-12.el10.x86_64
plymouth-scripts-24.004.60-12.el10.x86_64
wireless-regdb-2024.01.23-2.el10.noarch
libcollection-0.7.0-57.el10.x86_64
libdatrie-0.2.13-10.el10.x86_64
libthai-0.1.29-9.el10.x86_64
pango-1.54.0-2.el10.x86_64
librsvg2-2.57.1-4.el10.x86_64
rsvg-pixbuf-loader-2.57.1-4.el10.x86_64
gdk-pixbuf2-modules-2.42.10-11.el10.x86_64
libei-1.2.1-2.el10.x86_64
libeis-1.2.1-2.el10.x86_64
libestr-0.1.11-10.el10.x86_64
libev-4.33-12.el10.x86_64
libverto-libev-0.3.2-9.el10.x86_64
libfastjson-1.2304.0-5.el10.x86_64
libgomp-14.1.1-5.el10.x86_64
rpm-build-libs-4.19.1.1-2.el10.x86_64
libipt-2.1-4.el10.x86_64
liblc3-1.0.4-5.el10.x86_64
libldac-2.0.2.3-16.el10.x86_64
libndp-1.8-10.el10.x86_64
NetworkManager-1.48.4-1.el10.1.x86_64
NetworkManager-wifi-1.48.4-1.el10.1.x86_64
libpath_utils-0.2.1-57.el10.x86_64
libini_config-1.3.1-57.el10.x86_64
gssproxy-0.9.2-4.el10.x86_64
libsbc-2.0-5.el10.x86_64
libuv-1.48.0-2.el10.x86_64
lzo-2.10-13.el10.x86_64
mpdecimal-2.5.1-11.el10.x86_64
python3-3.12.4-2.el10.x86_64
python3-libs-3.12.4-2.el10.x86_64
python3-gobject-base-noarch-3.46.0-5.el10.noarch
python3-gobject-base-3.46.0-5.el10.x86_64
gstreamer1-1.22.12-2.el10.x86_64
python3-libselinux-3.7-2.el10.x86_64
libwacom-2.12.2-2.el10.x86_64
python3-dbus-1.3.2-7.el10.x86_64
crypto-policies-scripts-20240522-2.git77963ab.el10.noarch
nss-sysinit-3.101.0-1.el10.x86_64
nss-3.101.0-1.el10.x86_64
python3-bytesize-2.10-4.el10.x86_64
python3-blockdev-3.1.0-5.el10.x86_64
python3-idna-3.7-2.el10.noarch
python3-pyparted-3.13.0-6.el10.x86_64
python3-pyudev-0.24.1-9.el10.noarch
lvm2-dbusd-2.03.23-2.el10.noarch
python3-urllib3-1.26.19-1.el10.noarch
python3-libsemanage-3.7-1.el10.x86_64
python3-dasbus-1.7-7.el10.noarch
gdb-headless-14.2-2.el10.x86_64
gdb-14.2-2.el10.x86_64
python3-libcomps-0.1.21-2.el10.x86_64
unbound-libs-1.19.0-10.el10.x86_64
gnutls-dane-3.8.5-5.el10.x86_64
blivet-data-3.10.0-4.el10.noarch
python3-audit-4.0-9.el10.x86_64
python3-cairo-1.25.1-4.el10.x86_64
python3-gobject-3.46.0-5.el10.x86_64
python3-charset-normalizer-3.3.2-4.el10.noarch
python3-requests-2.31.0-4.el10.noarch
python3-kickstart-3.52.4-2.el10.noarch
python3-requests-file-2.0.0-3.el10.noarch
python3-requests-ftp-0.3.1-34.el10.noarch
python3-distro-1.9.0-4.el10.noarch
python3-iso639-0.1.4-26.el10.noarch
python3-langtable-0.0.65-3.el10.noarch
python3-libmount-2.40.2-4.el10.x86_64
python3-pam-2.0.2-8.el10.noarch
python3-pid-2.2.3-22.el10.noarch
python3-ply-3.11-24.el10.noarch
python3-pycparser-2.20-15.el10.noarch
python3-cffi-1.16.0-5.el10.x86_64
python3-xkbregistry-0.3-2.el10.x86_64
python3-pwquality-1.4.5-10.el10.x86_64
python3-setuptools-69.0.3-4.el10.noarch
python3-setools-4.5.1-3.el10.x86_64
python3-policycoreutils-3.7-1.el10.noarch
policycoreutils-python-utils-3.7-1.el10.noarch
smartmontools-selinux-7.4-4.el10.noarch
python3-six-1.16.0-15.el10.noarch
python3-productmd-1.38-4.el10.noarch
python3-systemd-235-10.el10.x86_64
mpg123-libs-1.31.3-5.el10.x86_64
libsndfile-1.2.2-3.el10.x86_64
pulseaudio-libs-16.1-8.el10.x86_64
pipewire-1.0.7-2.el10.x86_64
pipewire-libs-1.0.7-2.el10.x86_64
wireplumber-0.5.3-2.el10.x86_64
wireplumber-libs-0.5.3-2.el10.x86_64
libcanberra-0.30-36.el10.x86_64
freerdp-libs-3.6.2-1.el10.x86_64
gnome-remote-desktop-46.2-2.el10.x86_64
pulseaudio-libs-glib2-16.1-8.el10.x86_64
mtdev-1.1.6-9.el10.x86_64
libinput-1.26.1-1.el10.x86_64
npth-1.6-19.el10.x86_64
gnupg2-2.4.5-1.el10.x86_64
gpgme-1.23.2-4.el10.x86_64
ostree-libs-2024.6-2.el10.x86_64
ostree-2024.6-2.el10.x86_64
librepo-1.18.0-1.el10.x86_64
libdnf-0.73.1-4.el10.x86_64
python3-libdnf-0.73.1-4.el10.x86_64
skopeo-1.15.1-2.el10.x86_64
volume_key-libs-0.3.12-22.el10.x86_64
libblockdev-crypto-3.1.0-5.el10.x86_64
udisks2-2.10.1-5.el10.x86_64
udisks2-iscsi-2.10.1-5.el10.x86_64
libblockdev-plugins-all-3.1.0-5.el10.x86_64
python3-blivet-3.10.0-4.el10.noarch
python3-hawkey-0.73.1-4.el10.x86_64
flatpak-libs-1.15.8-2.el10.x86_64
rpm-ostree-libs-2024.6-2.el10.x86_64
rpm-ostree-2024.6-2.el10.x86_64
libjcat-0.2.1-3.el10.x86_64
wget2-libs-2.1.0-8.el10.x86_64
wget2-2.1.0-8.el10.x86_64
rpm-sign-libs-4.19.1.1-2.el10.x86_64
python3-rpm-4.19.1.1-2.el10.x86_64
python3-dnf-4.20.0-4.el10.noarch
python3-meh-0.52-2.el10.noarch
python3-simpleline-1.9.0-11.el10.noarch
anaconda-tui-40.22.3.8-1.el10.x86_64
anaconda-core-40.22.3.8-1.el10.x86_64
oniguruma-6.9.9-5.el10.x86_64
jq-1.7.1-5.el10.x86_64
dracut-network-101-2.el10.x86_64
dracut-live-101-2.el10.x86_64
fwupd-1.9.19-2.el10.x86_64
orc-0.4.33-6.el10.x86_64
gstreamer1-plugins-base-1.22.12-2.el10.x86_64
gstreamer1-plugins-bad-free-libs-1.22.12-2.el10.x86_64
pcre2-utf32-10.42-3.el10.1.x86_64
brlapi-0.8.5-15.el10.x86_64
brltty-6.6-15.el10.x86_64
rmt-1.6-14.el10.x86_64
sg3_utils-libs-1.48-5.el10.x86_64
xxhash-libs-0.8.2-4.el10.x86_64
rsync-3.3.0-2.el10.x86_64
bind-license-9.18.21-5.el10.noarch
bind-libs-9.18.21-5.el10.x86_64
appstream-data-10-20240326.1.el10.1.noarch
appstream-1.0.2-4.el10.x86_64
adwaita-cursor-theme-46.0-2.el10.noarch
adwaita-icon-theme-46.0-2.el10.noarch
libcanberra-gtk3-0.30-36.el10.x86_64
gtk3-3.24.42-2.el10.x86_64
gtk4-4.14.4-5.el10.x86_64
gnome-desktop3-44.0-16.el10.x86_64
gnome-desktop4-44.0-16.el10.x86_64
gnome-settings-daemon-46.0-1.el10.x86_64
mutter-46.3-1.el10.x86_64
gnome-kiosk-46.0-3.el10.x86_64
libadwaita-1.5.1-4.el10.x86_64
tecla-45.0-4.el10.x86_64
anaconda-widgets-40.22.3.8-1.el10.x86_64
libnma-1.10.6-8.el10.x86_64
nm-connection-editor-1.36.0-3.el10.x86_64
python3-meh-gui-0.52-2.el10.noarch
anaconda-gui-40.22.3.8-1.el10.x86_64
anaconda-40.22.3.8-1.el10.x86_64
kdump-anaconda-addon-006-16.20220714git7ca2d3e.el10.noarch
anaconda-install-env-deps-40.22.3.8-1.el10.x86_64
anaconda-install-img-deps-40.22.3.8-1.el10.x86_64
bind-utils-9.18.21-5.el10.x86_64
sg3_utils-1.48-5.el10.x86_64
restore-0.4-0.58.b47.el10.x86_64
shim-x64-15-15.el8_2.x86_64
anaconda-dracut-40.22.3.8-1.el10.x86_64
dnf-4.20.0-4.el10.noarch
wget2-wget-2.1.0-8.el10.x86_64
volume_key-0.3.12-22.el10.x86_64
smartmontools-7.4-4.el10.x86_64
python3-pyatspi-2.46.1-4.el10.noarch
libblockdev-lvm-dbus-3.1.0-5.el10.x86_64
nss-tools-3.101.0-1.el10.x86_64
nfs-utils-2.6.4-0.rc4.el10.1.x86_64
usbutils-017-3.el10.x86_64
rsyslog-8.2312.0-2.el10.x86_64
kernel-6.10.0-0.rc5.12.el10.x86_64
kernel-modules-extra-6.10.0-0.rc5.12.el10.x86_64
grub2-tools-efi-2.06-120.el10.x86_64
grub2-tools-extra-2.06-120.el10.x86_64
dracut-config-generic-101-2.el10.x86_64
openssh-clients-9.6p1-1.el10.4.x86_64
rng-tools-6.17-3.el10.x86_64
xfsdump-3.1.12-5.el10.x86_64
nmap-ncat-7.92-2.el10.x86_64
initscripts-10.21-2.el10.x86_64
openssh-server-9.6p1-1.el10.4.x86_64
ipmitool-1.8.19-8.el10.x86_64
mt-st-1.7-5.el10.x86_64
net-tools-2.0-0.70.20160912git.el10.x86_64
spice-vdagent-0.22.1-6.el10.x86_64
strace-6.7-2.el10.x86_64
cryptsetup-2.7.3-1.el10.x86_64
rpm-plugin-selinux-4.19.1.1-2.el10.x86_64
rdma-core-51.0-2.el10.x86_64
biosdevname-0.7.3-18.el10.x86_64
ethtool-6.7-2.el10.x86_64
ipcalc-1.0.3-11.el10.x86_64
efibootmgr-18-7.el10.x86_64
prefixdevname-0.2.0-2.el10.x86_64
mtr-0.95-9.el10.x86_64
nano-8.0-1.el10.x86_64
vim-minimal-9.1.083-2.el10.x86_64
grub2-efi-x64-cdboot-2.06-120.el10.x86_64
grub2-pc-modules-2.06-120.el10.noarch
bzip2-1.0.8-19.el10.x86_64
ftp-0.17-96.el10.x86_64
gdb-gdbserver-14.2-2.el10.x86_64
hostname-3.23-13.el10.x86_64
less-643-8.el10.x86_64
hexedit-1.6-7.el10.x86_64
dmidecode-3.6-2.el10.x86_64
hdparm-9.65-5.el10.x86_64
default-fonts-other-sans-4.1-1.el10.noarch
iwlegacy-firmware-20240624-5.el10.noarch
iwlwifi-dvm-firmware-20240624-5.el10.noarch
iwlwifi-mvm-firmware-20240624-5.el10.noarch
libertas-firmware-20240624-5.el10.noarch
google-noto-sans-cjk-fonts-2.004-8.el10.noarch
Saving list of expected tests to /var/tmp/kstest-list
Selected tests: keyboard.sh 
INFO:apply-ksappend.py: running ksappend substitution on: keyboard.ks.in
Including post-nochroot-lib-keyboard.sh into keyboard.ks
Including post-lib-keyboard.sh into keyboard.ks
Saving substituted kickstarts to /var/tmp/kstest-list-substituted
Starting the tests
```

Output with this patch
```
Using existing data/images/boot.iso
+ /usr/bin/podman run -it --rm --device=/dev/kvm --publish 127.0.0.1::16509 --env SCENARIO=unknown --env DRY_RUN= --env KSTESTS_TEST=keyboard --env TESTTYPE= --env SKIP_TESTTYPES= --env KSTESTS_RUN_TIMEOUT= --env TEST_JOBS=16 --env PLATFORM=fedora_rawhide --env TEST_RETRY= --env KSTESTS_KEEP=1 -v /var/tmp -v /var/home/jkonecny/Documents/RH/projects/kickstart-tests/data:/opt/kstest/data:z -v /var/home/jkonecny/Documents/RH/projects/kickstart-tests:/kickstart-tests:ro,z -v ./scripts/defaults-fedora_rawhide.sh:/home/kstest/.kstests.defaults.sh:ro,z quay.io/rhinstaller/kstest-runner /kickstart-tests/containers/runner/run-kstest
+ KSTESTS_REPOSITORY=https://github.com/rhinstaller/kickstart-tests
+ KSTESTS_BRANCH=master
+ KSTESTS_DIR=/opt/kstest/kickstart-tests
+ KSTESTS_TEST=keyboard
+ KSTESTS_KEEP=1
+ TIMEOUT=0
+ SCENARIO=unknown
+ UPDATES_IMAGE=
+ BOOT_ISO=boot.iso
+ ISO_DIR=/opt/kstest/data/images
+ LOGS_DIR=/opt/kstest/data/logs
+ '[' -d /kickstart-tests ']'
+ rsync -r --exclude /data/ /kickstart-tests/ /opt/kstest/kickstart-tests
skipping non-regular file "scripts/defaults-fedora_rawhide.sh"
+ UPDATES_IMAGE_ARG=
+ '[' -n '' ']'
+ PLATFORM_ARG=
+ '[' -n fedora_rawhide ']'
+ PLATFORM_ARG='-p fedora_rawhide'
+ TESTTYPE_ARG=
+ '[' -n '' ']'
+ SKIP_TESTTYPES_ARG=
+ '[' -n '' ']'
+ RETRY_ARG=
+ '[' -n '' ']'
+ DRY_RUN_ARG=
+ '[' -n '' ']'
+ mkdir -p /home/kstest/.cache/virt-manager/boot
+ mkdir -p /home/kstest/.config/libvirt
+ printf 'listen_tls = 0\nlisten_tcp = 1\nauth_tcp = "none"\n'
+ virtproxyd -f /home/kstest/.config/libvirt/virtproxyd.conf
++ ip -4 -c a show dev eth0
++ grep -Eo '[0-9.]+\.[0-9]+'
++ grep -v '\.255'
+ MY_IP=10.88.0.8
+ set +x
************************************************************************
You can connect to this container's libvirt with this connection string:

   qemu+tcp://10.88.0.8/session

************************************************************************
+ TEST_LOG=/var/tmp/kstest.log
+ pushd /opt/kstest/kickstart-tests
/opt/kstest/kickstart-tests /opt/kstest
+ set +e
+ scripts/run_kickstart_tests.sh -x 0 -k 1 -i /opt/kstest/data/images/boot.iso -p fedora_rawhide keyboard
+ tee /var/tmp/kstest.log
starting kickstart tests
Tue Jul 16 16:36:59 UTC 2024
2024-07-16 16:36:59.606+0000: 33: info : libvirt version: 9.7.0, package: 4.fc39 (Fedora Project, 2024-06-05-16:03:49, )
2024-07-16 16:36:59.606+0000: 33: info : hostname: a746cfac5888
2024-07-16 16:36:59.606+0000: 33: error : virGDBusGetSessionBus:126 : internal error: Unable to get session bus connection: Cannot autolaunch D-Bus without X11 $DISPLAY
2024-07-16 16:36:59.606+0000: 33: error : virGDBusGetSystemBus:99 : internal error: Unable to get system bus connection: Could not connect: No such file or directory
Extract filename /LiveOS/rootfs.img can't be resolved
Saving list of installer image packages to /var/tmp/kstest-image-packages.log
Saving list of expected tests to /var/tmp/kstest-list
Selected tests: keyboard.sh 
INFO:apply-ksappend.py: running ksappend substitution on: keyboard.ks.in
Including post-nochroot-lib-keyboard.sh into keyboard.ks
Including post-lib-keyboard.sh into keyboard.ks
Saving substituted kickstarts to /var/tmp/kstest-list-substituted
Starting the tests
```

One of the biggest issue I see is constant scrolling to find the IP for virt-viewer.