### PR TITLE
Add test for log processing

### DIFF
--- a/log-util-check.ks.in
+++ b/log-util-check.ks.in
@@ -1,0 +1,23 @@
+#version=DEVEL
+#test name: efi-log
+%ksappend repos/default.ks
+
+%ksappend common/common_no_payload.ks
+
+%packages
+@core
+%end
+
+%post --nochroot
+
+@KSINCLUDE@ log-util-tests.sh
+
+check_log_util_exist
+check_log_util_runs
+check_log_util_produces_log_archive
+
+%end
+
+# No error was written to /root/RESULT file, everything is OK
+%ksappend validation/success_if_result_empty_standalone.ks
+

--- a/log-util-check.sh
+++ b/log-util-check.sh
@@ -1,0 +1,24 @@
+#
+# Copyright (C) 2024  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Paweł Poławski <ppolawsk@redhat.com>
+
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
+TESTTYPE="logs"
+
+. ${KSTESTDIR}/functions.sh

--- a/log-util-tests.sh
+++ b/log-util-tests.sh
@@ -1,0 +1,33 @@
+SYSROOT=/mnt/sysroot
+RESULT_FILE=${SYSROOT}/root/RESULT
+
+# Check if log util can be called
+function check_log_util_exist() {
+    if [ ! -f /usr/libexec/anaconda/log-capture ]; then
+        echo "*** Failed check: log-capture util does not exist" >> ${RESULT_FILE}
+    fi
+}
+
+# Check if log utils runs without failure
+function check_log_util_runs() {
+    local exit_code=0
+    local ret_code=0
+
+    # Trigger the log util
+    /usr/libexec/anaconda/log-capture
+    ret_code=$?
+
+    if [[ $? -ne ${exit_code} ]]; then
+        echo "*** Failed check: log-capture util failed with code: ${ret_code}" >> ${RESULT_FILE}
+    fi
+}
+
+# Check if log utils produces log tarbal
+function check_log_util_produces_log_archive() {
+    # Trigger the log util
+    /usr/libexec/anaconda/log-capture
+
+    if [ ! -f /tmp/log-capture.tar.bz2 ]; then
+        echo "*** Failed check: log-capture util does not produced log archive" >> ${RESULT_FILE}
+    fi
+}


### PR DESCRIPTION
'/usr/libexec/anaconda/log-capture' is an util to generate runtime logs. This commit adds test validating output of this util.