### PR TITLE
Change author verification in testingfarm workflow

### DIFF
--- a/.github/workflows/testingfarm.yml
+++ b/.github/workflows/testingfarm.yml
@@ -7,14 +7,37 @@ on:
       - created
 
 jobs:
+  pr-info:
+    if: startsWith(github.event.comment.body, '/test-tmt')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Query comment author repository permissions
+        uses: octokit/request-action@v2.x
+        id: user_permission
+        with:
+          route: GET /repos/${{ github.repository }}/collaborators/${{ github.event.sender.login }}/permission
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # restrict running of tests to users with admin or write permission for the repository
+      # see https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#get-repository-permissions-for-a-user
+      # store output if user is allowed in allowed_user job output so it has to be checked in downstream job
+      - name: Check if user does have correct permissions
+        if: contains('admin write', fromJson(steps.user_permission.outputs.data).permission)
+        id: check_user_perm
+        run: |
+          echo "User '${{ github.event.sender.login }}' has permission '${{ fromJson(steps.user_permission.outputs.data).permission }}' allowed values: 'admin', 'write'"
+          echo "allowed_user=true" >> $GITHUB_OUTPUT
+
+    outputs:
+      allowed: ${{ steps.check_user_perm.outputs.allowed_user }}
+
   testingfarm:
     name: "Run in testing farm"
+    needs: pr-info
     runs-on: ubuntu-latest
     environment: testing-farm
-    if: |
-      github.event.issue.pull_request
-      && contains(github.event.comment.body, '/test-tmt')
-      && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association)
+    if: needs.pr-info.outputs.allowed == 'true'
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4

--- a/.github/workflows/testingfarm.yml
+++ b/.github/workflows/testingfarm.yml
@@ -10,6 +10,8 @@ jobs:
   pr-info:
     if: startsWith(github.event.comment.body, '/test-tmt')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Query comment author repository permissions
         uses: octokit/request-action@v2.x
@@ -37,6 +39,9 @@ jobs:
     needs: pr-info
     runs-on: ubuntu-latest
     environment: testing-farm
+    permissions:
+      contents: read
+      statuses: write
     if: needs.pr-info.outputs.allowed == 'true'
     steps:
     - name: Checkout repo


### PR DESCRIPTION
Currently it's problematic to debug skipped tests. Let's improve the state by adding separate job for processing the PR metadata.
This code is based on already tested code from the Anaconda repository.

Currently we are facing issue where users which should be allowed are skipped. With the current code it's impossible to debug.

Tested by https://github.com/jkonecny12/kickstart-tests/pull/2