### PR TITLE
Revert "Allow unknown args to be passed to generate-launch-args"

### DIFF
--- a/scripts/generate-launch-args.py
+++ b/scripts/generate-launch-args.py
@@ -88,8 +88,7 @@ def parse_args():
                          help="do not skip any tests based on os variant or branch")
     _parser.add_argument("--skip-file", type=str, metavar="PATH",
                          help="file containing data about disabled tests")
-    args, _ = _parser.parse_known_args()
-    return args
+    return _parser.parse_args()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This reverts commit cd666de0fa4a3153ff34d925fd6bbbeff85ff4ac.

It actually does not work for some cases, so let's rather remove any unsupported args before using the script.
Removed in https://github.com/rhinstaller/anaconda/pull/5783