### PR TITLE
Update network static tests for NM change (gh1349)

### DIFF
--- a/network-bootopts-static-mac.ks.in
+++ b/network-bootopts-static-mac.ks.in
@@ -41,19 +41,9 @@ else
 fi
 
 check_device_config_value @KSTEST_NETDEV1@ IPADDR __NONE ipv4 method auto
-
-@KSINCLUDE@ scripts-lib.sh
-platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
-if [ "${platform}" == "rhel10" ] || [ "${platform}" == "rhel9" ]; then
-    check_device_config_value @KSTEST_NETDEV2@ IPADDR @KSTEST_STATIC_IP@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@
-    check_device_config_value @KSTEST_NETDEV2@ PREFIX @KSTEST_STATIC_PREFIX@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@
-    check_device_config_value @KSTEST_NETDEV2@ GATEWAY @KSTEST_STATIC_GATEWAY@ ipv4 gateway @KSTEST_STATIC_GATEWAY@
-else
-    check_device_config_value @KSTEST_NETDEV2@ IPADDR @KSTEST_STATIC_IP@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@,@KSTEST_STATIC_GATEWAY@
-    check_device_config_value @KSTEST_NETDEV2@ PREFIX @KSTEST_STATIC_PREFIX@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@,@KSTEST_STATIC_GATEWAY@
-    check_device_config_value @KSTEST_NETDEV2@ GATEWAY @KSTEST_STATIC_GATEWAY@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@,@KSTEST_STATIC_GATEWAY@
-fi
-
+check_device_config_value @KSTEST_NETDEV2@ IPADDR @KSTEST_STATIC_IP@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@
+check_device_config_value @KSTEST_NETDEV2@ PREFIX @KSTEST_STATIC_PREFIX@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@
+check_device_config_value @KSTEST_NETDEV2@ GATEWAY @KSTEST_STATIC_GATEWAY@ ipv4 gateway @KSTEST_STATIC_GATEWAY@
 check_device_config_value @KSTEST_NETDEV2@ DNS1 @KSTEST_STATIC_DNS1@ ipv4 dns "@KSTEST_STATIC_DNS1@;"
 check_device_ipv4_address @KSTEST_NETDEV2@ @KSTEST_STATIC_IP@
 

--- a/network-bootopts-static-unspec-bootif.ks.in
+++ b/network-bootopts-static-unspec-bootif.ks.in
@@ -42,19 +42,9 @@ fi
 
 
 check_device_config_value @KSTEST_NETDEV1@ IPADDR __NONE ipv4 method auto
-
-@KSINCLUDE@ scripts-lib.sh
-platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
-if [ "${platform}" == "rhel10" ] || [ "${platform}" == "rhel9" ]; then
-    check_device_config_value @KSTEST_NETDEV2@ IPADDR @KSTEST_STATIC_IP@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@
-    check_device_config_value @KSTEST_NETDEV2@ PREFIX @KSTEST_STATIC_PREFIX@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@
-    check_device_config_value @KSTEST_NETDEV2@ GATEWAY @KSTEST_STATIC_GATEWAY@ ipv4 gateway @KSTEST_STATIC_GATEWAY@
-else
-    check_device_config_value @KSTEST_NETDEV2@ IPADDR @KSTEST_STATIC_IP@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@,@KSTEST_STATIC_GATEWAY@
-    check_device_config_value @KSTEST_NETDEV2@ PREFIX @KSTEST_STATIC_PREFIX@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@,@KSTEST_STATIC_GATEWAY@
-    check_device_config_value @KSTEST_NETDEV2@ GATEWAY @KSTEST_STATIC_GATEWAY@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@,@KSTEST_STATIC_GATEWAY@
-fi
-
+check_device_config_value @KSTEST_NETDEV2@ IPADDR @KSTEST_STATIC_IP@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@
+check_device_config_value @KSTEST_NETDEV2@ PREFIX @KSTEST_STATIC_PREFIX@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@
+check_device_config_value @KSTEST_NETDEV2@ GATEWAY @KSTEST_STATIC_GATEWAY@ ipv4 gateway @KSTEST_STATIC_GATEWAY@
 check_device_config_value @KSTEST_NETDEV2@ DNS1 @KSTEST_STATIC_DNS1@ ipv4 dns "@KSTEST_STATIC_DNS1@;"
 check_device_ipv4_address @KSTEST_NETDEV2@ @KSTEST_STATIC_IP@
 

