### PR TITLE
Extend container-uefi with fix for vconsole keymap

### DIFF
--- a/rpm-ostree-container-uefi.ks.in
+++ b/rpm-ostree-container-uefi.ks.in
@@ -59,9 +59,15 @@ if [ ${?} -ne 0 ]; then
 fi
 
 if [ "${remote_url}" != "${expected_url}" ]; then
-    echo "Unexpected URL: ${remote_url}, expected ${expected_url}"" >> /root/RESULT
+    echo "Unexpected URL: ${remote_url}, expected ${expected_url}" >> /root/RESULT
 fi
 
+# Test for vconsole kernel argument (specific to ostree installations)
+# https://bugzilla.redhat.com/show_bug.cgi?id=1890085
+journalctl | grep -q "vconsole.keymap=us"
+if [ $? -ne 0 ]; then
+    echo "Kernel argument 'vconsole.keymap' is not used in the installed system!" >> /root/RESULT
+fi
 
 EOF
 %end

--- a/rpm-ostree-container-uefi.sh
+++ b/rpm-ostree-container-uefi.sh
@@ -18,7 +18,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="payload uefi ostree bootc reboot skip-on-rhel-8 skip-on-rhel-9 skip-on-rhel-10"
+TESTTYPE="payload uefi ostree bootc keyboard reboot skip-on-rhel-8 skip-on-rhel-9 skip-on-rhel-10"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
It is fix for
https://bugzilla.redhat.com/show_bug.cgi?id=1890085 https://issues.redhat.com/browse/INSTALLER-2537

Currently, virtual console is not correctly set from localed on an ostree installations. To resolve this issue let's put the `vconsole.keymap` to the installed system kernel arguments.

Depends on  https://github.com/rhinstaller/anaconda/pull/5952