### PR TITLE
Fix RESULT validation

### DIFF
--- a/encrypt-device.sh
+++ b/encrypt-device.sh
@@ -34,7 +34,7 @@ validate() {
     if [[ $? != 0 ]]; then
         status=1
         echo '*** /home/RESULT does not exist in VM image.'
-    elif [[ "${result}" != SUCCESS* ]]; then
+    elif [[ "${result%% *}" != SUCCESS ]]; then
         status=1
         echo "${result}"
     fi

--- a/encrypt-swap.sh
+++ b/encrypt-swap.sh
@@ -44,7 +44,7 @@ validate() {
     if [[ $? != 0 ]]; then
         status=1
         echo '*** /root/RESULT does not exist in VM image.'
-    elif [[ "${result}" != SUCCESS* ]]; then
+    elif [[ "${result%% *}" != SUCCESS ]]; then
         status=1
         echo "${result}"
     fi

--- a/escrow-cert.sh
+++ b/escrow-cert.sh
@@ -35,7 +35,7 @@ validate() {
     if [[ $? != 0 ]]; then
         status=1
         echo '*** /root/RESULT does not exist in VM image.'
-    elif [[ "${result}" != SUCCESS* ]]; then
+    elif [[ "${result%% *}" != SUCCESS ]]; then
         status=1
         echo "${result}"
     fi

--- a/functions.sh
+++ b/functions.sh
@@ -212,7 +212,7 @@ check_result_file() {
     if [[ $? != 0 ]]; then
         status=1
         echo '*** /root/RESULT does not exist in VM image.'
-    elif [[ "${result}" != SUCCESS* ]]; then
+    elif [[ "${result%% *}" != SUCCESS ]]; then
         status=1
         echo "${result}"
     fi

--- a/nosave-1.sh
+++ b/nosave-1.sh
@@ -50,7 +50,7 @@ validate() {
     if [[ $? != 0 ]]; then
         status=1
         echo '*** /root/RESULT does not exist in VM image.'
-    elif [[ "${result}" != SUCCESS* ]]; then
+    elif [[ "${result%% *}" != SUCCESS ]]; then
         status=1
         echo "${result}"
     else

--- a/nosave-2.sh
+++ b/nosave-2.sh
@@ -50,7 +50,7 @@ validate() {
     if [[ $? != 0 ]]; then
         status=1
         echo '*** /root/RESULT does not exist in VM image.'
-    elif [[ "${result}" != SUCCESS* ]]; then
+    elif [[ "${result%% *}" != SUCCESS ]]; then
         status=1
         echo "${result}"
     else

--- a/nosave-3.sh
+++ b/nosave-3.sh
@@ -50,7 +50,7 @@ validate() {
     if [[ $? != 0 ]]; then
         status=1
         echo '*** /root/RESULT does not exist in VM image.'
-    elif [[ "${result}" != SUCCESS* ]]; then
+    elif [[ "${result%% *}" != SUCCESS ]]; then
         status=1
         echo "${result}"
     else

--- a/proxy-auth.sh
+++ b/proxy-auth.sh
@@ -93,16 +93,8 @@ validate() {
         fi
     fi
 
-    result=$(cat ${tmpdir}/RESULT)
-    if [[ $? != 0 ]]; then
-        echo '*** /root/RESULT does not exist in VM image.'
-        return 1
-    elif [[ "${result}" != SUCCESS* ]]; then
-        echo "${result}"
-        return 1
-    else
-        return 0
-    fi
+    check_result_file "${tmpdir}"
+    return $?
 }
 
 cleanup() {

--- a/proxy-cmdline.sh
+++ b/proxy-cmdline.sh
@@ -50,14 +50,6 @@ validate() {
 
     check_proxy_settings $tmpdir
 
-    result=$(cat ${tmpdir}/RESULT)
-    if [[ $? != 0 ]]; then
-        echo '*** /root/RESULT does not exist in VM image.'
-        return 1
-    elif [[ "${result}" != SUCCESS* ]]; then
-        echo "${result}"
-        return 1
-    else
-        return 0
-    fi
+    check_result_file "${tmpdir}"
+    return $?
 }

--- a/proxy-kickstart.sh
+++ b/proxy-kickstart.sh
@@ -87,16 +87,8 @@ validate() {
         fi
     fi
 
-    result=$(cat ${tmpdir}/RESULT)
-    if [[ $? != 0 ]]; then
-        echo '*** /root/RESULT does not exist in VM image.'
-        return 1
-    elif [[ "${result}" != SUCCESS* ]]; then
-        echo "${result}"
-        return 1
-    else
-        return 0
-    fi
+    check_result_file "${tmpdir}"
+    return $?
 }
 
 cleanup() {

--- a/raid-1.sh
+++ b/raid-1.sh
@@ -42,7 +42,7 @@ validate() {
     if [[ $? != 0 ]]; then
         status=1
         echo '*** /root/RESULT does not exist in VM image.'
-    elif [[ "${result}" != SUCCESS* ]]; then
+    elif [[ "${result%% *}" != SUCCESS ]]; then
         status=1
         echo "${result}"
     fi

--- a/raid-ddf.sh
+++ b/raid-ddf.sh
@@ -50,7 +50,7 @@ validate() {
     if [[ $? != 0 ]]; then
         status=1
         echo '*** /root/RESULT does not exist in VM image.'
-    elif [[ "${result}" != SUCCESS* ]]; then
+    elif [[ "${result%% *}" != SUCCESS ]]; then
         status=1
         echo "${result}"
     fi


### PR DESCRIPTION
Currently if RESULT file has an issue after the "SUCCESS" word it will tell success. That works in most of the cases but not if validation is done in the %post of KS but also later in the .sh file.

If %post section was fine and add SUCCESS but validation section will found issue it would take the whole test as successful.

Fix this in all the impacted tests and also in the functions.sh.