### PR TITLE
Use correct `defaults` sourcing for platform

### DIFF
--- a/containers/runner/launch
+++ b/containers/runner/launch
@@ -176,7 +176,7 @@ $CRUN run -it --rm --device=/dev/kvm --publish 127.0.0.1::16509 $PODMAN_SELINUX_
     --env DRY_RUN="${DRY_RUN:-}" \
     --env KSTESTS_TEST="$KSTESTS_TEST" --env TESTTYPE="${TESTTYPE:-}" --env SKIP_TESTTYPES="${SKIP_TESTTYPES:-}" \
     --env KSTESTS_RUN_TIMEOUT="${TIMEOUT:-}" \
-    --env TEST_JOBS="$TEST_JOBS" --env PLATFORM="${PLATFORM:-}" --env TEST_RETRY="${TEST_RETRY:-}" ${UPDATES_IMG_ARGS:-} ${CONTAINER_RUN_ARGS:-} \
+    --env TEST_JOBS="$TEST_JOBS" --env PLATFORM_NAME="${PLATFORM:-}" --env TEST_RETRY="${TEST_RETRY:-}" ${UPDATES_IMG_ARGS:-} ${CONTAINER_RUN_ARGS:-} \
     --env KSTESTS_KEEP=${KSTESTS_KEEP:-1} \
     --env BOOT_ISO=${BOOT_ISO} \
     ${TEST_ENV_VARS} \

--- a/containers/runner/run-kstest
+++ b/containers/runner/run-kstest
@@ -33,8 +33,8 @@ if [ -n "${UPDATES_IMAGE}" ]; then
 fi
 
 PLATFORM_ARG=""
-if [ -n "${PLATFORM}" ]; then
-    PLATFORM_ARG="-p ${PLATFORM}"
+if [ -n "${PLATFORM_NAME}" ]; then
+    PLATFORM_ARG="-p ${PLATFORM_NAME}"
 fi
 TESTTYPE_ARG=""
 if [ -n "${TESTTYPE}" ]; then

--- a/functions.sh
+++ b/functions.sh
@@ -22,6 +22,13 @@ if [[ -e scripts/defaults.sh ]]; then
     . scripts/defaults.sh
 fi
 
+# Platform-specific defaults
+if [[ -n "${PLATFORM_NAME}" ]]; then
+    if [[ -e "scripts/defaults-${PLATFORM_NAME}.sh" ]]; then
+        . "scripts/defaults-${PLATFORM_NAME}.sh"
+    fi
+fi
+
 if [[ -e $HOME/.kstests.defaults.sh ]]; then
     . $HOME/.kstests.defaults.sh
 fi


### PR DESCRIPTION
There are two issues breaking this functionality.

- The functions.sh is currently sourcing only not platform specific defaults file. This works sometimes but sometimes but it might went wrong on the other than Fedora platforms.

- The PLATFORM_NAME is incorrectly propagated to tests as PLATFORM variable. It was propagated from the container call this way and used correctly in the run-kstest with this name. However, all these variables are also propagated to shell scripts for given tests. There this name fails because PLATFORM_NAME is used everywhere else.