### PR TITLE
Enable back LUKS tests

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -69,7 +69,6 @@ rhel10_skip_array=(
   gh1207      # packages-multilib failing
   gh1213      # harddrive-iso-single failing
   gh1270      # selinux-contexts failing
-  gh1293      # rpm-ostree-container-luks failing
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -22,7 +22,6 @@ fedora_skip_array=(
   gh1023      # rpm-ostree failing
   gh1060      # vnc tests too flaky
   gh1237      # container failing
-  gh1250      # rpm-ostree-container-luks fails to boot
 )
 
 daily_iso_skip_array=(

--- a/rpm-ostree-container-luks.sh
+++ b/rpm-ostree-container-luks.sh
@@ -18,12 +18,12 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="payload ostree bootc luks reboot skip-on-rhel-8 gh1250 gh1293"
+TESTTYPE="payload ostree bootc luks reboot skip-on-rhel-8 gh1293"
 
 . ${KSTESTDIR}/functions.sh
 
 copy_interesting_files_from_system() {
-    local disksdir args luks_partition root_lv 
+    local disksdir args luks_partition root_lv
     disksdir="${1}"
 
     # Find disks.

--- a/rpm-ostree-container-luks.sh
+++ b/rpm-ostree-container-luks.sh
@@ -18,7 +18,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="payload ostree bootc luks reboot skip-on-rhel-8 gh1293"
+TESTTYPE="payload ostree bootc luks reboot skip-on-rhel-8"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Tested locally and works. Seems like the fix https://gitlab.com/fedora/bootc/base-images/-/issues/17 resolved the issue.

Closes https://github.com/rhinstaller/kickstart-tests/issues/1293 https://github.com/rhinstaller/kickstart-tests/issues/1250