### PR TITLE
Extend payload group

### DIFF
--- a/basic-ftp.sh
+++ b/basic-ftp.sh
@@ -20,6 +20,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="method"
+TESTTYPE="method payload"
 
 . ${KSTESTDIR}/functions.sh

--- a/basic-ftp.sh
+++ b/basic-ftp.sh
@@ -20,6 +20,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="method payload"
+TESTTYPE="payload"
 
 . ${KSTESTDIR}/functions.sh

--- a/basic-ostree.sh
+++ b/basic-ostree.sh
@@ -18,7 +18,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-#TESTTYPE="method"
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
 TESTTYPE="knownfailure payload"

--- a/basic-ostree.sh
+++ b/basic-ostree.sh
@@ -21,6 +21,6 @@
 #TESTTYPE="method"
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="knownfailure"
+TESTTYPE="knownfailure payload"
 
 . ${KSTESTDIR}/functions.sh

--- a/container.sh
+++ b/container.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="bootloader packaging coverage skip-on-rhel gh1237"
+TESTTYPE="bootloader packaging payload coverage skip-on-rhel gh1237"
 
 . ${KSTESTDIR}/functions.sh

--- a/driverdisk-disk.sh
+++ b/driverdisk-disk.sh
@@ -16,8 +16,10 @@
 # Author: Will Woods <wwoods@redhat.com>
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
+# The payload group is here because dud is creating repository during
+# installation and adding the DUD to the installed system this way
 # shellcheck disable=SC2034
-TESTTYPE="driverdisk"
+TESTTYPE="driverdisk payload"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/fedora-live-image-build.sh
+++ b/fedora-live-image-build.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging skip-on-rhel"
+TESTTYPE="packaging skip-on-rhel payload"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/groups-and-envs-1.sh
+++ b/groups-and-envs-1.sh
@@ -20,6 +20,6 @@
 # FIXME: times out on rhel8
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging skip-on-rhel"
+TESTTYPE="packaging payload skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/groups-and-envs-2.sh
+++ b/groups-and-envs-2.sh
@@ -20,7 +20,7 @@
 # FIXME: times out on rhel8
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging skip-on-rhel"
+TESTTYPE="packaging payload skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/groups-and-envs-3.sh
+++ b/groups-and-envs-3.sh
@@ -21,6 +21,6 @@
 # "Fedora Server default environment was not installed"
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging skip-on-rhel"
+TESTTYPE="packaging payload skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/groups-ignoremissing.sh
+++ b/groups-ignoremissing.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging"
+TESTTYPE="packaging payload"
 
 . ${KSTESTDIR}/functions.sh

--- a/harddrive-install-tree-relative.sh
+++ b/harddrive-install-tree-relative.sh
@@ -21,7 +21,7 @@
 # SourceSetupError: Nothing useful found for Hard drive ISO source at partition=/dev/sdb directory=/repo/
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging harddrive gh804"
+TESTTYPE="packaging payload harddrive gh804"
 
 . ${KSTESTDIR}/harddrive-install-tree.sh
 

--- a/harddrive-install-tree.sh
+++ b/harddrive-install-tree.sh
@@ -21,7 +21,7 @@
 # SourceSetupError: Nothing useful found for Hard drive ISO source at partition=/dev/sdb directory=/repo/
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"packaging harddrive gh804"}
+TESTTYPE=${TESTTYPE:-"packaging payload harddrive gh804"}
 
 . ${KSTESTDIR}/functions.sh
 

--- a/harddrive-iso-single.sh
+++ b/harddrive-iso-single.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"packaging harddrive gh804 gh1213"}
+TESTTYPE=${TESTTYPE:-"packaging payload harddrive gh804 gh1213"}
 
 . ${KSTESTDIR}/functions.sh
 

--- a/harddrive-iso.sh
+++ b/harddrive-iso.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"packaging harddrive gh804"}
+TESTTYPE=${TESTTYPE:-"packaging payload harddrive gh804"}
 
 . ${KSTESTDIR}/harddrive-install-tree.sh

--- a/https-repo.sh
+++ b/https-repo.sh
@@ -21,6 +21,6 @@
 # once there is a solution, create fragments/platform/rhel8/repos/https.ks
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="method skip-on-rhel"
+TESTTYPE="method payload skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/https-repo.sh
+++ b/https-repo.sh
@@ -21,6 +21,6 @@
 # once there is a solution, create fragments/platform/rhel8/repos/https.ks
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="method payload skip-on-rhel"
+TESTTYPE="payload skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/liveimg.sh
+++ b/liveimg.sh
@@ -20,7 +20,7 @@
 #TESTTYPE="method"
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="knownfailure"
+TESTTYPE="payload knownfailure"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/liveimg.sh
+++ b/liveimg.sh
@@ -17,7 +17,6 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
-#TESTTYPE="method"
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
 TESTTYPE="payload knownfailure"

