### PR TITLE
Enable basic-ftp test on RHELs

### DIFF
--- a/basic-ftp.sh
+++ b/basic-ftp.sh
@@ -20,6 +20,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="method skip-on-rhel gh871"
+TESTTYPE="method gh871"
 
 . ${KSTESTDIR}/functions.sh

--- a/scripts/defaults-rhel10.sh
+++ b/scripts/defaults-rhel10.sh
@@ -5,5 +5,5 @@ export KSTEST_OSINFO_NAME=fedora-eln
 source ./network-device-names.cfg
 export KSTEST_URL='http://download.devel.redhat.com/rhel-10/nightly/RHEL-10-Public-Beta/latest-RHEL-10.0/compose/BaseOS/x86_64/os/'
 export KSTEST_MODULAR_URL='http://download.devel.redhat.com/rhel-10/nightly/RHEL-10-Public-Beta/latest-RHEL-10.0/compose/AppStream/x86_64/os/'
-export KSTEST_FTP_URL='ftp://ftp.tu-chemnitz.de/pub/linux/fedora/linux/development/rawhide/Everything/x86_64/os/'
+export KSTEST_FTP_URL='ftp://download.devel.redhat.com/mnt/redhat/rhel-10/nightly/RHEL-10-Public-Beta/latest-RHEL-10.0/compose/BaseOS/x86_64/os/'
 export KSTEST_OSTREECONTAINER_URL='quay.io/centos-bootc/centos-bootc:stream10'

--- a/scripts/defaults-rhel8.sh
+++ b/scripts/defaults-rhel8.sh
@@ -3,4 +3,4 @@
 source ./network-device-names.cfg
 export KSTEST_URL='http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.10.0/compose/BaseOS/x86_64/os/'
 export KSTEST_MODULAR_URL='http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.10.0/compose/AppStream/x86_64/os/'
-export KSTEST_FTP_URL='ftp://ftp.tu-chemnitz.de/pub/linux/fedora/linux/development/rawhide/Everything/x86_64/os/'
+export KSTEST_FTP_URL='ftp://download.devel.redhat.com/mnt/redhat/rhel-8/nightly/RHEL-8/latest-RHEL-8.10.0/compose/BaseOS/x86_64/os/'

--- a/scripts/defaults-rhel9.sh
+++ b/scripts/defaults-rhel9.sh
@@ -3,5 +3,5 @@
 source ./network-device-names.cfg
 export KSTEST_URL='http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.5.0/compose/BaseOS/x86_64/os/'
 export KSTEST_MODULAR_URL='http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.5.0/compose/AppStream/x86_64/os/'
-export KSTEST_FTP_URL='ftp://ftp.tu-chemnitz.de/pub/linux/fedora/linux/development/rawhide/Everything/x86_64/os/'
+export KSTEST_FTP_URL='ftp://download.devel.redhat.com/mnt/redhat/rhel-9/nightly/RHEL-9/latest-RHEL-9/compose/BaseOS/x86_64/os/'
 export KSTEST_OSTREECONTAINER_URL='quay.io/centos-bootc/centos-bootc:stream9'


### PR DESCRIPTION
The test were disabled here because we were missing FTP source. We have it now.