### PR TITLE
Disable selinux-contexts on rhel10 temporarily (gh1270)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -71,6 +71,7 @@ rhel10_skip_array=(
   gh1178      # tests using ext2 failing
   gh1207      # packages-multilib failing
   gh1213      # harddrive-iso-single failing
+  gh1270      # selinux-contexts failing
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/selinux-contexts.sh
+++ b/selinux-contexts.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="security selinux"
+TESTTYPE="security selinux gh1270"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Disable selinux-context on rhel10 until gh1270 is fixed.