### PR TITLE
Move away from ubuntu runner 22.04

### DIFF
--- a/.github/workflows/static-code-tests.yml
+++ b/.github/workflows/static-code-tests.yml
@@ -2,7 +2,7 @@ name: static-code-tests
 on: [pull_request]
 jobs:
   static-code-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions: {}
     container:
       image: quay.io/rhinstaller/kstest-runner


### PR DESCRIPTION
Newest host is 24.04 but let's use latest as it is used everywhere else here.