### PR TITLE
Remove #test name comment from ks.in files

### DIFF
--- a/anabot-1.ks.in
+++ b/anabot-1.ks.in
@@ -1,4 +1,3 @@
 #version=DEVEL
-#test name: anabot-1
 
 # NOTHING TO DO HERE! THIS FILE IS NOT USED!

--- a/anaconda-conf.ks.in
+++ b/anaconda-conf.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: anaconda-conf
 
 # Verify that the Anaconda configuration can be changed.
 

--- a/anaconda-modules.ks.in
+++ b/anaconda-modules.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: anaconda-modules
 
 # Verify that only the enabled Anaconda DBus modules are started.
 

--- a/authconfig.ks.in
+++ b/authconfig.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: authconfig
 %ksappend repos/default.ks
 
 %ksappend common/common_no_payload.ks

--- a/authselect-not-set.ks.in
+++ b/authselect-not-set.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: authselect-not-set
 #Test that authselect default configuration if authselect is not set in kickstart
 %ksappend repos/default.ks
 

--- a/authselect.ks.in
+++ b/authselect.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: authselect
 %ksappend repos/default.ks
 
 %ksappend common/common_no_payload.ks

--- a/autopart-encrypted-1.ks.in
+++ b/autopart-encrypted-1.ks.in
@@ -1,4 +1,3 @@
-#test name: autopart-encrypted-1
 
 %ksappend repos/default.ks
 network --bootproto=dhcp

--- a/autopart-encrypted-2.ks.in
+++ b/autopart-encrypted-2.ks.in
@@ -1,4 +1,3 @@
-#test name: autopart-encrypted-2
 
 %ksappend repos/default.ks
 network --bootproto=dhcp

--- a/autopart-encrypted-3.ks.in
+++ b/autopart-encrypted-3.ks.in
@@ -1,4 +1,3 @@
-#test name: autopart-encrypted-3
 
 %ksappend repos/default.ks
 network --bootproto=dhcp

--- a/autopart-fstype.ks.in
+++ b/autopart-fstype.ks.in
@@ -1,4 +1,3 @@
-#test name: autopart-fstype
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/autopart-hibernation.ks.in
+++ b/autopart-hibernation.ks.in
@@ -1,4 +1,3 @@
-#test name: autopart-hibernation
 %ksappend repos/default.ks
 
 zerombr

--- a/autopart-luks-1.ks.in
+++ b/autopart-luks-1.ks.in
@@ -1,4 +1,3 @@
-#test name: autopart-luks-1
 
 %ksappend repos/default.ks
 network --bootproto=dhcp

--- a/autopart-luks-2.ks.in
+++ b/autopart-luks-2.ks.in
@@ -1,4 +1,3 @@
-#test name: autopart-luks-2
 
 %ksappend repos/default.ks
 network --bootproto=dhcp

--- a/autopart-luks-3.ks.in
+++ b/autopart-luks-3.ks.in
@@ -1,4 +1,3 @@
-#test name: autopart-luks-3
 
 %ksappend repos/default.ks
 network --bootproto=dhcp

--- a/autopart-luks-4.ks.in
+++ b/autopart-luks-4.ks.in
@@ -1,4 +1,3 @@
-#test name: autopart-luks-4
 
 %ksappend repos/default.ks
 network --bootproto=dhcp

--- a/autopart-luks-5.ks.in
+++ b/autopart-luks-5.ks.in
@@ -1,4 +1,3 @@
-#test name: autopart-luks-5
 
 %ksappend repos/default.ks
 network --bootproto=dhcp

--- a/autopart-nohome.ks.in
+++ b/autopart-nohome.ks.in
@@ -1,4 +1,3 @@
-#test name: autopart-nohome
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/basic-ftp.ks.in
+++ b/basic-ftp.ks.in
@@ -1,4 +1,3 @@
-#test name: basic-ftp
 url --url=@KSTEST_FTP_URL@
 network --bootproto=dhcp
 

--- a/basic-ostree.ks.in
+++ b/basic-ostree.ks.in
@@ -1,4 +1,3 @@
-#test name: basic-ostree
 # Substitute something in for REPO or this will all come crashing down.
 ostreesetup --nogpg --osname=fedora-atomic --remote=fedora-atomic --url=@KSTEST_OSTREE_REPO@ --ref=fedora-atomic/rawhide/x86_64/base/core
 network --bootproto=dhcp

--- a/bindtomac-bond-vlan-httpks.ks.in
+++ b/bindtomac-bond-vlan-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: bindtomac-bond-vlan
 %ksappend repos/default.ks
 
 network --device bond0 --bootproto static --ip @KSTEST_STATIC_IP@ --netmask @KSTEST_STATIC_NETMASK@ --gateway @KSTEST_STATIC_GATEWAY@ --bondslaves=@KSTEST_NETDEV2@,@KSTEST_NETDEV3@ --bondopts=mode=active-backup,miimon=100,primary=@KSTEST_NETDEV2@ --activate --vlanid=222 --activate --onboot=no --bindto=mac

--- a/bindtomac-bond2-httpks.ks.in
+++ b/bindtomac-bond2-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: bindtomac-bond2
 %ksappend repos/default.ks
 
 network --device bond0 --bootproto dhcp --bondslaves=@KSTEST_NETDEV2@,@KSTEST_NETDEV3@ --bondopts=mode=active-backup,primary=@KSTEST_NETDEV2@ --activate --onboot=no --bindto=mac

--- a/bindtomac-bond2-pre.ks.in
+++ b/bindtomac-bond2-pre.ks.in
@@ -1,4 +1,3 @@
-#test name: bindtomac-bond2-pre
 #NOTE: this test is a variant of bond2 test, it is sharing its .sh file (setup of NICs and network boot configuration) so beware of changing it independently of bond2 test
 %ksappend repos/default.ks
 

--- a/bindtomac-bridge-2devs-httpks.ks.in
+++ b/bindtomac-bridge-2devs-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name bindtomac-bridge-2devs
 # One bridge with slave activated in dracut,
 # the other one with slave activated only with the bridge
 %ksappend repos/default.ks

--- a/bindtomac-bridge-2devs-pre.ks.in
+++ b/bindtomac-bridge-2devs-pre.ks.in
@@ -1,4 +1,3 @@
-#test name bindtomac-bridge-2devs-pre
 # One bridge with slave activated in dracut,
 # the other one with slave activated only with the bridge
 %ksappend repos/default.ks

--- a/bindtomac-bridge-httpks.ks.in
+++ b/bindtomac-bridge-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name bindtomac-bridge
 %ksappend repos/default.ks
 
 # --onboot=no doesn't make much sense as a use case but we want to test that it works in this test

--- a/bindtomac-bridge-no-bootopts-net.ks.in
+++ b/bindtomac-bridge-no-bootopts-net.ks.in
@@ -1,4 +1,3 @@
-#test name bindtomac-bridge-no-bootopts-net
 # Test activating bridge from kickstart in dracut (requires no active network
 # when parsing kickstart, ie ks=hd: or ks=file:)
 # https://bugzilla.redhat.com/show_bug.cgi?id=1373360

--- a/bindtomac-bridged-bond-httpks.ks.in
+++ b/bindtomac-bridged-bond-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name bindtomac-bridged-bond
 %ksappend repos/default.ks
 
 network --device=@KSTEST_NETDEV1@ --bootproto=dhcp --onboot=yes --activate

--- a/bindtomac-ifname-httpks.ks.in
+++ b/bindtomac-ifname-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: bindtomac-ifname-httpks
 %ksappend repos/default.ks
 
 network --bootproto=dhcp --device=ifname0 --ipv6=2001:cafe:cafe::2/64 --bindto=mac

--- a/bindtomac-network-device-default-httpks.ks.in
+++ b/bindtomac-network-device-default-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: bindtomac-network-device-default
 #NOTE: as this test is a "-httpks" the kickstart should be really applied
 #      in initrafs (config files created by parse-kickstart). The parse-kickstart
 #      code actually ignores the command without --device specified

--- a/bindtomac-network-device-mac-httpks.ks.in
+++ b/bindtomac-network-device-mac-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: bindtomac-network-device-mac
 %ksappend repos/default.ks
 
 network --bootproto=dhcp --device=52:54:00:12:34:51 --bindto=mac

--- a/bindtomac-network-device-mac-pre.ks.in
+++ b/bindtomac-network-device-mac-pre.ks.in
@@ -1,4 +1,3 @@
-#test name: bindtomac-network-device-mac-pre
 %ksappend repos/default.ks
 
 %include /tmp/ksinclude

