### PR TITLE
Revert "Disable selinux-contexts on rhel10 temporarily (gh1270)"

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -69,7 +69,6 @@ rhel10_skip_array=(
   gh1110      # storage-multipath-autopart failing
   gh1207      # packages-multilib failing
   gh1213      # harddrive-iso-single failing
-  gh1270      # selinux-contexts failing
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/selinux-contexts.sh
+++ b/selinux-contexts.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="security selinux gh1270"
+TESTTYPE="security selinux"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
This reverts commit 4b9803cc7575e00569d5af5e5aa3dc80cd6ba0f1.