--- a/module-1.sh
+++ b/module-1.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging modularity skip-on-rhel skip-on-fedora"
+TESTTYPE="packaging payload modularity skip-on-rhel skip-on-fedora"
 
 . ${KSTESTDIR}/functions.sh

--- a/module-2.sh
+++ b/module-2.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging modularity skip-on-rhel skip-on-fedora"
+TESTTYPE="packaging payload modularity skip-on-rhel skip-on-fedora"
 
 . ${KSTESTDIR}/functions.sh

--- a/module-3.sh
+++ b/module-3.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging modularity skip-on-rhel skip-on-fedora"
+TESTTYPE="packaging payload modularity skip-on-rhel skip-on-fedora"
 
 . ${KSTESTDIR}/functions.sh

--- a/module-4.sh
+++ b/module-4.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging modularity skip-on-rhel skip-on-fedora"
+TESTTYPE="packaging payload modularity skip-on-rhel skip-on-fedora"
 
 . ${KSTESTDIR}/functions.sh

--- a/module-enable-one-module-multiple-streams.sh
+++ b/module-enable-one-module-multiple-streams.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="knownfailure packaging modularity skip-on-rhel"
+TESTTYPE="knownfailure packaging payload modularity skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/module-enable-one-stream-install-different-stream.sh
+++ b/module-enable-one-stream-install-different-stream.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging modularity knownfailure"
+TESTTYPE="packaging payload modularity knownfailure"
 
 . ${KSTESTDIR}/functions.sh

--- a/module-ignoremissing.sh
+++ b/module-ignoremissing.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging modularity"
+TESTTYPE="packaging payload modularity"
 
 . ${KSTESTDIR}/functions.sh

--- a/module-install-no-stream-no-profile.sh
+++ b/module-install-no-stream-no-profile.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="knownfailure packaging modularity skip-on-rhel"
+TESTTYPE="knownfailure packaging payload modularity skip-on-rhel"
 # there are currently no modules with a default streams in Fedora
 
 . ${KSTESTDIR}/functions.sh

--- a/module-install-one-module-multiple-streams-and-profiles.sh
+++ b/module-install-one-module-multiple-streams-and-profiles.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="knownfailure packaging modularity skip-on-rhel"
+TESTTYPE="knownfailure packaging payload modularity skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/module-install-one-module-multiple-streams.sh
+++ b/module-install-one-module-multiple-streams.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="knownfailure packaging modularity skip-on-rhel"
+TESTTYPE="knownfailure packaging payload modularity skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/nfs.sh
+++ b/nfs.sh
@@ -20,6 +20,6 @@
 # requires special setup (NFS server) which we don't have in our test environments
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="method packaging knownfailure"
+TESTTYPE="method packaging payload knownfailure"
 
 . ${KSTESTDIR}/functions.sh

--- a/nfs.sh
+++ b/nfs.sh
@@ -20,6 +20,6 @@
 # requires special setup (NFS server) which we don't have in our test environments
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="method packaging payload knownfailure"
+TESTTYPE="packaging payload knownfailure"
 
 . ${KSTESTDIR}/functions.sh

--- a/packages-and-groups-1.sh
+++ b/packages-and-groups-1.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging"
+TESTTYPE="packaging payload"
 
 . ${KSTESTDIR}/functions.sh

--- a/packages-and-groups-ignoremissing.sh
+++ b/packages-and-groups-ignoremissing.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging coverage"
+TESTTYPE="packaging payload coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/packages-default.sh
+++ b/packages-default.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging skip-on-rhel gh975"
+TESTTYPE="packaging payload skip-on-rhel gh975"
 
 . ${KSTESTDIR}/functions.sh

--- a/packages-excludedocs.sh
+++ b/packages-excludedocs.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging"
+TESTTYPE="packaging payload"
 
 . ${KSTESTDIR}/functions.sh

--- a/packages-ignorebroken.sh
+++ b/packages-ignorebroken.sh
@@ -18,7 +18,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging skip-on-rhel"
+TESTTYPE="packaging payload skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/packages-ignoremissing.sh
+++ b/packages-ignoremissing.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging"
+TESTTYPE="packaging payload"
 
 . ${KSTESTDIR}/functions.sh

--- a/packages-instlangs-1.sh
+++ b/packages-instlangs-1.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging"
+TESTTYPE="packaging payload"
 
 . ${KSTESTDIR}/functions.sh

--- a/packages-instlangs-2.sh
+++ b/packages-instlangs-2.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging"
+TESTTYPE="packaging payload"
 
 . ${KSTESTDIR}/functions.sh

--- a/packages-instlangs-3.sh
+++ b/packages-instlangs-3.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging"
+TESTTYPE="packaging payload"
 
 . ${KSTESTDIR}/functions.sh

--- a/packages-multilib.sh
+++ b/packages-multilib.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging skip-on-rhel-8 gh641 gh1207"
+TESTTYPE="packaging payload skip-on-rhel-8 gh641 gh1207"
 
 . ${KSTESTDIR}/functions.sh

