### PR TITLE
Update pre-install test for new modularization

### DIFF
--- a/script-pre-install.ks.in
+++ b/script-pre-install.ks.in
@@ -12,16 +12,10 @@ with open("/mnt/sysroot/root/preinstall_python.log", "a") as log_file:
 %end
 
 # Second pre-install script with intentional error
-%pre-install --erroronfail --log=/mnt/sysroot/root/preinstall_error.log
+%pre-install --log=/mnt/sysroot/root/preinstall_error.log
 echo "SUCCESS"
 echo "Logging from bash pre-install script" >> /mnt/sysroot/root/preinstall_error.log
-shutdown +1
 exit 1
-%end
-
-# Pre-install script that should be unreachable
-%pre-install
-echo "Unreachable code" >> /mnt/sysroot/root/preinstall_error.log
 %end
 
 text

--- a/script-pre-install.sh
+++ b/script-pre-install.sh
@@ -37,10 +37,9 @@ validate() {
         status=1
     fi
 
-    # Ensure that the "Unreachable code" message is NOT present.
-    grep -q "Unreachable code" "${disksdir}/virt-install.log"
-    if [[ $? == 0 ]]; then
-        echo '*** ERROR: The test failed because unreachable code was executed after "exit 1".'
+    # Check for the specific error message in the virt-install.log
+    if ! grep -q "kickstart.script: Error code 1 running the kickstart script" "${disksdir}/virt-install.log"; then
+        echo '*** ERROR: Expected error message "kickstart.script: Error code 1 running the kickstart script" not found in virt-install.log.'
         status=1
     fi
 


### PR DESCRIPTION
Due to modularization it was necessary to make a change in the tests because the triggered error from the module shows a traceback in the log, which automatically terminates the test at --erroronfail. So the temporary solution is to test the test without this parameter, and look for the error in the log.