### PR TITLE
Add rpm-ostree-container-bootc to coverage group

### DIFF
--- a/rpm-ostree-container-bootc.sh
+++ b/rpm-ostree-container-bootc.sh
@@ -18,7 +18,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="payload ostree bootc reboot skip-on-rhel-8"
+TESTTYPE="payload ostree bootc coverage reboot skip-on-rhel-8"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
We want to have at least one tests in the coverage group because it's completely different code path and because it's a high priority feature.