### PR TITLE
Improve documentation for TMT local run

### DIFF
--- a/.github/workflows/testingfarm.yml
+++ b/.github/workflows/testingfarm.yml
@@ -1,4 +1,8 @@
 ---
+# Run TMT test plans in the Testing Farm machines
+#
+# This could be also started locally if needed. Take a look into the plans directory.
+#
 name: Testing farm tests
 
 on:

--- a/plans/testing-farm.fmf
+++ b/plans/testing-farm.fmf
@@ -6,7 +6,7 @@
 #
 # If you really need to debug this locally follow these steps:
 # 1. Create PR against rhinstaller/kickstart tests
-# 2. Run `tmt run --all -vvv -e PR_NUMBER=<Pull Request id> provision --how virtual --memory 16384  # Don't go with memory under 3072 MB
+# 2. Run `tmt run --all -vvv -e PR_NUMBER=<Pull Request id> provision --how virtual --hardware 'cpu.processors=8' --memory 16384  # Don't go with memory under 3072 MB
 #
 # Steps above will start local VM which will clone your PR and execute tests on that code. It means
 # that TMT plan data are taken from local but everything else is taken from the PR.
@@ -36,7 +36,7 @@ discover:
 
         trap "cp -rv data/logs/ ${TMT_TEST_DATA}/" EXIT INT QUIT PIPE
 
-        cd /root/kickstart-tests 
+        cd /root/kickstart-tests
         scripts/run_travis.sh
 
 


### PR DESCRIPTION
Now I finally know how to set number of CPUs for local runs.

Also link the information how to run TMT locally into the GitHub workflow.