### PR TITLE
Do not fail on missing kstest-list-substituted logs directory

### DIFF
--- a/containers/runner/run-kstest
+++ b/containers/runner/run-kstest
@@ -112,7 +112,7 @@ chmod a+rw "${LOGS_DIR}/$(basename ${VIRT_INSTALL_LOG})" || true
 
 # Move to target logs directory; this sometimes fails on nested directory permission/ownership
 cp -pr /var/tmp/kstest-* ${LOGS_DIR} || true
-cp -r /var/tmp/kstest-list-substituted ${LOGS_DIR}
+cp -r /var/tmp/kstest-list-substituted ${LOGS_DIR} || true
 
 # Show summary report
 ${KSTESTS_DIR}/scripts/run_report.sh < $TEST_LOG


### PR DESCRIPTION
Example of the issue: https://github.com/rhinstaller/kickstart-tests/pull/1175
and its Travis CI test https://github.com/rhinstaller/kickstart-tests/pull/1175/checks?check_run_id=27506031974