--- a/packages-weakdeps.sh
+++ b/packages-weakdeps.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging gh604"
+TESTTYPE="packaging payload gh604"
 
 . ${KSTESTDIR}/functions.sh

--- a/proxy-auth.sh
+++ b/proxy-auth.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="method payload proxy"
+TESTTYPE="payload proxy"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/functions-proxy.sh

--- a/proxy-auth.sh
+++ b/proxy-auth.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="method proxy"
+TESTTYPE="method payload proxy"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/functions-proxy.sh

--- a/proxy-cmdline.sh
+++ b/proxy-cmdline.sh
@@ -20,7 +20,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="method payload proxy"
+TESTTYPE="payload proxy"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/functions-proxy.sh

--- a/proxy-cmdline.sh
+++ b/proxy-cmdline.sh
@@ -20,7 +20,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="method proxy"
+TESTTYPE="method payload proxy"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/functions-proxy.sh

--- a/proxy-kickstart.sh
+++ b/proxy-kickstart.sh
@@ -20,7 +20,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="method payload proxy"
+TESTTYPE="payload proxy"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/functions-proxy.sh

--- a/proxy-kickstart.sh
+++ b/proxy-kickstart.sh
@@ -20,7 +20,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="method proxy"
+TESTTYPE="method payload proxy"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/functions-proxy.sh

--- a/repo-addrepo-hd-iso.sh
+++ b/repo-addrepo-hd-iso.sh
@@ -18,7 +18,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging repo harddrive gh804"
+TESTTYPE="packaging payload repo harddrive gh804"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/repo-addrepo-hd-tree.sh
+++ b/repo-addrepo-hd-tree.sh
@@ -19,7 +19,7 @@
 # FIXME: Fails on RHEL 8: "Nothing useful found for Hard drive ISO source"
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging repo harddrive gh804"
+TESTTYPE="packaging payload repo harddrive gh804"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/repo-addrepo.sh
+++ b/repo-addrepo.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging repo"
+TESTTYPE="packaging payload repo"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/repo-baseurl.sh
+++ b/repo-baseurl.sh
@@ -18,7 +18,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging repo"
+TESTTYPE="packaging payload repo"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/repo-enable.sh
+++ b/repo-enable.sh
@@ -18,7 +18,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging repo"
+TESTTYPE="packaging payload repo"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/repo-exclude.sh
+++ b/repo-exclude.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging repo"
+TESTTYPE="packaging payload repo"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/repo-include.sh
+++ b/repo-include.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging repo"
+TESTTYPE="packaging payload repo"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/repo-install.sh
+++ b/repo-install.sh
@@ -18,7 +18,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging repo"
+TESTTYPE="packaging payload repo"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/repo-metalink.sh
+++ b/repo-metalink.sh
@@ -18,7 +18,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging repo skip-on-rhel"
+TESTTYPE="packaging payload repo skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/repo-mirrorlist.sh
+++ b/repo-mirrorlist.sh
@@ -18,7 +18,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging repo skip-on-rhel"
+TESTTYPE="packaging payload repo skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/unified-cdrom.sh
+++ b/unified-cdrom.sh
@@ -27,6 +27,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="skip-on-fedora manual"
+TESTTYPE="skip-on-fedora payload manual"
 
 . ${KSTESTDIR}/functions.sh

--- a/unified-cmdline.sh
+++ b/unified-cmdline.sh
@@ -21,7 +21,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="skip-on-fedora manual"
+TESTTYPE="skip-on-fedora payload manual"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/unified-harddrive.sh
+++ b/unified-harddrive.sh
@@ -21,7 +21,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="skip-on-fedora manual"
+TESTTYPE="skip-on-fedora payload manual"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/unified-nfs.sh
+++ b/unified-nfs.sh
@@ -21,6 +21,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="skip-on-fedora manual"
+TESTTYPE="skip-on-fedora payload manual"
 
 . ${KSTESTDIR}/functions.sh

--- a/unified.sh
+++ b/unified.sh
@@ -20,6 +20,6 @@
 # times out
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging skip-on-fedora manual"
+TESTTYPE="packaging payload skip-on-fedora manual"
 
 . ${KSTESTDIR}/functions.sh

--- a/url-baseurl.sh
+++ b/url-baseurl.sh
@@ -18,6 +18,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging url"
+TESTTYPE="packaging payload url"
 
 . ${KSTESTDIR}/functions.sh

--- a/url-metalink.sh
+++ b/url-metalink.sh
@@ -18,6 +18,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging url skip-on-rhel"
+TESTTYPE="packaging payload url skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh

--- a/url-mirrorlist.sh
+++ b/url-mirrorlist.sh
@@ -18,6 +18,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging url skip-on-rhel"
+TESTTYPE="packaging payload url skip-on-rhel"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Extend the `payload` group to all payload related tests and remove old `method` group which is outdated and confusing.