### PR TITLE
Show stdout and stderr when virt-install fails

### DIFF
--- a/scripts/launcher/lib/virtual_controller.py
+++ b/scripts/launcher/lib/virtual_controller.py
@@ -207,7 +207,13 @@ class VirtualInstall(object):
         try:
             execWithRedirect("virt-install", args, raise_err=True)
         except subprocess.CalledProcessError as e:
-            raise InstallError("Problem starting virtual install: %s" % e) from e
+            stdout = e.stdout.strip() if e.stdout else ""
+            stderr = e.stderr.strip() if e.stderr else ""
+            raise InstallError("""
+Problem starting virtual install: %s
+                          stdout: %s
+                          stderr: %s""" % (e, stdout, stderr)
+                               ) from e
 
         conn = libvirt.openReadOnly(None)
         dom = conn.lookupByName(self._virt_name)


### PR DESCRIPTION
Currently the output is suppressed because we are showing only exception but not it's stdout and stderr content. That could be really valuable when debugging virt-install issues.

New output:
2024-07-17 15:14:20,164 INFO: RESULT:keyboard:b9624d95066a:FAILED: Problem starting virtual install: Command '['virt-install', '-n', 'kstest-keyboard_(4922e9d9-157a-4eb7-8c00-7d169edba38b)', '-r', '2048', '--noautoconsole', '--vcpus', '1', '--rng', '/dev/random', '--osinfo', 'require=off,detect=on', '--graphics', 'vnc,listen=0.0.0.0', '--video', 'virtio', '--initrd-inject', '/opt/kstest/kickstart-tests/keyboard.ks', '--disk', 'path=/var/tmp/kstest-keyboard.2024_07_17-15_14_12.3c4e43xh/disk-a.img,cache=unsafe,bus=virtio', '--network', 'user,model=virtio', '--disk', 'path=/var/tmp/kstest-keyboard.2024_07_17-15_14_12.3c4e43xh/boot.iso,device=cdrom,readonly=on,shareable=on', '--boot', 'uefi', '--channel', 'tcp,host=127.0.0.1:36781,mode=connect,target_type=virtio,name=org.fedoraproject.anaconda.log.0']' returned non-zero exit status 1.
                          stdout: ERROR    Install method does not support initrd injections.
                          stderr:
/var/tmp/kstest-keyboard.2024_07_17-15_14_12.3c4e43xh