### PR TITLE
Add second test for LVM on RAID

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -57,6 +57,7 @@ rhel9_skip_array=(
   gh641       # packages-multilib failing on systemd conflict
   gh774       # autopart-luks-1 failing
   gh804       # tests requiring dvd iso failing
+  rhel75659   # pykickstart removes md_ prefix from new MD devices
 )
 
 rhel10_skip_array=(
@@ -70,6 +71,7 @@ rhel10_skip_array=(
   gh1110      # storage-multipath-autopart failing
   gh1207      # packages-multilib failing
   gh1213      # harddrive-iso-single failing
+  rhel80086   # pykickstart removes md_ prefix from new MD devices
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/lvm-raid-1.sh
+++ b/lvm-raid-1.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="lvm storage gh1414"
+TESTTYPE="lvm storage gh1414 rhel75659 rhel80086"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/lvm-raid-2.ks.in
+++ b/lvm-raid-2.ks.in
@@ -1,6 +1,7 @@
-# Basic test for LVM on top of MD array. In the volgroup command the
-# array is referred by the PV format "mount point" (pv.01), referring
-# to the array by its name is tested in lvm-raid-2 test case.
+# Tests usage of newly created MD array name in the volgroup command and
+# handling of MD RAID names with md_ prefix by kickstart. See lvm-raid-1
+# test case for alternative way to refer to the array in the volgroup
+# command.
 
 #version=DEVEL
 %ksappend repos/default.ks
@@ -14,9 +15,8 @@ reqpart
 part /boot --fstype=ext4 --size=500
 part raid.01 --size=7500 --ondisk=vda
 part raid.02 --size=7500 --ondisk=vdb
-part raid.03 --size=7500 --ondisk=vdc
-raid pv.01 --level=RAID5 --device=md_test raid.01 raid.02 raid.03
-volgroup fedora pv.01
+raid pv.01 --level=RAID1 --device=md_test raid.01 raid.02
+volgroup fedora md_test
 logvol swap --name=swap --vgname=fedora --size=500 --fstype=swap
 logvol / --name=root --vgname=fedora --grow --size=4000 --fstype=ext4
 
@@ -82,11 +82,6 @@ fi
 swap_lv_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/swap)
 if [ $swap_lv_size != "500.00" ]; then
     echo "*** swap lv has incorrect size" >> /root/RESULT
-fi
-
-# verify that /dev/md/md_test exists (array was created with the correct name)
-if [ ! -e /dev/md/md_test ]; then
-    echo "** MD array has incorrect name" >> /root/RESULT
 fi
 
 if [ ! -e /root/RESULT ]; then

--- a/lvm-raid-2.sh
+++ b/lvm-raid-2.sh
@@ -1,0 +1,37 @@
+#
+# Copyright (C) 2015-2025  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s):
+#   Vratislav Podzimek <vpodzime@redhat.com>
+#   Vojtech Trefny <vtrefny@redhat.com>
+
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
+TESTTYPE="lvm storage gh1414"
+
+. ${KSTESTDIR}/functions.sh
+
+prepare_disks() {
+    tmpdir=$1
+
+    # make sure the first disk have some extra space for /boot
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-a.img 9G
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-b.img 8G
+
+    echo ${tmpdir}/disk-a.img
+    echo ${tmpdir}/disk-b.img
+}

--- a/lvm-raid-2.sh
+++ b/lvm-raid-2.sh
@@ -21,7 +21,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="lvm storage gh1414"
+TESTTYPE="lvm storage gh1414 rhel75659 rhel80086"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
This and the change to the first test case make sure the MD array can be referred by both its name and the "mount point" when used under a VG and also make sure the preferred name is not changed by or pykickstart.

This needs new version of both pykickstart and anaconda. See https://github.com/rhinstaller/anaconda/pull/6185 and https://github.com/pykickstart/pykickstart/pull/534