--- a/network-bootopts-static-unspec-single.ks.in
+++ b/network-bootopts-static-unspec-single.ks.in
@@ -31,18 +31,9 @@ check_gui_configurations @KSTEST_NETDEV1@
 
 check_device_connected @KSTEST_NETDEV1@ yes
 
-@KSINCLUDE@ scripts-lib.sh
-platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
-if [ "${platform}" == "rhel10" ] || [ "${platform}" == "rhel9" ]; then
-    check_device_config_value @KSTEST_NETDEV1@ IPADDR @KSTEST_STATIC_IP@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@
-    check_device_config_value @KSTEST_NETDEV1@ PREFIX @KSTEST_STATIC_PREFIX@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@
-    check_device_config_value @KSTEST_NETDEV1@ GATEWAY @KSTEST_STATIC_GATEWAY@ ipv4 gateway @KSTEST_STATIC_GATEWAY@
-else
-    check_device_config_value @KSTEST_NETDEV1@ IPADDR @KSTEST_STATIC_IP@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@,@KSTEST_STATIC_GATEWAY@
-    check_device_config_value @KSTEST_NETDEV1@ PREFIX @KSTEST_STATIC_PREFIX@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@,@KSTEST_STATIC_GATEWAY@
-    check_device_config_value @KSTEST_NETDEV1@ GATEWAY @KSTEST_STATIC_GATEWAY@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@,@KSTEST_STATIC_GATEWAY@
-fi
-
+check_device_config_value @KSTEST_NETDEV1@ IPADDR @KSTEST_STATIC_IP@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@
+check_device_config_value @KSTEST_NETDEV1@ PREFIX @KSTEST_STATIC_PREFIX@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@
+check_device_config_value @KSTEST_NETDEV1@ GATEWAY @KSTEST_STATIC_GATEWAY@ ipv4 gateway @KSTEST_STATIC_GATEWAY@
 check_device_config_value @KSTEST_NETDEV1@ DNS1 @KSTEST_STATIC_DNS1@ ipv4 dns "@KSTEST_STATIC_DNS1@;"
 check_device_ipv4_address @KSTEST_NETDEV1@ @KSTEST_STATIC_IP@
 

--- a/network-bootopts-static.ks.in
+++ b/network-bootopts-static.ks.in
@@ -29,18 +29,9 @@ check_gui_configurations @KSTEST_NETDEV1@
 
 check_device_connected @KSTEST_NETDEV1@ yes
 
-@KSINCLUDE@ scripts-lib.sh
-platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
-if [ "${platform}" == "rhel10" ] || [ "${platform}" == "rhel9" ]; then
-    check_device_config_value @KSTEST_NETDEV1@ IPADDR @KSTEST_STATIC_IP@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@
-    check_device_config_value @KSTEST_NETDEV1@ PREFIX @KSTEST_STATIC_PREFIX@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@
-    check_device_config_value @KSTEST_NETDEV1@ GATEWAY @KSTEST_STATIC_GATEWAY@ ipv4 gateway @KSTEST_STATIC_GATEWAY@
-else
-    check_device_config_value @KSTEST_NETDEV1@ IPADDR @KSTEST_STATIC_IP@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@,@KSTEST_STATIC_GATEWAY@
-    check_device_config_value @KSTEST_NETDEV1@ PREFIX @KSTEST_STATIC_PREFIX@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@,@KSTEST_STATIC_GATEWAY@
-    check_device_config_value @KSTEST_NETDEV1@ GATEWAY @KSTEST_STATIC_GATEWAY@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@,@KSTEST_STATIC_GATEWAY@
-fi
-
+check_device_config_value @KSTEST_NETDEV1@ IPADDR @KSTEST_STATIC_IP@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@
+check_device_config_value @KSTEST_NETDEV1@ PREFIX @KSTEST_STATIC_PREFIX@ ipv4 address1 @KSTEST_STATIC_IP@/@KSTEST_STATIC_PREFIX@
+check_device_config_value @KSTEST_NETDEV1@ GATEWAY @KSTEST_STATIC_GATEWAY@ ipv4 gateway @KSTEST_STATIC_GATEWAY@
 check_device_config_value @KSTEST_NETDEV1@ DNS1 @KSTEST_STATIC_DNS1@ ipv4 dns "@KSTEST_STATIC_DNS1@;"
 check_device_ipv4_address @KSTEST_NETDEV1@ @KSTEST_STATIC_IP@
 

