### PR TITLE
Revert "Disable basic-ftp temporarily on daily-iso (gh#871)"

### DIFF
--- a/basic-ftp.sh
+++ b/basic-ftp.sh
@@ -20,6 +20,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="method gh871"
+TESTTYPE="method"
 
 . ${KSTESTDIR}/functions.sh

--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -17,7 +17,6 @@ fedora_skip_array=(
   gh777       # raid-1-reqpart failing
   gh910       # stage2-from-ks test needs to be fixed for daily-iso
   gh890       # default-systemd-target-vnc-graphical-provides flaking too much
-  gh871       # basic-ftp failing due to mirror
   rhbz1853668 # multipath device not constructed back after installation
   gh975       # packages-default failing
   gh1023      # rpm-ostree failing


### PR DESCRIPTION
Closes https://github.com/rhinstaller/kickstart-tests/issues/871

Based on my local testing this seems to be working just fine now. Let's try it running for a while and see.