--- a/bindtomac-network-device-mac.ks.in
+++ b/bindtomac-network-device-mac.ks.in
@@ -1,4 +1,3 @@
-#test name: bindtomac-network-device-mac
 %ksappend repos/default.ks
 
 network --bootproto=dhcp --device=52:54:00:12:34:50 --bindto=mac

--- a/bindtomac-network-static-2-httpks.ks.in
+++ b/bindtomac-network-static-2-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: bindtomac-network-static-2
 #various combinations of activation in initramfs and stage 2
 %ksappend repos/default.ks
 # activated in initramfs with dhcp, reactivated in stage 2

--- a/bindtomac-network-static-to-dhcp-pre-single.ks.in
+++ b/bindtomac-network-static-to-dhcp-pre-single.ks.in
@@ -1,4 +1,3 @@
-#test name: bindtomac-network-static-to-dhcp-pre-single
 # rhbz#1432886
 %ksappend repos/default.ks
 %include /tmp/ksinclude

--- a/bindtomac-onboot-activate-httpks.ks.in
+++ b/bindtomac-onboot-activate-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: bindtomac-onboot-activate-httpks
 %ksappend repos/default.ks
 network --device=@KSTEST_NETDEV2@ --bootproto=dhcp --no-activate --onboot=yes --bindto=mac
 network --device=@KSTEST_NETDEV1@ --bootproto=dhcp --onboot=no --bindto=mac

--- a/bindtomac-onboot-bootopts-pre.ks.in
+++ b/bindtomac-onboot-bootopts-pre.ks.in
@@ -1,4 +1,3 @@
-#test name: bindtomac-onboot-bootopts-pre
 %ksappend repos/default.ks
 
 %include /tmp/ksinclude

--- a/bindtomac-team-httpks.ks.in
+++ b/bindtomac-team-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: bindtomac-team
 %ksappend repos/default.ks
 
 network --device team0 --bootproto dhcp --teamslaves="@KSTEST_NETDEV2@'{\"prio\": -10, \"sticky\": true}',@KSTEST_NETDEV3@'{\"prio\": 100}'" --teamconfig="{\"runner\": {\"name\": \"activebackup\"}}" --activate --onboot=no --bindto=mac

--- a/bindtomac-team-pre.ks.in
+++ b/bindtomac-team-pre.ks.in
@@ -1,4 +1,3 @@
-#test name: bindtomac-team-pre
 #NOTE: this test is a variant of team test, it is sharing its .sh file (setup of NICs and network boot configuration) so beware of changing it independently of team test
 %ksappend repos/default.ks
 

--- a/bond-ks-initramfs.ks.in
+++ b/bond-ks-initramfs.ks.in
@@ -1,4 +1,3 @@
-#test name: bond-ks-intiramfs
 # Test bond configured via kickstart in initramfs
 # Because kickstart is obtained (injected in initramfs) without activating
 # network (which would be done from boot options network configuration),

--- a/bond-vlan-httpks.ks.in
+++ b/bond-vlan-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: bond-vlan
 %ksappend repos/default.ks
 
 network --device bond0 --bootproto static --ip @KSTEST_STATIC_IP@ --netmask @KSTEST_STATIC_NETMASK@ --gateway @KSTEST_STATIC_GATEWAY@ --bondslaves=@KSTEST_NETDEV2@,@KSTEST_NETDEV3@ --bondopts=mode=active-backup,miimon=100,primary=@KSTEST_NETDEV2@ --activate --vlanid=222 --activate --onboot=no

--- a/bond-vlan-pre.ks.in
+++ b/bond-vlan-pre.ks.in
@@ -1,4 +1,3 @@
-#test name: bond-vlan-pre
 #NOTE: this test is a variant of bond-vlan-httpks test, it is sharing its .sh file (setup of NICs and network boot configuration) so beware of changing it independently of bond-vlan-httpks test
 %ksappend repos/default.ks
 

--- a/bond2-httpks.ks.in
+++ b/bond2-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: bond2
 %ksappend repos/default.ks
 
 network --device bond0 --bootproto dhcp --bondslaves=@KSTEST_NETDEV2@,@KSTEST_NETDEV3@ --bondopts=mode=active-backup,primary=@KSTEST_NETDEV2@ --activate --onboot=no

--- a/bond2-pre.ks.in
+++ b/bond2-pre.ks.in
@@ -1,4 +1,3 @@
-#test name: bond2-pre
 #NOTE: this test is a variant of bond2 test, it is sharing its .sh file (setup of NICs and network boot configuration) so beware of changing it independently of bond2 test
 %ksappend repos/default.ks
 

--- a/bridge-2devs-httpks.ks.in
+++ b/bridge-2devs-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name bridge-2devs
 # One bridge with slave activated in dracut,
 # the other one with slave activated only with the bridge
 %ksappend repos/default.ks

--- a/bridge-2devs-pre.ks.in
+++ b/bridge-2devs-pre.ks.in
@@ -1,4 +1,3 @@
-#test name bridge-2devs-pre
 # One bridge with slave activated in dracut,
 # the other one with slave activated only with the bridge
 %ksappend repos/default.ks

--- a/bridge-2devs.ks.in
+++ b/bridge-2devs.ks.in
@@ -1,4 +1,3 @@
-#test name bridge-2devs
 # One bridge with slave activated in dracut,
 # the other one with slave activated only with the bridge
 %ksappend repos/default.ks

--- a/bridge-httpks.ks.in
+++ b/bridge-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name bridge
 # This test differs from bridge-2devs in using ip=dhcp (no dev specification)
 %ksappend repos/default.ks
 

--- a/bridge-no-bootopts-net.ks.in
+++ b/bridge-no-bootopts-net.ks.in
@@ -1,4 +1,3 @@
-#test name bridge-no-bootopts-net
 # Test activating bridge from kickstart in dracut (requires no active network
 # when parsing kickstart, ie ks=hd: or ks=file:)
 # https://bugzilla.redhat.com/show_bug.cgi?id=1373360

--- a/bridged-bond-httpks.ks.in
+++ b/bridged-bond-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name bridged-bond
 %ksappend repos/default.ks
 
 network --device=@KSTEST_NETDEV1@ --bootproto=dhcp --onboot=yes --activate

--- a/btrfs-1.ks.in
+++ b/btrfs-1.ks.in
@@ -1,4 +1,3 @@
-#test name: btrfs-1
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/btrfs-2.ks.in
+++ b/btrfs-2.ks.in
@@ -1,4 +1,3 @@
-#test name: btrfs-2
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/clearpart-1.ks.in
+++ b/clearpart-1.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: ignoredisk
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/clearpart-2.ks.in
+++ b/clearpart-2.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: ignoredisk
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/clearpart-3.ks.in
+++ b/clearpart-3.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: ignoredisk
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/clearpart-4.ks.in
+++ b/clearpart-4.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: ignoredisk
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/container.ks.in
+++ b/container.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: container
 #
 # Test that a very minimal installation,
 # generally targetting constainer base images,

--- a/default-desktop.ks.in
+++ b/default-desktop.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: default-desktop
 #
 # Test default desktop configuration via the xconfig command.
 %ksappend repos/default.ks

--- a/default-fstype.ks.in
+++ b/default-fstype.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: default-fstype
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/default-menu-auto-hide-fedora.ks.in
+++ b/default-menu-auto-hide-fedora.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: default-menu-auto-hide
 %ksappend repos/default.ks
 
 %ksappend common/common_no_payload.ks

--- a/default-menu-auto-hide-rhel.ks.in
+++ b/default-menu-auto-hide-rhel.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: default-menu-auto-hide
 %ksappend repos/default.ks
 
 %ksappend common/common_no_payload.ks

--- a/default-systemd-target-gui-graphical-provides.ks.in
+++ b/default-systemd-target-gui-graphical-provides.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: default-systemd-target-gui-graphical-login-provides
 #
 # Test graphical.target is set as the default systemd target if:
 # - the installation runs in GUI mode

--- a/default-systemd-target-gui.ks.in
+++ b/default-systemd-target-gui.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: default-systemd-target-gui
 #
 # Test multi-user.target should be set by default as the default systemd target
 # when installation runs in GUI mode but not package with service(graphical-login)

--- a/default-systemd-target-rdp-graphical-provides.ks.in
+++ b/default-systemd-target-rdp-graphical-provides.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: default-systemd-target-rdp-graphical-provides
 #
 # Test multi-user.target is set as the default systemd target if:
 # - the installation runs in remote desktop mode

