### PR TITLE
Another Glib error from Wayland native on Live

### DIFF
--- a/scripts/launcher/lib/log_monitor/log_handler.py
+++ b/scripts/launcher/lib/log_monitor/log_handler.py
@@ -39,6 +39,7 @@ class VirtualLogRequestHandler(LogRequestHandler):
         # Ignore known Gdk errors in RDP
         # TODO: Remove when https://issues.redhat.com/browse/RHEL-40884 is fixed
         "Gdk-#033[1;35mCRITICAL#033",
+        "Gtk-#033[1;35mCRITICAL#033",
 
         # Ignore a call trace during debugging.
         # Ignoring permanently for gh768.


### PR DESCRIPTION
Introduced by changes in:
https://github.com/rhinstaller/anaconda/pull/6018

Ignores this message:
```
10:26:59,558 DEBUG anaconda:anaconda: misc: GLib: #012(anaconda:2630): Gtk-#033[1;35mCRITICAL#033[0m **: #033[34m10:26:59.551#033[0m: gtk_widget_set_child_visible: assertion '!_gtk_widget_is_toplevel (widget)' failed
```