### PR TITLE
Fix validation issue in rpm-ostree-container-uefi

### DIFF
--- a/rpm-ostree-container-uefi.ks.in
+++ b/rpm-ostree-container-uefi.ks.in
@@ -25,7 +25,8 @@ reboot
 %ksappend validation/success_on_first_boot.ks
 
 %post
-efibootmgr | grep "Boot0001" | grep "HD(1"
+# We need to use tr because sometimes there is newline inside of the efibootmgr entry line :(
+efibootmgr | tr -s '\n' ' ' | grep -E 'Boot0001\* Fedora\s+HD\(1'
 if [ $? -ne 0 ]; then
     echo -e "EFI boot entry wasn't created properly:\n$(efibootmgr)"  >> /root/RESULT
 fi


### PR DESCRIPTION
The current efibootmgr validation has failed because newer uefi entries are so long that the line for the given entry is split to two lines.

Fix this by removing newlines and tweaking the grep calls.

Closes https://github.com/rhinstaller/kickstart-tests/issues/1298
Obsoletes https://github.com/rhinstaller/kickstart-tests/pull/1299