--- a/default-systemd-target-rdp.ks.in
+++ b/default-systemd-target-rdp.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: default-systemd-target-rdp
 #
 # Test multi-user.target should be set by default as the default systemd target
 # for remote desktop installs. While controlled remotely over RDP the installation itself runs

--- a/default-systemd-target-skipx.ks.in
+++ b/default-systemd-target-skipx.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: default-systemd-target-skipx
 #
 # Test default systemd target is correctly set via the skipx command.
 %ksappend repos/default.ks

--- a/default-systemd-target-startxonboot.ks.in
+++ b/default-systemd-target-startxonboot.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: default-systemd-target-startxonboot
 #
 # Test default systemd target configuration via the xconfig --startxonboot command.
 %ksappend repos/default.ks

--- a/default-systemd-target-tui-graphical-provides.ks.in
+++ b/default-systemd-target-tui-graphical-provides.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: default-systemd-target-tui-graphical-provides
 #
 # Test multi-user.target is set as the default systemd target if:
 # - the installation tuns in text mode

--- a/default-systemd-target-tui.ks.in
+++ b/default-systemd-target-tui.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: default-systemd-target-tui
 #
 # Test multi-user.target should be set by default as the default systemd target when:
 # - the installation runs in text mode

--- a/default-systemd-target-vnc-graphical-provides.ks.in
+++ b/default-systemd-target-vnc-graphical-provides.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: default-systemd-target-vnc-graphical-provides
 #
 # Test multi-user.target is set as the default systemd target if:
 # - the installation runs in VNC mode

--- a/default-systemd-target-vnc.ks.in
+++ b/default-systemd-target-vnc.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: default-systemd-target-vnc
 #
 # Test multi-user.target should be set by default as the default systemd target
 # for VNC installs. While controlled remotely over VNC the installation itslef runs

--- a/deprecated-rhel9-part1.ks.in
+++ b/deprecated-rhel9-part1.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: deprecated-logging-level
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/deprecated-rhel9-part2.ks.in
+++ b/deprecated-rhel9-part2.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: deprecated-timezone-ntpservers
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/disklabel-default.ks.in
+++ b/disklabel-default.ks.in
@@ -1,4 +1,3 @@
-#test name: disklabel-default
 
 # Use defaults.
 %ksappend repos/default.ks

--- a/disklabel-gpt.ks.in
+++ b/disklabel-gpt.ks.in
@@ -1,4 +1,3 @@
-#test name: disklabel-gpt
 
 # Use defaults.
 %ksappend repos/default.ks

--- a/disklabel-mbr.ks.in
+++ b/disklabel-mbr.ks.in
@@ -1,4 +1,3 @@
-#test name: disklabel-mbr
 
 # Use defaults.
 %ksappend repos/default.ks

--- a/dns.ks.in
+++ b/dns.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: dns
 # Test domain name resolution:
 # - origin of /etc/resolv.conf (rhbz#2018913, rhbz#1989472)
 # - dns resolution in %post scripts (RHEL-26651)

--- a/driverdisk-disk-kargs.ks.in
+++ b/driverdisk-disk-kargs.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: driverdisk-disk
 %ksappend repos/default.ks
 
 %ksappend common/common_no_payload.ks

--- a/driverdisk-disk.ks.in
+++ b/driverdisk-disk.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: driverdisk-disk
 %ksappend repos/default.ks
 
 %ksappend common/common_no_payload.ks

--- a/encrypt-device.ks.in
+++ b/encrypt-device.ks.in
@@ -1,4 +1,3 @@
-#test name: encrypt-device
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/encrypt-swap.ks.in
+++ b/encrypt-swap.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: encrypt-swap
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/escrow-cert.ks.in
+++ b/escrow-cert.ks.in
@@ -1,4 +1,3 @@
-#test name: escrow-cert
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/firewall-disable-with-options.ks.in
+++ b/firewall-disable-with-options.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: firewall-disable-with-options
 #
 # Test that firewall can be properly disabled & all the
 # firewall options are still set correctly on the target system.

--- a/firewall-disable.ks.in
+++ b/firewall-disable.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: firewall-disable
 #
 # Test that firewall can be properly disabled.
 %ksappend repos/default.ks

--- a/firewall-use-system-defaults-ignore-options.ks.in
+++ b/firewall-use-system-defaults-ignore-options.ks.in
@@ -1,6 +1,5 @@
 
 #version=DEVEL
-#test name: firewall-use-system-defaults-ignore-options
 #
 # Test that firewall can be properly configured to use
 # system defaults. This basically means avoiding any

--- a/firewall-use-system-defaults.ks.in
+++ b/firewall-use-system-defaults.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: firewall-use-system-defaults
 #
 # Test that firewall can be properly configured to use
 # system defaults. This basically means avoiding any

--- a/firewall.ks.in
+++ b/firewall.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: firewall
 %ksappend repos/default.ks
 
 %ksappend common/common_no_payload.ks

--- a/geolocation-off-by-default-with-ks.ks.in
+++ b/geolocation-off-by-default-with-ks.ks.in
@@ -1,4 +1,3 @@
-#test name: geolocation-off-by-default-with-ks
 #
 # Check that geolocation is not done during a regular kickstart installation.
 %ksappend repos/default.ks

--- a/groups-and-envs-1.ks.in
+++ b/groups-and-envs-1.ks.in
@@ -1,4 +1,3 @@
-#test name: groups-and-envs-1
 #
 # Check that groups and an environment can both be installed.
 

--- a/groups-and-envs-2.ks.in
+++ b/groups-and-envs-2.ks.in
@@ -1,4 +1,3 @@
-#test name: groups-and-envs-2
 # what we are testing there:
 # - that we can exclude groups which are a part of an environment
 # - that we can exclude groups we have specified in ourselves

--- a/groups-and-envs-3.ks.in
+++ b/groups-and-envs-3.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: groups-and-envs-3
 #
 # Check that default environment is installed correctly.
 

--- a/groups-ignoremissing.ks.in
+++ b/groups-ignoremissing.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: groups-ignoremissing
 #
 # what we are testing there:
 # - that missing groups are ignored if --ignoremissing is used

--- a/harddrive-install-tree-relative.ks.in
+++ b/harddrive-install-tree-relative.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: harddrive-install-tree-relative
 
 # This test is for testing the install from an harddrive ks command
 # with extracted installation tree.

--- a/harddrive-install-tree.ks.in
+++ b/harddrive-install-tree.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: harddrive-install-tree
 
 # This test is for testing the install from an harddrive ks command
 # with extracted installation tree.

--- a/harddrive-iso-single.ks.in
+++ b/harddrive-iso-single.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: harddrive-iso-single
 
 # This test is for testing the install from an harddrive ks command with ISO
 # using single disk (RHEL-35701).

--- a/harddrive-iso.ks.in
+++ b/harddrive-iso.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: harddrive-iso
 
 # This test is for testing the install from an harddrive ks command with ISO.
 #

--- a/hello-world.ks.in
+++ b/hello-world.ks.in
@@ -1,4 +1,3 @@
-#test name: hello-world
 
 %ksappend common/common.ks
 %ksappend repos/default.ks

--- a/hmc.ks.in
+++ b/hmc.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: hmc
 
 # This test is for testing the install method hmc.
 #

--- a/hostname-bootopts.ks.in
+++ b/hostname-bootopts.ks.in
@@ -1,4 +1,3 @@
-#test name: hostname-bootopts
 # rhbz#1441337
 %ksappend repos/default.ks
 

--- a/hostname.ks.in
+++ b/hostname.ks.in
@@ -1,4 +1,3 @@
-#test name: hostname
 %ksappend repos/default.ks
 network --bootproto=dhcp
 # Set hostname for testing

--- a/https-repo.ks.in
+++ b/https-repo.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: https-repo
 #
 # Test that https:// repositories work as expected. Most tests run with http to
 # be able to squid-cache the downloads.

--- a/ibft.ks.in
+++ b/ibft.ks.in
@@ -1,4 +1,3 @@
-#test name: ibft
 
 %ksappend repos/default.ks
 

--- a/ifname-httpks.ks.in
+++ b/ifname-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: ifname
 %ksappend repos/default.ks
 
 network --bootproto=dhcp --device=ifname0 --ipv6=2001:cafe:cafe::2/64

