### PR TITLE
Revert "Disable tests using ext2 temporarily on rhel10 (gh#1178)"

### DIFF
--- a/autopart-fstype.sh
+++ b/autopart-fstype.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage gh1178"
+TESTTYPE="autopart storage"
 
 
 . ${KSTESTDIR}/functions.sh

--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -68,7 +68,6 @@ rhel10_skip_array=(
   gh1104      # network-prefixdevname failing
   gh1107      # rpm-ostree-container failing
   gh1110      # storage-multipath-autopart failing
-  gh1178      # tests using ext2 failing
   gh1207      # packages-multilib failing
   gh1213      # harddrive-iso-single failing
 )

--- a/mountpoint-assignment-1.sh
+++ b/mountpoint-assignment-1.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="mount storage coverage gh1178"
+TESTTYPE="mount storage coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/mountpoint-assignment-2.sh
+++ b/mountpoint-assignment-2.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="mount storage gh1178"
+TESTTYPE="mount storage"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
This reverts commit e593174a3395cc5a74c830b4596ce57da0248ee1.

https://issues.redhat.com/browse/RHEL-37249 has been fixed.