### PR TITLE
Revert "rhel10: workaround incorrect naming of network devices by udev"

### DIFF
--- a/scripts/defaults-rhel10.sh
+++ b/scripts/defaults-rhel10.sh
@@ -7,6 +7,3 @@ export KSTEST_URL='http://download.devel.redhat.com/rhel-10/nightly/RHEL-10-Publ
 export KSTEST_MODULAR_URL='http://download.devel.redhat.com/rhel-10/nightly/RHEL-10-Public-Beta/latest-RHEL-10.0/compose/AppStream/x86_64/os/'
 export KSTEST_FTP_URL='ftp://download.devel.redhat.com/mnt/redhat/rhel-10/nightly/RHEL-10-Public-Beta/latest-RHEL-10.0/compose/BaseOS/x86_64/os/'
 export KSTEST_OSTREECONTAINER_URL='quay.io/centos-bootc/centos-bootc:stream10'
-
-# FIXME: This is a temporary workaround until https://issues.redhat.com/browse/RHEL-55728 is fixed.
-export KSTEST_EXTRA_BOOTOPS='net.naming_scheme=v255'


### PR DESCRIPTION
This reverts commit 69c0e97e0abf89e3b12e3e3cec3671e196ee38c0.