--- a/ignoredisk-1.ks.in
+++ b/ignoredisk-1.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: ignoredisk
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/ignoredisk-2.ks.in
+++ b/ignoredisk-2.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: ignoredisk
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/image-deployment-1.ks.in
+++ b/image-deployment-1.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: image-deployment-1
 
 # Compare files on the installed system with the content
 # of the deployed image and check files that were changed

--- a/image-deployment-2-rhel8.ks.in
+++ b/image-deployment-2-rhel8.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: image-deployment-2-rhel8
 
 # Test that we can disable modules and installation tasks
 # that are not suitable for the image deployment. Use the

--- a/image-deployment-2.ks.in
+++ b/image-deployment-2.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: image-deployment-2
 
 # Test that we can disable modules and installation tasks
 # that are not suitable for the image deployment. Use the

--- a/initial-setup-default.ks.in
+++ b/initial-setup-default.ks.in
@@ -1,4 +1,3 @@
-#test name: initial-setup-default
 #
 # Check that Initial Setup is configured correctly if the firstboot command
 # is not present in the installation kickstart.

--- a/initial-setup-disable.ks.in
+++ b/initial-setup-disable.ks.in
@@ -1,4 +1,3 @@
-#test name: initial-setup-disable
 #
 # Check that Initial Setup is correctly disabled if specified in kickstart.
 %ksappend repos/default.ks

--- a/initial-setup-enable.ks.in
+++ b/initial-setup-enable.ks.in
@@ -1,4 +1,3 @@
-#test name: initial-setup-enable
 #
 # Check that Initial Setup is correctly enabled if specified in kickstart.
 %ksappend repos/default.ks

--- a/initial-setup-gui.ks.in
+++ b/initial-setup-gui.ks.in
@@ -1,4 +1,3 @@
-#test name: initial-setup-gui
 #
 # Check that the initial-setup-gui package is correctly installed
 # when specified in the %packages section.

--- a/initial-setup-reconfig.ks.in
+++ b/initial-setup-reconfig.ks.in
@@ -1,4 +1,3 @@
-#test name: initial-setup-reconfig
 #
 # Check that Initial Setup is correctly configured in reconfig mode if specified in kickstart.
 %ksappend repos/default.ks

--- a/iscsi-bind.ks.in
+++ b/iscsi-bind.ks.in
@@ -1,4 +1,3 @@
-#test name: iscsi-bind
 
 %ksappend repos/default.ks
 

--- a/iscsi.ks.in
+++ b/iscsi.ks.in
@@ -1,4 +1,3 @@
-#test name: iscsi-root
 
 %ksappend repos/default.ks
 

--- a/keyboard-bootopt-only.ks.in
+++ b/keyboard-bootopt-only.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: keyboard-bootopt-only
 # Test setting keyboard from boot options (no kickstart command)
 %ksappend repos/default.ks
 network --bootproto=dhcp

--- a/keyboard-convert-vc.ks.in
+++ b/keyboard-convert-vc.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: keyboard-convert-vc
 # Test that conversion from --vckeymap option to x layouts is performed correctly
 %ksappend repos/default.ks
 network --bootproto=dhcp

--- a/keyboard-convert-x-override-bootopt.ks.in
+++ b/keyboard-convert-x-override-bootopt.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: keyboard-convert-x-override-bootopt
 # Test conversion from x layouts to vc keymap and overriding of boot option by
 # kickstart command
 %ksappend repos/default.ks

--- a/keyboard-generic-argument.ks.in
+++ b/keyboard-generic-argument.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: keyboard-generic-argument
 # Test handling of keyboard command generid argument (conversion to vc keymap
 # and x layouts)
 %ksappend repos/default.ks

--- a/keyboard.ks.in
+++ b/keyboard.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: keyboard
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/ks-include.ks.in
+++ b/ks-include.ks.in
@@ -1,4 +1,3 @@
-#test name: ks-include
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/lang.ks.in
+++ b/lang.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: lang
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/liveimg.ks.in
+++ b/liveimg.ks.in
@@ -1,4 +1,3 @@
-#test name: liveimg
 liveimg --url=@KSTEST_LIVEIMG_URL@ --checksum=@KSTEST_LIVEIMG_CHECKSUM@
 
 network --bootproto=dhcp

--- a/lvm-1.ks.in
+++ b/lvm-1.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: lvm-1
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/lvm-2.ks.in
+++ b/lvm-2.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: lvm-2
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/lvm-cache-1.ks.in
+++ b/lvm-cache-1.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: lvm-cache-1
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/lvm-cache-2.ks.in
+++ b/lvm-cache-2.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: lvm-cache-2
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/lvm-luks-1.ks.in
+++ b/lvm-luks-1.ks.in
@@ -1,4 +1,3 @@
-#test name: lvm-luks-1
 
 %ksappend repos/default.ks
 network --bootproto=dhcp

--- a/lvm-luks-2.ks.in
+++ b/lvm-luks-2.ks.in
@@ -1,4 +1,3 @@
-#test name: lvm-luks-2
 
 %ksappend repos/default.ks
 network --bootproto=dhcp

--- a/lvm-luks-3.ks.in
+++ b/lvm-luks-3.ks.in
@@ -1,4 +1,3 @@
-#test name: lvm-luks-3
 
 %ksappend repos/default.ks
 network --bootproto=dhcp

--- a/lvm-luks-4.ks.in
+++ b/lvm-luks-4.ks.in
@@ -1,4 +1,3 @@
-#test name: lvm-luks-4
 
 %ksappend repos/default.ks
 network --bootproto=dhcp

--- a/lvm-raid-1.ks.in
+++ b/lvm-raid-1.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: lvm-raid-1
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/lvm-thinp-1.ks.in
+++ b/lvm-thinp-1.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: lvm-thinp-1
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/lvm-thinp-2.ks.in
+++ b/lvm-thinp-2.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: lvm-thinp-2
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/module-1.ks.in
+++ b/module-1.ks.in
@@ -1,4 +1,3 @@
-#test name: module-1
 #
 # generic module install test:
 # - enable one module

--- a/module-2.ks.in
+++ b/module-2.ks.in
@@ -1,4 +1,3 @@
-#test name: module-2
 #
 # generic module install test:
 # - enable one module with a stream

--- a/module-3.ks.in
+++ b/module-3.ks.in
@@ -1,4 +1,3 @@
-#test name: module-3
 #
 # Specify one module in packages section twice with same stream
 # but different profiles. Check both profiles are installed.

--- a/module-4.ks.in
+++ b/module-4.ks.in
@@ -1,4 +1,3 @@
-#test name: module-4
 #
 # test enabling many different modules at once
 

--- a/module-enable-one-module-multiple-streams.ks.in
+++ b/module-enable-one-module-multiple-streams.ks.in
@@ -1,4 +1,3 @@
-#test name: module-install
 #
 # try enabling one module multiple times
 # - with diferent stream specififcations

--- a/module-enable-one-stream-install-different-stream.ks.in
+++ b/module-enable-one-stream-install-different-stream.ks.in
@@ -1,4 +1,3 @@
-#test name: module-enable-one-stream-install-different-stream
 #
 # - enable one module with a stream
 # - install the same module with a different stream

--- a/module-ignoremissing.ks.in
+++ b/module-ignoremissing.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: module-ignoremissing
 #
 # what we are testing there:
 # - that missing modules are ignored if --ignoremissing is used

--- a/module-install-no-stream-no-profile.ks.in
+++ b/module-install-no-stream-no-profile.ks.in
@@ -1,4 +1,3 @@
-#test name: module-enable-many
 #
 # test installing many modules without stream & profile specififcation
 # NOTE: this is not really testable on Rawhide right now as there are

--- a/module-install-one-module-multiple-streams-and-profiles.ks.in
+++ b/module-install-one-module-multiple-streams-and-profiles.ks.in
@@ -1,4 +1,3 @@
-#test name: module-install
 #
 # specify one module in packages section twice with different streams & profiles
 #

--- a/module-install-one-module-multiple-streams.ks.in
+++ b/module-install-one-module-multiple-streams.ks.in
@@ -1,4 +1,3 @@
-#test name: module-install
 #
 # specify one module in packages section twice with different streams
 #

--- a/mountpoint-assignment-1.ks.in
+++ b/mountpoint-assignment-1.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: mountpoint-assignment-1
 
 %ksappend repos/default.ks
 network --bootproto=dhcp

--- a/mountpoint-assignment-2.ks.in
+++ b/mountpoint-assignment-2.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: mountpoint-assignment-2
 
 %ksappend repos/default.ks
 network --bootproto=dhcp

