### PR TITLE
Stop travis runs by removing config file and update documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-dist: focal
-sudo: true
-language: minimal
-addons:
-  apt:
-    packages:
-      - nftables
-script: scripts/run_travis.sh

--- a/README.rst
+++ b/README.rst
@@ -368,12 +368,6 @@ created PRs, however, only committers have privileged to execute `tmt workflow`_
 by comment ``/test-tmt`` on the PR. After a while status on PR will have a link to
 TMT run.
 
-Thus PR tests run on Travis_, which is one of the few public CI providers who
-offer ``/dev/kvm``. The entry point is `.travis.yml`_. The ``run_travis.sh``
-script checks which tests are affected by the PR, and runs the first six in
-the runner container's launch script. Travis jobs are limited to 50 minutes, so
-we cannot currently run more; but that should suffice in most cases.
-
 PR runs do *not* auto-retry test failures. This avoids introducing unstable
 tests, and PRs usually just run a few tests so that flakes are much less likely
 to ruin the result.

--- a/plans/testing-farm.fmf
+++ b/plans/testing-farm.fmf
@@ -37,7 +37,7 @@ discover:
         trap "cp -rv data/logs/ ${TMT_TEST_DATA}/" EXIT INT QUIT PIPE
 
         cd /root/kickstart-tests
-        scripts/run_travis.sh
+        scripts/run-ci.sh
 
 
       duration: 6h

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -12,7 +12,6 @@ CHANGED_TESTS=$(git diff --name-only upstream/master..HEAD -- *.ks.in $(find -ma
 TESTS=$CHANGED_TESTS
 
 # if the PR changes anything in the test runner, or does not touch any tests, pick a few representative tests
-# FIXME: Once the runner container can run groups properly, replace with a TESTTYPE="travis" group
 if [ -z "$TESTS" ] || [ -n "$(git diff --name-only upstream/master..HEAD -- containers scripts)" ]; then
     TESTS="$TESTS
 bindtomac-network-device-default-httpks
@@ -35,6 +34,7 @@ sudo -n chmod 666 /dev/kvm
 
 sudo -n containers/squid.sh start
 
+# FIXME: Maybe it's not needed with testing farm
 # With parallel jobs, each test takes a little longer than 10 minutes, which makes Travis abort
 # <https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received>
 # Avoid this by printing a keep-alive '.' line every minute


### PR DESCRIPTION
We run our tests reliably on testing farm and we stopped our travis subscription.