### PR TITLE
Add test support of bootupd EUFI entry insertion

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -39,6 +39,13 @@ inject_ks_to_initrd() {
     echo "true"
 }
 
+enable_uefi() {
+    # Run the VM in the UEFI mode.
+    # This will add '--boot uefi' argument to the virt-install script
+    # returns: "true" or "false"
+    echo "false"
+}
+
 EXTRA_BOOTOPTS=$(echo "${KSTEST_EXTRA_BOOTOPTS}" | tr ';' ' ')
 
 DEFAULT_BASIC_BOOTOPTS="debug=1 inst.debug ${EXTRA_BOOTOPTS}"

--- a/rpm-ostree-container-leavebootorder.ks.in
+++ b/rpm-ostree-container-leavebootorder.ks.in
@@ -1,0 +1,40 @@
+#test name: rpm-ostree-container-bootorder
+# https://github.com/rhinstaller/anaconda/pull/5399
+#
+# Test that ostree container installation works with leavebootorder.
+# In this test bootupd should be able to do dualboot. For sanity 
+# of this test just check if bootupd is invoked with the correct
+# arguments.
+#
+
+# Use the default settings.
+%ksappend common/common.ks
+
+# network
+network --bootproto=dhcp
+# l10n
+keyboard us
+lang en
+timezone America/New_York
+# user confguration
+rootpw testcase
+
+# On Fedora enforce lvm scheme (overriding btrfs default)
+%ksappend storage/ostreecontainer_autopart.ks
+
+# Test if UEFI entry is not created!
+bootloader --leavebootorder --timeout 1
+
+ostreecontainer --no-signature-verification --remote=test-remote --stateroot=test-stateroot --url=@KSTEST_OSTREECONTAINER_URL@
+
+
+%post
+# check if efibootmgr don't have entry to boot from a disk
+efibootmgr | grep "HD("
+if [ $? -eq 0 ]; then
+    echo "EFI boot entry was created with leavebootorder: $(efibootmgr)" >> /root/RESULT
+fi
+
+%ksappend validation/success_if_result_empty.ks
+
+%end