--- a/network-addr-gen-mode-dhcpall.ks.in
+++ b/network-addr-gen-mode-dhcpall.ks.in
@@ -1,4 +1,3 @@
-#test name: network-addr-gen-mode-dhcpall
 # Test ipv6.addr-gen-mode default (rhbz#1873021) for ip=dhcp (or missing ip=) boot option
 %ksappend repos/default.ks
 

--- a/network-addr-gen-mode.ks.in
+++ b/network-addr-gen-mode.ks.in
@@ -1,4 +1,3 @@
-#test name: network-addr-gen-mode
 # Test ipv6.addr-gen-mode default (rhbz#1873021) for
 # - device configured by ip=<IFACE>:dhcp boot option
 # - device unconfigured

--- a/network-autoconnections-dhcpall-httpks.ks.in
+++ b/network-autoconnections-dhcpall-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: network-autoconnection-dhcpall-httpks
 # Test assumptions about connections and config files created in initramfs (by NM)
 # Also test consolidating of the connections by anaconda.
 # Variant for ip=dhcp option (which is currently equivalent to no boot options)

--- a/network-autoconnections-httpks.ks.in
+++ b/network-autoconnections-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: network-autoconnection-httpks
 # Test assumptions about connections and config files created in initramfs (by NM)
 # Also test consolidating of the connections by anaconda.
 # Variant for ip=dhcp option (which is currently equivalent to no boot options)

--- a/network-bootopts-bond-bootif.ks.in
+++ b/network-bootopts-bond-bootif.ks.in
@@ -1,4 +1,3 @@
-#test name: network-bootopts-bond-bootif
 # Test bond configured via boot options with BOOTIF present.
 # The slave ifaces configuration files are correct slave files.
 # rhbz#2175664, RHEL-4766

--- a/network-bootopts-bond-dhcp-httpks.ks.in
+++ b/network-bootopts-bond-dhcp-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: network-bootopts-bond-dhcp-httpks
 # Test bond configured via boot options
 
 %ksappend repos/default.ks

--- a/network-bootopts-bond-ks-override.ks.in
+++ b/network-bootopts-bond-ks-override.ks.in
@@ -1,4 +1,3 @@
-#test name: network-bootopts-bond-ks-override
 # Test bond configured via boot options in a way that it does not have wired
 # setting (by leaving out ip=bond0:dhcp option) and is attempted to be
 # reconfigured via kickstart network command which would trigger #1963834.

--- a/network-bootopts-bootif-httpks.ks.in
+++ b/network-bootopts-bootif-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: network-bootopts-bootif-httpks
 # Test that only device specified by BOOTIF is activated in initramfs
 
 %ksappend repos/default.ks

--- a/network-bootopts-bridge-dhcp-httpks.ks.in
+++ b/network-bootopts-bridge-dhcp-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: network-bootopts-bond-dhcp-httpks
 # Test bridge configured via boot options
 
 %ksappend repos/default.ks

--- a/network-bootopts-noautodefault.ks.in
+++ b/network-bootopts-noautodefault.ks.in
@@ -1,4 +1,3 @@
-#test name: network-bootopts-noautodefault
 #Test option to disable default autoconnections
 
 # Use defaults, but no network that could activate the other device

--- a/network-bootopts-static-legacy-httpks.ks.in
+++ b/network-bootopts-static-legacy-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: network-static-to-dhcp-pre
 # Testing legacy boot options (rhel6). Works on RHEL 7, doesn't work on Fedora 26
 %ksappend repos/default.ks
 

--- a/network-bootopts-static-mac.ks.in
+++ b/network-bootopts-static-mac.ks.in
@@ -1,4 +1,3 @@
-#test name: network-bootopts-static-mac
 # Static configuration of single interface via boot options using MAC address
 # https://bugzilla.redhat.com/show_bug.cgi?id=1915493#c43
 %ksappend repos/default.ks

--- a/network-bootopts-static-unspec-bootif.ks.in
+++ b/network-bootopts-static-unspec-bootif.ks.in
@@ -1,4 +1,3 @@
-#test name: network-bootopts-static-unspec-bootif
 # Multiple interfaces, no interface specified in ip= static configuration, BOOTIF is used to choose the device
 # See rhbz#1910438, rhbz#1915493
 %ksappend repos/default.ks

--- a/network-bootopts-static-unspec-single.ks.in
+++ b/network-bootopts-static-unspec-single.ks.in
@@ -1,4 +1,3 @@
-#test name: network-bootopts-static-unspec-single
 # No interface specified in ip= static configuration and there is only single device available
 # (eg others can have no carrier but in this test there is just a single interface).
 # See rhbz#1915493

--- a/network-bootopts-static.ks.in
+++ b/network-bootopts-static.ks.in
@@ -1,4 +1,3 @@
-#test name: network-bootopts-static
 # Static configuration of single interface via boot options
 %ksappend repos/default.ks
 

--- a/network-bootopts-team-dhcp-httpks.ks.in
+++ b/network-bootopts-team-dhcp-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: network-bootopts-team-dhcp-httpks
 # Test team configured via boot options
 
 %ksappend repos/default.ks

--- a/network-bootopts-vlan-static-httpks.ks.in
+++ b/network-bootopts-vlan-static-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: network-bootopts-vlan-static-httpks
 # Test team configured via boot options
 
 %ksappend repos/default.ks

--- a/network-device-bootif-httpks.ks.in
+++ b/network-device-bootif-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: network-device-bootif
 %ksappend repos/default.ks
 
 network --device=bootif --bootproto=dhcp --ipv6=2001:cafe:cafe::1/64

--- a/network-device-default-httpks.ks.in
+++ b/network-device-default-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: network-device-default
 %ksappend repos/default.ks
 
 network --bootproto=dhcp --ipv6=2001:cafe:cafe::1/64

--- a/network-device-default-ksdevice-httpks.ks.in
+++ b/network-device-default-ksdevice-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: network-device-default-ksdevice
 #NOTE: as this test is a "-httpks" the kickstart should be really applied
 #      in initrafs (config files created by parse-kickstart). The code actually
 #      ignores the command without --device specified (and no ksdevice set),

--- a/network-device-default-ksdevice-pre.ks.in
+++ b/network-device-default-ksdevice-pre.ks.in
@@ -1,4 +1,3 @@
-#test name: network-device-default-ksdevice-pre
 #NOTE: as this test is a "-httpks" the kickstart should be really applied
 #      in initrafs (config files created by parse-kickstart). The code actually
 #      ignores the command without --device specified (and no ksdevice set),

--- a/network-device-default-pre-hostname.ks.in
+++ b/network-device-default-pre-hostname.ks.in
@@ -1,4 +1,3 @@
-#test name: network-device-default-pre-hostname
 # rhbz#1272274
 %ksappend repos/default.ks
 

--- a/network-device-default.ks.in
+++ b/network-device-default.ks.in
@@ -1,4 +1,3 @@
-#test name: network-device-default
 %ksappend repos/default.ks
 
 network --bootproto=dhcp --ipv6=2001:cafe:cafe::1/64

--- a/network-device-mac-httpks.ks.in
+++ b/network-device-mac-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: network-device-mac
 %ksappend repos/default.ks
 
 network --bootproto=dhcp --device=52:54:00:12:34:57

--- a/network-device-mac-pre.ks.in
+++ b/network-device-mac-pre.ks.in
@@ -1,4 +1,3 @@
-#test name: network-device-mac-pre
 %ksappend repos/default.ks
 
 %include /tmp/ksinclude

--- a/network-device-mac.ks.in
+++ b/network-device-mac.ks.in
@@ -1,4 +1,3 @@
-#test name: network-device-mac
 %ksappend repos/default.ks
 
 network --bootproto=dhcp --device=52:54:00:12:34:56 --ipv6=2001:cafe:cafe::1/64

--- a/network-dns-search.ks.in
+++ b/network-dns-search.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: network-dns-search
 # Test domain name search properties set from kickstart
 
 # Use defaults.

--- a/network-missing-ifcfg-httpks.ks.in
+++ b/network-missing-ifcfg-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: network-missing-ifcfg
 #creating missing config files (devices not activated in initramfs and not configured in kickstart)
 %ksappend repos/default.ks
 

--- a/network-noipv4-httpks.ks.in
+++ b/network-noipv4-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: network-noipv4-httpks
 %ksappend repos/default.ks
 
 network --device=@KSTEST_NETDEV2@ --noipv4 --no-activate --onboot=yes