--- a/network-static-httpks.ks.in
+++ b/network-static-httpks.ks.in
@@ -27,15 +27,8 @@ check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@
 
 @KSINCLUDE@ post-lib-network.sh
 
-@KSINCLUDE@ scripts-lib.sh
-platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
-if [ "${platform}" == "rhel10" ] || [ "${platform}" == "rhel9" ]; then
-    check_device_config_value @KSTEST_NETDEV2@ IPADDR @KSTEST_STATIC_IP@ ipv4 address1 @KSTEST_STATIC_IP@/24
-    check_device_config_value @KSTEST_NETDEV2@ GATEWAY @KSTEST_STATIC_GATEWAY@ ipv4 gateway @KSTEST_STATIC_GATEWAY@
-else
-    check_device_config_value @KSTEST_NETDEV2@ IPADDR @KSTEST_STATIC_IP@ ipv4 address1 @KSTEST_STATIC_IP@/24,@KSTEST_STATIC_GATEWAY@
-fi
-
+check_device_config_value @KSTEST_NETDEV2@ IPADDR @KSTEST_STATIC_IP@ ipv4 address1 @KSTEST_STATIC_IP@/24
+check_device_config_value @KSTEST_NETDEV2@ GATEWAY @KSTEST_STATIC_GATEWAY@ ipv4 gateway @KSTEST_STATIC_GATEWAY@
 check_device_config_value @KSTEST_NETDEV2@ ONBOOT no connection autoconnect false
 check_device_connected @KSTEST_NETDEV1@ yes
 check_device_connected @KSTEST_NETDEV2@ yes

--- a/network-static.ks.in
+++ b/network-static.ks.in
@@ -27,15 +27,8 @@ check_gui_configurations @KSTEST_NETDEV1@ @KSTEST_NETDEV2@
 
 @KSINCLUDE@ post-lib-network.sh
 
-@KSINCLUDE@ scripts-lib.sh
-platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
-if [ "${platform}" == "rhel10" ] || [ "${platform}" == "rhel9" ]; then
-    check_device_config_value @KSTEST_NETDEV2@ IPADDR @KSTEST_STATIC_IP@ ipv4 address1 @KSTEST_STATIC_IP@/24
-    check_device_config_value @KSTEST_NETDEV2@ GATEWAY @KSTEST_STATIC_GATEWAY@ ipv4 gateway @KSTEST_STATIC_GATEWAY@
-else
-    check_device_config_value @KSTEST_NETDEV2@ IPADDR @KSTEST_STATIC_IP@ ipv4 address1 @KSTEST_STATIC_IP@/24,@KSTEST_STATIC_GATEWAY@
-fi
-
+check_device_config_value @KSTEST_NETDEV2@ IPADDR @KSTEST_STATIC_IP@ ipv4 address1 @KSTEST_STATIC_IP@/24
+check_device_config_value @KSTEST_NETDEV2@ GATEWAY @KSTEST_STATIC_GATEWAY@ ipv4 gateway @KSTEST_STATIC_GATEWAY@
 check_device_config_value @KSTEST_NETDEV2@ ONBOOT no connection autoconnect false
 check_device_connected @KSTEST_NETDEV1@ yes
 check_device_connected @KSTEST_NETDEV2@ yes


### PR DESCRIPTION
NM now dumps ipv4 address setting value into two separate 'address1' and 'gateway' keys by default.
https://github.com/NetworkManager/NetworkManager/commit/38dca2f044a5cf0f68752d3d73ceb5407f948238

Fixes: https://github.com/rhinstaller/kickstart-tests/issues/1349