### PR TITLE
Adjust luks-lvm-2 test case to cover RHEL-45180

### DIFF
--- a/lvm-luks-2.ks.in
+++ b/lvm-luks-2.ks.in
@@ -15,7 +15,7 @@ part pv.1 --fstype="lvmpv" --size=8915
 
 volgroup fedora pv.1
 
-logvol / --name=root --vgname=fedora --fstype="ext4" --grow --size=1024 --encrypted --passphrase="passphrase" --luks-version=luks2
+logvol / --name=root --vgname=fedora --fstype="ext4" --grow --size=1 --encrypted --passphrase="passphrase" --luks-version=luks2
 logvol swap --name=swap --vgname=fedora --fstype="swap" --size=1023
 
 keyboard us


### PR DESCRIPTION
We have a bug in blivet triggered by using LUKS encrypted LV with --size=1 and --grow. This can be easily covered by adjusting the existing luks-lvm-2 test case which also uses --grow.