--- a/network-noipv4-pre.ks.in
+++ b/network-noipv4-pre.ks.in
@@ -1,4 +1,3 @@
-#test name: network-noipv4-pre
 %ksappend repos/default.ks
 
 %include /tmp/ksinclude

--- a/network-options-pre.ks.in
+++ b/network-options-pre.ks.in
@@ -1,4 +1,3 @@
-#test name: onboot-options-pre
 # Test network command options defined in %pre section
 # --nodefroute
 # --mtu

--- a/network-prefixdevname.ks.in
+++ b/network-prefixdevname.ks.in
@@ -1,4 +1,3 @@
-#test name: network-prefixdevname
 # Tests the prefixdevname feature (rhbz#2267227)
 %ksappend repos/default.ks
 

--- a/network-static-2-httpks.ks.in
+++ b/network-static-2-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: network-static-2
 #various combinations of activation in initramfs and stage 2
 %ksappend repos/default.ks
 # activated in initramfs with dhcp, reactivated in stage 2

--- a/network-static-2-pre.ks.in
+++ b/network-static-2-pre.ks.in
@@ -1,4 +1,3 @@
-#test name: network-static-2-pre
 #various combinations of activation in initramfs and stage 2
 %ksappend repos/default.ks
 

--- a/network-static-httpks.ks.in
+++ b/network-static-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: network-static
 %ksappend repos/default.ks
 network --device=@KSTEST_NETDEV2@ --bootproto static --ip @KSTEST_STATIC_IP@ --netmask @KSTEST_STATIC_NETMASK@ --gateway @KSTEST_STATIC_GATEWAY@ --onboot=no
 

--- a/network-static-to-dhcp-pre-single.ks.in
+++ b/network-static-to-dhcp-pre-single.ks.in
@@ -1,4 +1,3 @@
-#test name: network-static-to-dhcp-pre-single
 # rhbz#1432886
 %ksappend repos/default.ks
 %include /tmp/ksinclude

--- a/network-static-to-dhcp-pre.ks.in
+++ b/network-static-to-dhcp-pre.ks.in
@@ -1,4 +1,3 @@
-#test name: network-static-to-dhcp-pre
 # rhbz#1433891
 # rhbz#1432886
 %ksappend repos/default.ks

--- a/network-static.ks.in
+++ b/network-static.ks.in
@@ -1,4 +1,3 @@
-#test name: network-static
 %ksappend repos/default.ks
 network --device=@KSTEST_NETDEV2@ --bootproto static --ip @KSTEST_STATIC_IP@ --netmask @KSTEST_STATIC_NETMASK@ --gateway @KSTEST_STATIC_GATEWAY@ --onboot=no
 

--- a/nfs.ks.in
+++ b/nfs.ks.in
@@ -1,4 +1,3 @@
-#test name: nfs
 nfs --server=@KSTEST_NFS_SERVER@ --dir=@KSTEST_NFS_PATH@
 network --bootproto=dhcp
 

--- a/nosave-1.ks.in
+++ b/nosave-1.ks.in
@@ -1,4 +1,3 @@
-#test name: nosave-1
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/nosave-2.ks.in
+++ b/nosave-2.ks.in
@@ -1,4 +1,3 @@
-#test name: nosave-2
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/nosave-3.ks.in
+++ b/nosave-3.ks.in
@@ -1,4 +1,3 @@
-#test name: nosave-3
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/ntp-nontp-without-chrony-gui.ks.in
+++ b/ntp-nontp-without-chrony-gui.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: ntp-nontp-without-chrony-gui
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/ntp-nontp-without-chrony.ks.in
+++ b/ntp-nontp-without-chrony.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: ntp-nontp-without-chrony
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/ntp-pools.ks.in
+++ b/ntp-pools.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: ntp-pools
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/ntp-with-nontp-gui.ks.in
+++ b/ntp-with-nontp-gui.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: ntp-with-nontp-gui
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/ntp-with-nontp.ks.in
+++ b/ntp-with-nontp.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: ntp-with-nontp
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/ntp-without-chrony-gui.ks.in
+++ b/ntp-without-chrony-gui.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: ntp-without-chrony-gui
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/ntp-without-chrony.ks.in
+++ b/ntp-without-chrony.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: ntp-without-chrony
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/onboot-activate-httpks.ks.in
+++ b/onboot-activate-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: onboot-activate-httpks
 %ksappend repos/default.ks
 network --device=@KSTEST_NETDEV2@ --bootproto=dhcp --no-activate --onboot=yes
 network --device=@KSTEST_NETDEV1@ --bootproto=dhcp --onboot=no

--- a/onboot-activate.ks.in
+++ b/onboot-activate.ks.in
@@ -1,4 +1,3 @@
-#test name: onboot-activate
 %ksappend repos/default.ks
 network --device=@KSTEST_NETDEV2@ --bootproto=dhcp --no-activate --onboot=yes
 network --device=@KSTEST_NETDEV1@ --bootproto=dhcp --onboot=no

--- a/onboot-bootopts-pre.ks.in
+++ b/onboot-bootopts-pre.ks.in
@@ -1,4 +1,3 @@
-#test name: onboot-bootopts-pre
 %ksappend repos/default.ks
 
 %include /tmp/ksinclude

--- a/packages-and-groups-1.ks.in
+++ b/packages-and-groups-1.ks.in
@@ -1,4 +1,3 @@
-#test name: packages-and-groups-1
 #
 # Check package exclusion works correctly.
 

--- a/packages-and-groups-ignoremissing.ks.in
+++ b/packages-and-groups-ignoremissing.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: packages-and-groups-ignoremissing
 #
 # what we are testing there:
 # - that multiple missing packages & groups (at the same time) are ignored

--- a/packages-default.ks.in
+++ b/packages-default.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: packages-default
 #
 # Check the %packages --default flag works.
 

--- a/packages-excludedocs.ks.in
+++ b/packages-excludedocs.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: packages-excludedocs
 #
 # Check that the %packages section --excludedocs options
 # correctly excludes all docs.

--- a/packages-ignorebroken.ks.in
+++ b/packages-ignorebroken.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: packages-ignorebroken
 #
 # what we are testing there:
 # - that packages with dependency solving problems are ignored if --ignorebroken is used

--- a/packages-ignoremissing.ks.in
+++ b/packages-ignoremissing.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: packages-ignoremissing
 #
 # what we are testing there:
 # - that missing packages are ignored if --ignoremissing is used

--- a/packages-instlangs-1.ks.in
+++ b/packages-instlangs-1.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: packages-instlangs-1
 #
 # Check that only english locales are installed for
 # %packages --instlangs=en_US.

--- a/packages-instlangs-2.ks.in
+++ b/packages-instlangs-2.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: packages-instlangs-2
 #
 # Check that no locales get installed for
 # %packages --instlangs=.

--- a/packages-instlangs-3.ks.in
+++ b/packages-instlangs-3.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: packages-instlangs-3
 #
 # Check --instlangs with multiple languages, using the lang command
 # and glibc langpack installation.

--- a/packages-multilib.ks.in
+++ b/packages-multilib.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: packages-multilib
 #
 # Run a multilib installation.
 

--- a/packages-weakdeps.ks.in
+++ b/packages-weakdeps.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: packages-weakdeps
 #
 # Check the --excludeWeakdeps flag works correctly.
 # Using this flag should effectively turn off weak

--- a/part-luks-1.ks.in
+++ b/part-luks-1.ks.in
@@ -1,4 +1,3 @@
-#test name: part-luks-1
 
 %ksappend repos/default.ks
 network --bootproto=dhcp

--- a/part-luks-2.ks.in
+++ b/part-luks-2.ks.in
@@ -1,4 +1,3 @@
-#test name: part-luks-2
 
 %ksappend repos/default.ks
 network --bootproto=dhcp

--- a/part-luks-3.ks.in
+++ b/part-luks-3.ks.in
@@ -1,4 +1,3 @@
-#test name: part-luks-3
 
 %ksappend repos/default.ks
 network --bootproto=dhcp

--- a/part-luks-4.ks.in
+++ b/part-luks-4.ks.in
@@ -1,4 +1,3 @@
-#test name: part-luks-4
 
 %ksappend repos/default.ks
 network --bootproto=dhcp

--- a/pre-install.ks.in
+++ b/pre-install.ks.in
@@ -1,4 +1,3 @@
-#test name: pre-install
 %ksappend repos/default.ks
 
 

--- a/preexisting-btrfs.ks.in
+++ b/preexisting-btrfs.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: preexisting-btrfs
 
 # Use defaults.
 %ksappend repos/default.ks