--- a/rpm-ostree-container-leavebootorder.sh
+++ b/rpm-ostree-container-leavebootorder.sh
@@ -1,0 +1,71 @@
+#
+# Copyright (C) 2024  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
+TESTTYPE="payload uefi ostree bootc reboot skip-on-rhel-8"
+
+. ${KSTESTDIR}/functions.sh
+
+enable_uefi() {
+    echo "true"
+}
+
+copy_interesting_files_from_system() {
+    local disksdir
+    disksdir="${1}"
+
+    # Find disks.
+    local args
+    args=$(for d in ${disksdir}/disk-*img; do echo -a ${d}; done)
+
+    # Use also iscsi disk if there is any.
+    if [[ -n ${iscsi_disk_img} ]]; then
+        args="${args} -a ${disksdir}/${iscsi_disk_img}"
+    fi
+
+    # Grab files out of the installed system while it still exists.
+    # Grab these files:
+    #
+    # logs from Anaconda - whole /var/log/anaconda/ directory is copied out,
+    #                      this can be used for saving specific test output
+    # original-ks.cfg - the kickstart used for the test
+    # anaconda-ks.cfg - the kickstart saved after installation, useful for
+    #                   debugging
+    # RESULT - file from the test
+    #
+    # The location of aforementioned files is different in an ostree system
+
+    root_device=$(guestfish ${args} <<< "
+        launch
+        lvs" | \
+        grep root)
+
+    for item in /ostree/deploy/test-stateroot/var/roothome/original-ks.cfg \
+                /ostree/deploy/test-stateroot/var/roothome/anaconda-ks.cfg \
+                /ostree/deploy/test-stateroot/var/roothome/anabot.log \
+                /ostree/deploy/test-stateroot/var/log/anaconda/ \
+                /ostree/deploy/test-stateroot/var/roothome/RESULT
+    do
+        guestfish ${args} <<< "
+            launch
+            mount ${root_device} /
+            copy-out '${item}' '${disksdir}'
+            " 2>/dev/null
+    done
+}

--- a/rpm-ostree-container-uefi.ks.in
+++ b/rpm-ostree-container-uefi.ks.in
@@ -1,0 +1,66 @@
+#test name: rpm-ostree-container-bootc
+# https://github.com/rhinstaller/anaconda/pull/5399
+#
+# Test the UEFI entry is created correctly and the system is bootable.
+# This doesn't work so far on RHEL-9 and RHEL-10 so the test will be
+# disabled there after this is implemented:
+# * https://issues.redhat.com/browse/RHEL-40897
+# * https://issues.redhat.com/browse/RHEL-40896
+#
+# Also this test is mostly a copy of rpm-ostree-container-bootc test
+# and it could be merged when RHEL-9 and RHEL-10 is enabled.
+#
+
+# Use the default settings.
+%ksappend common/common_no_storage_and_payload.ks
+# On Fedora enforce lvm scheme (overriding btrfs default)
+%ksappend storage/ostreecontainer_autopart.ks
+
+ostreecontainer --no-signature-verification --remote=test-remote --stateroot=test-stateroot --url=@KSTEST_OSTREECONTAINER_URL@
+
+# Reboot the installed system.
+reboot
+
+# Validate on the first boot.
+%ksappend validation/success_on_first_boot.ks
+
+%post
+efibootmgr | grep "Boot0001" | grep "HD(1"
+if [ $? -ne 0 ]; then
+    echo -e "EFI boot entry wasn't created properly:\n$(efibootmgr)"  >> /root/RESULT
+fi
+
+# Checks after boot
+cat >> /var/lib/extensions/kickstart-tests/usr/libexec/kickstart-test.sh << 'EOF'
+
+# propagate any errors from %post validations
+if [ -e /root/RESULT ]; then
+    cat /root/RESULT
+fi
+
+# Check that state root 'test-stateroot' exists
+if [ ! -d /ostree/deploy/test-stateroot ]; then
+    echo "Couldn't find 'test-stateroot' stateroot"
+fi
+
+# Check that bootupd information is present
+if [ ! -e /boot/bootupd-state.json ]; then
+    echo "/boot/bootupd-state.json not found on installed system after booting"
+fi
+
+bootupctl --help &> /dev/null || echo "bootupctl command not available after booting"
+bootc --help &> /dev/null || echo "bootc command not available after booting"
+
+expected_url="@KSTEST_OSTREECONTAINER_URL@"
+remote_url="$(ostree remote show-url test-remote)"
+if [ ${?} -ne 0 ]; then
+    echo "Couldn't list remote URL for 'test-remote'" >> /root/RESULT
+fi
+
+if [ "${remote_url}" != "${expected_url}" ]; then
+    echo "Unexpected URL: ${remote_url}, expected ${expected_url}"" >> /root/RESULT
+fi
+
+
+EOF
+%end

--- a/rpm-ostree-container-uefi.sh
+++ b/rpm-ostree-container-uefi.sh
@@ -1,0 +1,77 @@
+#
+# Copyright (C) 2023  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
+TESTTYPE="payload uefi ostree bootc reboot skip-on-rhel-8 skip-on-rhel-9 skip-on-rhel-10"
+
+. ${KSTESTDIR}/functions.sh
+
+enable_uefi() {
+    echo "true"
+}
+
+copy_interesting_files_from_system() {
+    local disksdir
+    disksdir="${1}"
+
+    # Find disks.
+    local args
+    args=$(for d in ${disksdir}/disk-*img; do echo -a ${d}; done)
+
+    # Use also iscsi disk if there is any.
+    if [[ -n ${iscsi_disk_img} ]]; then
+        args="${args} -a ${disksdir}/${iscsi_disk_img}"
+    fi
+
+    # Grab files out of the installed system while it still exists.
+    # Grab these files:
+    #
+    # logs from Anaconda - whole /var/log/anaconda/ directory is copied out,
+    #                      this can be used for saving specific test output
+    # original-ks.cfg - the kickstart used for the test
+    # anaconda-ks.cfg - the kickstart saved after installation, useful for
+    #                   debugging
+    # RESULT - file from the test
+    #
+    # The location of aforementioned files is different in an ostree system
+
+    root_device=$(guestfish ${args} <<< "
+        launch
+        lvs" | \
+        grep root)
+
+    for item in /ostree/deploy/test-stateroot/var/roothome/original-ks.cfg \
+                /ostree/deploy/test-stateroot/var/roothome/anaconda-ks.cfg \
+                /ostree/deploy/test-stateroot/var/roothome/anabot.log \
+                /ostree/deploy/test-stateroot/var/log/anaconda/ \
+                /ostree/deploy/test-stateroot/var/roothome/RESULT
+    do
+        guestfish ${args} <<< "
+            launch
+            mount ${root_device} /
+            copy-out '${item}' '${disksdir}'
+            " 2>/dev/null
+    done
+}
+
+additional_runner_args() {
+   # Wait for reboot and shutdown of the VM,
+   # but exit after the specified timeout.
+   echo "--wait $(get_timeout)"
+}

--- a/scripts/launcher/lib/conf/configuration.py
+++ b/scripts/launcher/lib/conf/configuration.py
@@ -184,6 +184,7 @@ class VirtualConfiguration(BaseConfiguration):
         self._timeout = None
         self._runner_args = []
         self._stage2_from_ks = False
+        self._enable_uefi = False
 
     @property
     def test_name(self):
@@ -381,3 +382,13 @@ class VirtualConfiguration(BaseConfiguration):
     def stage2_from_ks(self, value: list):
         """Set use installer image from location defined in kickstart"""
         self._stage2_from_ks = value
+
+    @property
+    def enable_uefi(self) -> bool:
+        """Start VM with UEFI bootloader"""
+        return self._enable_uefi
+
+    @enable_uefi.setter
+    def enable_uefi(self, value: list):
+        """Set if VM should start with UEFI bootloader"""
+        self._enable_uefi = value

--- a/scripts/launcher/lib/launcher_interface.sh
+++ b/scripts/launcher/lib/launcher_interface.sh
@@ -92,6 +92,10 @@ case $1 in
         msg="$(inject_ks_to_initrd)"
         ret=$?
         ;;
+    enable_uefi)
+        msg="$(enable_uefi)"
+        ret=$?
+        ;;
     stage2_from_ks)
         msg="$(stage2_from_ks)"
         ret=$?

