### PR TITLE
Fix link to devel-tools

### DIFF
--- a/fragments/platform/fedora_rawhide/payload/unified_packages.ks
+++ b/fragments/platform/fedora_rawhide/payload/unified_packages.ks
@@ -1,5 +1,5 @@
 # Fedora Rawhide unified ISO created by create_dvd script [1] should contain test-rpm rpm
-# [1]: https://github.com/rhinstaller/devel-tools/tree/main/create_unified_iso
+# [1]: https://github.com/rhinstaller/devel-tools/tree/main/modify_install_iso
 
 %packages
 test-rpm

--- a/unified-cdrom.ks.in
+++ b/unified-cdrom.ks.in
@@ -4,7 +4,7 @@
 #
 # You have to have unified ISO as a source mounted on the HTTP server.
 # To create unified ISO for Fedora you can use this tool:
-# https://github.com/rhinstaller/devel-tools/tree/main/create_unified_iso
+# https://github.com/rhinstaller/devel-tools/tree/main/modify_install_iso
 #
 
 #

--- a/unified-cmdline.ks.in
+++ b/unified-cmdline.ks.in
@@ -4,7 +4,7 @@
 #
 # You have to have unified ISO as a source mounted on the HTTP server.
 # To create unified ISO for Fedora you can use this tool:
-# https://github.com/rhinstaller/devel-tools/tree/main/create_unified_iso
+# https://github.com/rhinstaller/devel-tools/tree/main/modify_install_iso
 #
 
 %ksappend common/common_no_payload.ks

--- a/unified-harddrive.ks.in
+++ b/unified-harddrive.ks.in
@@ -4,7 +4,7 @@
 #
 # You have to have unified ISO as a source mounted on the NFS server.
 # To create unified ISO for Fedora you can use this tool:
-# https://github.com/rhinstaller/devel-tools/tree/main/create_unified_iso
+# https://github.com/rhinstaller/devel-tools/tree/main/modify_install_iso
 #
 
 %ksappend common/common_no_payload.ks

--- a/unified-nfs.ks.in
+++ b/unified-nfs.ks.in
@@ -4,7 +4,7 @@
 #
 # You have to have unified ISO as a source mounted on the NFS server.
 # To create unified ISO for Fedora you can use this tool:
-# https://github.com/rhinstaller/devel-tools/tree/main/create_unified_iso
+# https://github.com/rhinstaller/devel-tools/tree/main/modify_install_iso
 #
 # This test has to have access to the NFS server. However NFS won't mount
 # if the VM is behind a NAT (NFS problem). So this test won't work on our setup

--- a/unified.ks.in
+++ b/unified.ks.in
@@ -4,7 +4,7 @@
 #
 # You have to have unified ISO as a source mounted on the HTTP server.
 # To create unified ISO for Fedora you can use this tool:
-# https://github.com/rhinstaller/devel-tools/tree/main/create_unified_iso
+# https://github.com/rhinstaller/devel-tools/tree/main/modify_install_iso
 #
 
 %ksappend common/common_no_payload.ks


### PR DESCRIPTION
The create_unified_iso script was renamed to modify_install_iso but links here stayed the old way.