--- a/proxy-auth.ks.in
+++ b/proxy-auth.ks.in
@@ -1,4 +1,3 @@
-#test name: proxy-auth
 url --url=@KSTEST_URL@ --proxy=http://anaconda:qweqwe@PROXY-ADDON
 repo --name=addon --baseurl=HTTP-ADDON-REPO --proxy=http://anaconda:qweqwe@PROXY-ADDON --install
 network --bootproto=dhcp

--- a/proxy-cmdline.ks.in
+++ b/proxy-cmdline.ks.in
@@ -1,4 +1,3 @@
-#test name: proxy-cmdline
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/proxy-kickstart.ks.in
+++ b/proxy-kickstart.ks.in
@@ -1,4 +1,3 @@
-#test name: proxy-kickstart
 url --url=@KSTEST_URL@ --proxy=PROXY-ADDON
 repo --name=addon --baseurl=HTTP-ADDON-REPO --proxy=PROXY-ADDON --install
 

--- a/raid-1-reqpart.ks.in
+++ b/raid-1-reqpart.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: raid-1-reqpart
 #
 # This is raid-1 test using reqpart command which is broken for raid: RHBZ 2277150
 

--- a/raid-1.ks.in
+++ b/raid-1.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: raid-1
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/raid-ddf.ks.in
+++ b/raid-ddf.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: raid-ddf
 # This test covers https://bugzilla.redhat.com/show_bug.cgi?id=2063791
 
 %ksappend repos/default.ks

--- a/raid-luks-1.ks.in
+++ b/raid-luks-1.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: raid-luks-1
 
 %ksappend repos/default.ks
 network --bootproto=dhcp

--- a/raid-luks-2.ks.in
+++ b/raid-luks-2.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: raid-luks-2
 
 %ksappend repos/default.ks
 network --bootproto=dhcp

--- a/raid-luks-3.ks.in
+++ b/raid-luks-3.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: raid-luks-3
 
 %ksappend repos/default.ks
 network --bootproto=dhcp

--- a/raid-luks-4.ks.in
+++ b/raid-luks-4.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: raid-luks-4
 
 %ksappend repos/default.ks
 network --bootproto=dhcp

--- a/reboot-initial-setup-gui.ks.in
+++ b/reboot-initial-setup-gui.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: reboot-initial-setup-gui
 
 # Make sure that there is nothing else to configure.
 %ksappend users/user.ks

--- a/reboot-initial-setup-tui.ks.in
+++ b/reboot-initial-setup-tui.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: reboot-initial-setup-tui
 
 # Make sure that there is nothing else to configure.
 %ksappend users/user.ks

--- a/reboot-uefi.ks.in
+++ b/reboot-uefi.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: reboot-uefi
 
 # Use defaults.
 %ksappend repos/default.ks

--- a/reboot.ks.in
+++ b/reboot.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: reboot
 
 # Use defaults.
 %ksappend repos/default.ks

--- a/repo-addrepo-hd-iso.ks.in
+++ b/repo-addrepo-hd-iso.ks.in
@@ -1,4 +1,3 @@
-#test name: repo-addrepo-hd-iso
 
 ## Test the inst.addrepo boot option with an ISO on a hard drive.
 # The test is based on the harddrive-iso test.

--- a/repo-addrepo-hd-tree.ks.in
+++ b/repo-addrepo-hd-tree.ks.in
@@ -1,4 +1,3 @@
-#test name: repo-addrepo-hd-tree
 
 ## Test the inst.addrepo boot option with a installation tree on a hard drive.
 # The test is based on the harddrive-install-tree test.

--- a/repo-addrepo.ks.in
+++ b/repo-addrepo.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: repo-addrepo
 
 # This test will check the installation with addrepo kernel parameter functionality.
 # The inst.addrepo boot option will add additional software repository,

--- a/repo-baseurl.ks.in
+++ b/repo-baseurl.ks.in
@@ -1,4 +1,3 @@
-#test name: repo-baseurl
 
 ## Simple test for repo --baseurl.
 

--- a/repo-enable.ks.in
+++ b/repo-enable.ks.in
@@ -1,4 +1,3 @@
-#test name: repo-enable
 
 ## Test for enabling repositories using repo --name.
 

--- a/repo-exclude.ks.in
+++ b/repo-exclude.ks.in
@@ -1,4 +1,3 @@
-#test name: repo-exclude
 
 ## Test for repo --cost and --excludepkgs.
 

--- a/repo-include.ks.in
+++ b/repo-include.ks.in
@@ -1,4 +1,3 @@
-#test name: repo-include
 
 ## Test for repo --cost and --includepkgs.
 

--- a/repo-install.ks.in
+++ b/repo-install.ks.in
@@ -1,4 +1,3 @@
-#test name: repo-install
 
 ## Test for repo --install.
 

--- a/repo-metalink.ks.in
+++ b/repo-metalink.ks.in
@@ -1,4 +1,3 @@
-#test name: repo-metalink
 
 ## Simple test for repo --metalink.
 

--- a/repo-mirrorlist.ks.in
+++ b/repo-mirrorlist.ks.in
@@ -1,4 +1,3 @@
-#test name: repo-mirrorlist
 
 ## Simple test for repo --mirrorlist.
 

--- a/reqpart.ks.in
+++ b/reqpart.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: reqpart
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/rootpw-allow-ssh.ks.in
+++ b/rootpw-allow-ssh.ks.in
@@ -1,4 +1,3 @@
-#test name: rootpw-allow-ssh
 #
 # Test that root ssh login with password is working.
 

--- a/rootpw-basic.ks.in
+++ b/rootpw-basic.ks.in
@@ -1,4 +1,3 @@
-#test name: rootpw-basic
 %ksappend repos/default.ks
 
 

--- a/rootpw-crypted.ks.in
+++ b/rootpw-crypted.ks.in
@@ -1,4 +1,3 @@
-#test name: rootpw-crypted
 %ksappend repos/default.ks
 
 

--- a/rootpw-lock-no-password.ks.in
+++ b/rootpw-lock-no-password.ks.in
@@ -1,4 +1,3 @@
-#test name: rootpw-lock-no-password
 #
 # Test that root account locking works correctly and
 # that if no password is set in kickstart no password is

--- a/rootpw-lock.ks.in
+++ b/rootpw-lock.ks.in
@@ -1,4 +1,3 @@
-#test name: rootpw-lock
 #
 # Test that root account locking works correctly and
 # that there is a (locked) password present.

--- a/rpm-ostree-container-bootc.ks.in
+++ b/rpm-ostree-container-bootc.ks.in
@@ -1,4 +1,3 @@
-#test name: rpm-ostree-container-bootc
 # https://github.com/rhinstaller/anaconda/pull/5399
 #
 # Test that ostree container installation works.

--- a/rpm-ostree-container-leavebootorder.ks.in
+++ b/rpm-ostree-container-leavebootorder.ks.in
@@ -1,4 +1,3 @@
-#test name: rpm-ostree-container-bootorder
 # https://github.com/rhinstaller/anaconda/pull/5399
 #
 # Test that ostree container installation works with leavebootorder.

--- a/rpm-ostree-container-luks.ks.in
+++ b/rpm-ostree-container-luks.ks.in
@@ -1,4 +1,3 @@
-#test name: rpm-ostree-container-luks
 # for bootc/bootupd, remote and stateroot ostreecontainer options
 # depends on the referenced ostree container being bootable
 

--- a/rpm-ostree-container-silverblue.ks.in
+++ b/rpm-ostree-container-silverblue.ks.in
@@ -1,4 +1,3 @@
-#test name: rpm-ostree-container-silverblue
 # https://github.com/rhinstaller/anaconda/pull/4617
 
 # Test that ostreecontainer ks command works on Silverblue.

--- a/rpm-ostree-container-uefi.ks.in
+++ b/rpm-ostree-container-uefi.ks.in
@@ -1,4 +1,3 @@
-#test name: rpm-ostree-container-bootc
 # https://github.com/rhinstaller/anaconda/pull/5399
 #
 # Test the UEFI entry is created correctly and the system is bootable.

--- a/rpm-ostree.ks.in
+++ b/rpm-ostree.ks.in
@@ -1,4 +1,3 @@
-#test name: rpm-ostree
 
 # Use the default settings.
 %ksappend common/common_no_payload.ks

--- a/script-pre.ks.in
+++ b/script-pre.ks.in
@@ -1,4 +1,3 @@
-#test name: pre_install_interpreter_test
 
 %ksappend repos/default.ks
 

