### PR TITLE
Add an UEFI test (reboot-uefi) to coverage and smoke groups

### DIFF
--- a/reboot-uefi.ks.in
+++ b/reboot-uefi.ks.in
@@ -1,0 +1,25 @@
+#version=DEVEL
+#test name: reboot-uefi
+
+# Use defaults.
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
+%ksappend payload/default_packages.ks
+
+# Reboot the installed system.
+reboot
+
+# Validate on the first boot.
+%ksappend validation/success_on_first_boot.ks
+
+# Set up the actual test.
+%post
+
+efibootmgr
+rc=$?
+
+if [ $rc -ne 0 ]; then
+    echo "*** efibootmgr call failed." | tee -a /root/RESULT
+fi
+
+%end

--- a/reboot-uefi.sh
+++ b/reboot-uefi.sh
@@ -1,0 +1,32 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
+TESTTYPE="reboot uefi coverage smoke"
+
+. ${KSTESTDIR}/functions.sh
+
+enable_uefi() {
+    echo "true"
+}
+
+additional_runner_args() {
+    # Wait for reboot and shutdown of the VM,
+    # but exit after the specified timeout.
+    echo "--wait $(get_timeout)"
+}


### PR DESCRIPTION
Resolves: INSTALLER-4061
A modification of `reboot` test.