### PR TITLE
Add check to dns resolution to container test

### DIFF
--- a/rpm-ostree-container-bootc.ks.in
+++ b/rpm-ostree-container-bootc.ks.in
@@ -20,6 +20,15 @@ reboot
 
 %post
 
+curl fedoraproject.org
+if [[ $? != 0 ]]; then
+    echo '*** curl fedoraproject.org failed' >> /root/RESULT
+fi
+
+%end
+
+%post
+
 # Checks after boot
 cat >> /var/lib/extensions/kickstart-tests/usr/libexec/kickstart-test.sh << 'EOF'
 


### PR DESCRIPTION
This is just a draft PR to check the current status.
The real check would go to a separate test.
Related: https://github.com/rhinstaller/kickstart-tests/issues/1352