--- a/selinux-contexts.ks.in
+++ b/selinux-contexts.ks.in
@@ -1,4 +1,3 @@
-#test name: selinux-contexts
 
 %ksappend repos/default.ks
 %ksappend common/common_no_payload.ks

--- a/selinux-disabled.ks.in
+++ b/selinux-disabled.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: selinux-disabled
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/selinux-enforcing.ks.in
+++ b/selinux-enforcing.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: selinux-enforcing
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/selinux-permissive.ks.in
+++ b/selinux-permissive.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: selinux-permissive
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/services.ks.in
+++ b/services.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: services
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/snapshot-post.ks.in
+++ b/snapshot-post.ks.in
@@ -1,4 +1,3 @@
-#test name: snapshot-post
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/snapshot-pre.ks.in
+++ b/snapshot-pre.ks.in
@@ -1,4 +1,3 @@
-#test name: snapshot-pre
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/stage2-from-ks.ks.in
+++ b/stage2-from-ks.ks.in
@@ -1,4 +1,3 @@
-#test name: stage2-from-ks
 #
 # Test configuration of stage2 location via kickstart url command
 # and activation of network in initramfs from kickstart configuration.

--- a/storage-multipath-autopart.ks.in
+++ b/storage-multipath-autopart.ks.in
@@ -1,4 +1,3 @@
-#test name: storage-multipath-autopart
 
 %ksappend repos/default.ks
 %ksappend common/common_no_payload.ks

--- a/team-httpks.ks.in
+++ b/team-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: team
 %ksappend repos/default.ks
 
 network --device team0 --bootproto dhcp --teamslaves="@KSTEST_NETDEV2@'{\"prio\": -10, \"sticky\": true}',@KSTEST_NETDEV3@'{\"prio\": 100}'" --teamconfig="{\"runner\": {\"name\": \"activebackup\"}}" --activate --onboot=no

--- a/team-pre.ks.in
+++ b/team-pre.ks.in
@@ -1,4 +1,3 @@
-#test name: team-pre
 #NOTE: this test is a variant of team test, it is sharing its .sh file (setup of NICs and network boot configuration) so beware of changing it independently of team test
 %ksappend repos/default.ks
 

--- a/team.ks.in
+++ b/team.ks.in
@@ -1,4 +1,3 @@
-#test name: team
 %ksappend repos/default.ks
 
 network --device team0 --bootproto dhcp --teamslaves="@KSTEST_NETDEV2@'{\"prio\": -10, \"sticky\": true}',@KSTEST_NETDEV3@'{\"prio\": 100}'" --teamconfig="{\"runner\": {\"name\": \"activebackup\"}}" --activate --onboot=no

--- a/timezone-noncommon.ks.in
+++ b/timezone-noncommon.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: timezone-noncommon
 # Test that timezones that are in pytz.all_timezones but not in
 # pytz.common_timezones can be used in kickstart
 # (jira#RHEL-13150, jira#RHEL-13151, rhbz#1452873)

--- a/timezoneLOCAL.ks.in
+++ b/timezoneLOCAL.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: timezoneLOCAL
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/timezoneUTC.ks.in
+++ b/timezoneUTC.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: timezoneUTC
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/tmpfs-fixed_size.ks.in
+++ b/tmpfs-fixed_size.ks.in
@@ -1,4 +1,3 @@
-#test name: tmpfs-fixed_size
 %ksappend repos/default.ks
 network --bootproto=dhcp
 

--- a/ui_cmdline.ks.in
+++ b/ui_cmdline.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: ui_cmdline
 
 # Use defaults.
 %ksappend repos/default.ks

--- a/ui_graphical_interactive.ks.in
+++ b/ui_graphical_interactive.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: ui_graphical_interactive
 
 # Use defaults.
 %ksappend repos/default.ks

--- a/ui_graphical_noninteractive.ks.in
+++ b/ui_graphical_noninteractive.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: ui_graphical_noninteractive
 
 # Use defaults.
 %ksappend repos/default.ks

--- a/ui_rdp.ks.in
+++ b/ui_rdp.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: ui_rdp
 
 # Use defaults.
 %ksappend repos/default.ks

--- a/ui_text_interactive.ks.in
+++ b/ui_text_interactive.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: ui_text_interactive
 
 # Use defaults.
 %ksappend repos/default.ks

--- a/ui_text_noninteractive.ks.in
+++ b/ui_text_noninteractive.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: ui_text_noninteractive
 
 # Use defaults.
 %ksappend repos/default.ks

--- a/ui_vnc.ks.in
+++ b/ui_vnc.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: ui_vnc
 
 # Use defaults.
 %ksappend repos/default.ks

--- a/unified-cdrom.ks.in
+++ b/unified-cdrom.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: unified
 
 # This test is for testing the install from an unified repository.
 #

--- a/unified-cmdline.ks.in
+++ b/unified-cmdline.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: unified
 
 # This test is for testing the install from an unified repository.
 #

--- a/unified-harddrive.ks.in
+++ b/unified-harddrive.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: unified-nfs
 
 # This test is for testing the install from an unified repository.
 #

--- a/unified-nfs.ks.in
+++ b/unified-nfs.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: unified-nfs
 
 # This test is for testing the install from an unified repository.
 #

--- a/unified.ks.in
+++ b/unified.ks.in
@@ -1,5 +1,4 @@
 #version=DEVEL
-#test name: unified
 
 # This test is for testing the install from an unified repository.
 #

--- a/url-baseurl.ks.in
+++ b/url-baseurl.ks.in
@@ -1,4 +1,3 @@
-#test name: url-baseurl
 
 ## Simple test for url --url.
 

--- a/url-metalink.ks.in
+++ b/url-metalink.ks.in
@@ -1,4 +1,3 @@
-#test name: url-metalink
 
 ## Simple test for url --metalink.
 

--- a/url-mirrorlist.ks.in
+++ b/url-mirrorlist.ks.in
@@ -1,4 +1,3 @@
-#test name: url-mirrorlist
 
 ## Simple test for url --mirrorlist.
 

--- a/user-locked-root-locked-admin.ks.in
+++ b/user-locked-root-locked-admin.ks.in
@@ -1,4 +1,3 @@
-#test name: user-locked-root-locked-admin
 #
 # Check that we can install a system with locked root account
 # and the only user admin account being locked as well.

--- a/user-multiple-wheel-no-root.ks.in
+++ b/user-multiple-wheel-no-root.ks.in
@@ -1,4 +1,3 @@
-#test name: user-multiple-wheel-no-root
 #
 # Check that we can install a system without specifying the root account
 # (this should lock the root account) but with a user that is an admin.

--- a/user-multiple.ks.in
+++ b/user-multiple.ks.in
@@ -1,4 +1,3 @@
-#test name: user-multiple
 #
 # Test that we can correctly create multiple users via kickstart.
 # This also includes checking that we ignore any errors in the

--- a/user-no-wheel-no-root.ks.in
+++ b/user-no-wheel-no-root.ks.in
@@ -1,4 +1,3 @@
-#test name: user-no-wheel-no-root
 #
 # Test that we can install if no root is specified and no users
 # with admin priviledges are specified.

--- a/user-single.ks.in
+++ b/user-single.ks.in
@@ -1,4 +1,3 @@
-#test name: user-single
 %ksappend repos/default.ks
 
 

--- a/user-wheel-no-root.ks.in
+++ b/user-wheel-no-root.ks.in
@@ -1,4 +1,3 @@
-#test name: user-wheel-no-root
 #
 # Check that we can install a system without specifying the root account
 # (this should lock the root account) but with a user that is an admin.

--- a/vlan-httpks.ks.in
+++ b/vlan-httpks.ks.in
@@ -1,4 +1,3 @@
-#test name: vlan-httpks
 %ksappend repos/default.ks
 
 # Parent configured and activated in initramfs

--- a/vlan-pre.ks.in
+++ b/vlan-pre.ks.in
@@ -1,4 +1,3 @@
-#test name: vlan-pre
 # variant with commands run in %pre section
 %ksappend repos/default.ks
 


### PR DESCRIPTION
I am not aware of any purpose of this comment and it is difficult to keep in sync with the real test name. If at all it should be generated at some point.

For example in https://github.com/rhinstaller/kickstart-tests/pull/1324 I suggested renaming of the test in the review, but the `#test name` was not updated during update of the PR. Instead requiring additional update I decided to handle it in an additional PR or to get rid of the comments completely.