### PR TITLE
Use full systemd in daily iso build container

### DIFF
--- a/.github/workflows/daily-boot-iso-rawhide.yml
+++ b/.github/workflows/daily-boot-iso-rawhide.yml
@@ -49,6 +49,8 @@ jobs:
           sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v /tmp/lorax-images:/images:z ${{ env.LORAX_BUILD_CONTAINER }} <<EOF
           set -eux
           echo "::group::Install lorax"
+          # Replace standalone systemd package with systemd as these are conflicting
+          dnf swap -y systemd-standalone-sysusers systemd
           dnf install -y lorax
           echo "::endgroup::"
 


### PR DESCRIPTION
The systemd-standalone-sysusers package, which is pre-installed in the rawhide container conflicts with systemd. Since lorax requires systemd as a dependency, this conflict prevents lorax installation.

See also https://github.com/rhinstaller/anaconda/pull/6147