### PR TITLE
Disable rpm-ostree-container-luks on rhel10 until gh1293 is fixed

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -70,6 +70,7 @@ rhel10_skip_array=(
   gh1207      # packages-multilib failing
   gh1213      # harddrive-iso-single failing
   gh1270      # selinux-contexts failing
+  gh1293      # rpm-ostree-container-luks failing
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/rpm-ostree-container-luks.sh
+++ b/rpm-ostree-container-luks.sh
@@ -18,7 +18,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="payload ostree bootc luks reboot skip-on-rhel-8 gh1250"
+TESTTYPE="payload ostree bootc luks reboot skip-on-rhel-8 gh1250 gh1293"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
The issue: https://github.com/rhinstaller/kickstart-tests/issues/1293