### PR TITLE
edns: test passing of global dns configuration to installed system

### DIFF
--- a/dns-global-bootopts.ks.in
+++ b/dns-global-bootopts.ks.in
@@ -1,0 +1,40 @@
+# The goal is to test options and configuration passing to installed system
+# not the functionality of the name resolution.
+
+# Use defaults, but no network
+%ksappend common/common.ks
+%ksappend repos/default.ks
+%ksappend l10n/default.ks
+%ksappend users/default.ks
+%ksappend storage/default.ks
+%ksappend payload/default_packages.ks
+
+%post
+
+# Check the arguments are passed to the installed system
+grep "^GRUB_CMDLINE_LINUX=" /etc/default/grub | grep "rd.net.dns=10.0.2.3"
+if [[ $? -ne 0 ]]; then
+    echo '*** Failed check: rd.net.dns option is passed to installed system' >> /root/RESULT
+fi
+grep "^GRUB_CMDLINE_LINUX=" /etc/default/grub | grep "rd.net.dns-resolve-mode=exclusive"
+if [[ $? -ne 0 ]]; then
+    echo '*** Failed check: rd.net.dns-resolve-mode option is passed to installed system' >> /root/RESULT
+fi
+
+grep "^GRUB_CMDLINE_LINUX=" /etc/default/grub | grep "rd.net.dns-backend=dnsconfd"
+if [[ $? -ne 0 ]]; then
+    echo '*** Failed check: rd.net.dns-backend option is passed to installed system' >> /root/RESULT
+fi
+
+# Check the NM runtime global config file is passed to the installed system
+if [[ ! -e /etc/NetworkManager/conf.d/16-global-dns.conf ]]; then
+    echo '*** Failed check: NetworkManger global dns configuration file 16-global-dns.conf is passed to installed system' >> /root/RESULT
+fi
+if [[ ! -e /etc/NetworkManager/conf.d/16-dns-backend.conf ]]; then
+    echo '*** Failed check: NetworkManger global dns configuration file 16-dns-backend.conf is passed to installed system' >> /root/RESULT
+fi
+
+
+%ksappend validation/success_if_result_empty.ks
+
+%end

--- a/dns-global-bootopts.ks.in
+++ b/dns-global-bootopts.ks.in
@@ -34,6 +34,11 @@ if [[ ! -e /etc/NetworkManager/conf.d/16-dns-backend.conf ]]; then
     echo '*** Failed check: NetworkManger global dns configuration file 16-dns-backend.conf is passed to installed system' >> /root/RESULT
 fi
 
+# Check that dnsconfd service is enabled on installed system
+systemctl is-enabled dnsconfd
+if [[ $? -ne 0 ]]; then
+    echo '*** Failed check: dnsconfd service is enabled on installed system' >> /root/RESULT
+fi
 
 %ksappend validation/success_if_result_empty.ks
 

--- a/dns-global-bootopts.sh
+++ b/dns-global-bootopts.sh
@@ -25,5 +25,5 @@ TESTTYPE=${TESTTYPE:-"network dns"}
 
 kernel_args() {
     # ip=dhcp does not work
-    echo ${DEFAULT_BOOTOPTS} rd.net.dns=10.0.2.3 rd.net.dns-backend=dnsconfd rd.net.dns-resolve-mode=exclusive ip=10.0.2.200::10.0.2.2:255.255.255.0::${KSTEST_NETDEV1}:none
+    echo ${DEFAULT_BOOTOPTS} rd.net.dns=10.0.2.3 rd.net.dns-backend=dnsconfd rd.net.dns-resolve-mode=exclusive ip=10.0.2.200::10.0.2.2:255.255.255.0:::none
 }

--- a/dns-global-bootopts.sh
+++ b/dns-global-bootopts.sh
@@ -1,0 +1,29 @@
+#
+# Copyright (C) 2025  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
+
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
+TESTTYPE=${TESTTYPE:-"network dns"}
+
+. ${KSTESTDIR}/functions.sh
+
+kernel_args() {
+    # ip=dhcp does not work
+    echo ${DEFAULT_BOOTOPTS} rd.net.dns=10.0.2.3 rd.net.dns-backend=dnsconfd rd.net.dns-resolve-mode=exclusive ip=10.0.2.200::10.0.2.2:255.255.255.0::${KSTEST_NETDEV1}:none
+}

--- a/dns-global-bootopts.sh
+++ b/dns-global-bootopts.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"network dns"}
+TESTTYPE=${TESTTYPE:-"network dns gh1380"}
 
 . ${KSTESTDIR}/functions.sh
 

--- a/dns-global-bootopts.sh
+++ b/dns-global-bootopts.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"network dns gh1380 gh1379"}
+TESTTYPE=${TESTTYPE:-"network dns gh1380 gh1379 gh1378"}
 
 . ${KSTESTDIR}/functions.sh
 

--- a/dns-global-bootopts.sh
+++ b/dns-global-bootopts.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"network dns gh1380"}
+TESTTYPE=${TESTTYPE:-"network dns gh1380 gh1379"}
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Related: INSTALLER-4097

The purpose of this (kind of reference) test is to check that it is setting up the options and configuration for installed system in expected way. Not the functionality of the resolution itself.