--- a/scripts/launcher/lib/shell_launcher.py
+++ b/scripts/launcher/lib/shell_launcher.py
@@ -218,6 +218,9 @@ class ShellLauncher(ProcessLauncher):
     def inject_ks_to_initrd(self):
         return self._run_bool_shell_func("inject_ks_to_initrd")
 
+    def enable_uefi(self):
+        return self._run_bool_shell_func("enable_uefi")
+
     def stage2_from_ks(self):
         return self._run_bool_shell_func("stage2_from_ks")
 

--- a/scripts/launcher/run_one_test.py
+++ b/scripts/launcher/run_one_test.py
@@ -171,6 +171,7 @@ class Runner(object):
         v_conf.networks = nics_args
         v_conf.runner_args = self._shell.additional_runner_args()
         v_conf.stage2_from_ks = self._shell.stage2_from_ks()
+        v_conf.enable_uefi = self._shell.enable_uefi()
         v_conf.ram = ram
 
         return v_conf

--- a/scripts/probe_boot_iso.sh
+++ b/scripts/probe_boot_iso.sh
@@ -88,7 +88,7 @@ DISCINFO_VER=$(isoinfo -R -x /.discinfo -i "$IMAGE" | sed -n '2 p')
 if [ -n "$DISCINFO_VER" ]; then
     # make sure it looks like a Fedora version name/number
     if [ "$DISCINFO_VER" = "Rawhide" ] || [ $(echo $DISCINFO_VER | cut -d. -f1) -gt 30 ]; then
-        echo "NAME=Fedora"
+        echo "NAME=fedora"
         echo "VERSION=$DISCINFO_VER"
         exit 0
     fi


### PR DESCRIPTION
Enhance existing test `rpm-ostree-container-bootc` to check for UEFI entry insertion on the first disk.
Add a new test working similar to other container tests but with `bootloader --leavebootorder` which will disable UEFI entry insertion.

To be able to do this add support to run VM in UEFI mode. And fix one bug during the path which caused troubles here.

The bootc test will be enabled only for Fedora until https://github.com/rhinstaller/anaconda/pull/5760 and https://github.com/rhinstaller/anaconda/pull/5761 are merged. The leavebootorder test should work all the time because UEFI entry just won't be inserted anyway on RHEL 9 and 10