### PR TITLE
Extend smoke tests set by 8 tests to 12

### DIFF
--- a/autopart-encrypted-1.sh
+++ b/autopart-encrypted-1.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage coverage"
+TESTTYPE="autopart storage coverage smoke"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/bond2-httpks.sh
+++ b/bond2-httpks.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="${TESTTYPE:-"network"} coverage"
+TESTTYPE="${TESTTYPE:-"network"} coverage smoke"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/keyboard.sh
+++ b/keyboard.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="keyboard i18n coverage"
+TESTTYPE="keyboard i18n coverage smoke"
 
 . ${KSTESTDIR}/functions.sh

--- a/lvm-thinp-1.sh
+++ b/lvm-thinp-1.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="lvm storage coverage"
+TESTTYPE="lvm storage coverage smoke"
 
 . ${KSTESTDIR}/functions.sh

--- a/network-static-2-httpks.sh
+++ b/network-static-2-httpks.sh
@@ -26,7 +26,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="${TESTTYPE:-"network"} coverage"
+TESTTYPE="${TESTTYPE:-"network"} coverage smoke"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/packages-and-groups-ignoremissing.sh
+++ b/packages-and-groups-ignoremissing.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging payload coverage"
+TESTTYPE="packaging payload coverage smoke"
 
 . ${KSTESTDIR}/functions.sh

--- a/raid-1.sh
+++ b/raid-1.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"raid storage coverage"}
+TESTTYPE=${TESTTYPE:-"raid storage coverage smoke"}
 
 . ${KSTESTDIR}/functions.sh
 

--- a/user-multiple.sh
+++ b/user-multiple.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="users coverage"
+TESTTYPE="users coverage smoke"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Resolves: INSTALLER-3943

Currently we run 16 tests in parallel in a single batch run so let's use the resources for better coverage in mandatory CI test.

These tests are mandatory to be run on an anaconda PR (`/kickstart-test --testtype smoke`).
(It is on the developer's/reviewer's consideration to run more tests (or the whole suite) on the PR, for example `/kickstart-test --testtype storage` on a PR touching storage.)

The PR increases the number of tests from 4 to 12.

**Feel free to suggest / replace a test, suggestions are very welcome.**
I picked the tests
- from the `coverage` group (may need review as well).
- stable enough (should be most of the tests from `coverage`)
- that cover wide and important area together (here my choice can be definitely suboptimal)

