### PR TITLE
Fix boot_args() processing

### DIFF
--- a/ibft.sh
+++ b/ibft.sh
@@ -65,7 +65,7 @@ prepare_disks() {
 boot_args() {
     . ${tmpdir}/httpd_url
     ipxe_script_url="${httpd_url}${ipxe_script}"
-    echo "--boot kernel=${ipxe_image},kernel_args='ifconf -c dhcp net0 && chain ${ipxe_script_url}'"
+    echo "kernel=${ipxe_image},kernel_args='ifconf -c dhcp net0 && chain ${ipxe_script_url}'"
 }
 
 prepare() {

--- a/scripts/launcher/lib/shell_launcher.py
+++ b/scripts/launcher/lib/shell_launcher.py
@@ -173,7 +173,7 @@ class ShellLauncher(ProcessLauncher):
     def boot_args(self):
         out = self._run_shell_func("boot_args")
         out.check_ret_code_with_exception()
-        return out.stdout_as_array
+        return out.stdout
 
     def get_timeout(self):
         """Per test timeout override.


### PR DESCRIPTION
We can't use this field as array because of the complex arguments we can pass in. Also it doesn't give much sense because it could be used only for one --boot.

Also remove --boot part from the ibft test. It's already added when the argument is processed.