### PR TITLE
runner: add python3-rpm to kstest-runner container image (gh1342)

### DIFF
--- a/containers/runner/Dockerfile
+++ b/containers/runner/Dockerfile
@@ -18,6 +18,7 @@ RUN dnf -y update && \
     createrepo_c \
     python3-pip \
     python3-rpmfluff \
+    python3-rpm \
     squid \
     make \
     openssh-clients && \


### PR DESCRIPTION
Follow up of moving base for Fedora 39 to Fedora 41 commit accfd3b1e1425f226ab847fe94f4ab331fbad026

Fix for https://github.com/rhinstaller/kickstart-tests/issues/1342