### PR TITLE
Revert "Disable tmpfs-fixed-size on rhel-10 for gh1336"

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -69,7 +69,6 @@ rhel10_skip_array=(
   gh1110      # storage-multipath-autopart failing
   gh1207      # packages-multilib failing
   gh1213      # harddrive-iso-single failing
-  gh1336      # tmpfs-fixed-size failing due to RHEL-66617
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/tmpfs-fixed_size.sh
+++ b/tmpfs-fixed_size.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage gh1336"
+TESTTYPE="storage"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
This reverts commit fd2982f4cc9f4211b7afaf70326299b74da98019.

The RHEL-66617 has been fixed