### PR TITLE
Add network from kickstart version of e2e edns test

### DIFF
--- a/dns-global-exclusive-tls-ksnet.ks.in
+++ b/dns-global-exclusive-tls-ksnet.ks.in
@@ -3,10 +3,15 @@
 # Partial tests of reqiured features are in 'certificate' and 'dns-global-bootopts'
 # tests.
 
-# Use defaults.
+# Use defaults, but no network
+%ksappend common/common.ks
 %ksappend repos/default.ks
-%ksappend common/common_no_payload.ks
+%ksappend l10n/default.ks
+%ksappend users/default.ks
+%ksappend storage/default.ks
 %ksappend payload/default_packages.ks
+
+network --bootproto static --ip @KSTEST_STATIC_IP@ --netmask @KSTEST_STATIC_NETMASK@ --gateway @KSTEST_STATIC_GATEWAY@
 
 %certificate --filename tls-ca-bundle.pem --dir /etc/pki/dns/extracted/pem
 %ksappend data/edns-idmops.psi.redhat.com.crt

--- a/dns-global-exclusive-tls-ksnet.ks.in
+++ b/dns-global-exclusive-tls-ksnet.ks.in
@@ -1,0 +1,100 @@
+# Test the e2e functionality of global exclusive encrypted DNS functionality
+# This variant provides everything except global dns configuration via kickstart.
+# Partial tests of reqiured features are in 'certificate' and 'dns-global-bootopts'
+# tests.
+
+# Use defaults.
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
+%ksappend payload/default_packages.ks
+
+%certificate --filename tls-ca-bundle.pem --dir /etc/pki/dns/extracted/pem
+%ksappend data/edns-idmops.psi.redhat.com.crt
+%end
+
+# Reboot the installed system.
+reboot
+
+# Validate on the first boot.
+%ksappend validation/success_on_first_boot.ks
+
+
+%pre
+
+# Check the presence in installer environment in %pre
+if [ ! -f /etc/pki/dns/extracted/pem/tls-ca-bundle.pem ]; then
+    echo "*** Failed check: tls-ca-bundle.pem found in /etc/pki/dns/extracted/pem in installer environment in %pre" >> /root/RESULT
+fi
+
+HOSTNAME=fedoraproject.org
+nslookup ${HOSTNAME}
+if [[ $? -ne 0 ]]; then
+    echo "*** Failed check: name resolution on ${HOSTNAME}in %pre" >> /root/RESULT
+fi
+
+%end
+
+%post --nochroot
+
+@KSINCLUDE@ post-nochroot-lib-network.sh
+# First copy result from %pre stage to chroot
+copy_pre_stage_result
+
+# Check the presence in installer environment during %post
+if [ ! -f /etc/pki/dns/extracted/pem/tls-ca-bundle.pem ]; then
+    echo "*** Failed check: tls-ca-bundle.pem found in /etc/pki/dns/extracted/pem in installer environment %post --nochroot" >> /mnt/sysroot/root/RESULT
+fi
+
+HOSTNAME=fedoraproject.org
+nslookup ${HOSTNAME}
+if [[ $? -ne 0 ]]; then
+    echo "*** Failed check: name resolution on ${HOSTNAME} in %post --nochroot" >> /mnt/sysroot/root/RESULT
+fi
+
+%end
+
+%post
+
+# Check the presence on installed system
+if [ ! -f /etc/pki/dns/extracted/pem/tls-ca-bundle.pem ]; then
+    echo "*** Failed check: tls-ca-bundle.pem found in /etc/pki/dns/extracted/pem on installed system" >> /root/RESULT
+fi
+
+HOSTNAME=fedoraproject.org
+getent hosts ${HOSTNAME}
+if [[ $? -ne 0 ]]; then
+    echo "*** Failed check: name resolution on ${HOSTNAME} in %post script" >> /root/RESULT
+fi
+
+%ksappend validation/success_if_result_empty.ks
+
+%end
+
+# Set up the actual test.
+%post
+
+# Write the code to run after reboot.
+cat > /usr/libexec/kickstart-test.sh << 'EOF'
+
+HOSTNAME=fedoraproject.org
+succeeded="no"
+i=0
+# The anaconda service running this test is not waiting for network-online
+# targe so let's give it some time here.
+while [ $i -le 15 ] && [ ${succeeded} != "yes" ];
+do
+    getent hosts ${HOSTNAME} &> /dev/null
+    if [[ $? -eq 0 ]]; then
+        succeeded=yes
+    fi
+    sleep 1
+    (( i++ ))
+done
+
+if [ ${succeeded} != "yes" ]; then
+    echo "*** Failed check: name resolution on ${HOSTNAME}"
+fi
+
+EOF
+
+%end

--- a/dns-global-exclusive-tls-ksnet.sh
+++ b/dns-global-exclusive-tls-ksnet.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"network dns"}
+TESTTYPE=${TESTTYPE:-"network dns gh1380"}
 
 . ${KSTESTDIR}/functions.sh
 

--- a/dns-global-exclusive-tls-ksnet.sh
+++ b/dns-global-exclusive-tls-ksnet.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"network dns gh1380 gh1379"}
+TESTTYPE=${TESTTYPE:-"network dns gh1380 gh1379 gh1378"}
 
 . ${KSTESTDIR}/functions.sh
 

--- a/dns-global-exclusive-tls-ksnet.sh
+++ b/dns-global-exclusive-tls-ksnet.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"network dns gh1380"}
+TESTTYPE=${TESTTYPE:-"network dns gh1380 gh1379"}
 
 . ${KSTESTDIR}/functions.sh
 

--- a/dns-global-exclusive-tls-ksnet.sh
+++ b/dns-global-exclusive-tls-ksnet.sh
@@ -27,6 +27,15 @@ kernel_args() {
     echo ${DEFAULT_BOOTOPTS} rd.net.dns=dns+tls://10.0.196.143#edns-idmops.psi.redhat.com rd.net.dns-resolve-mode=exclusive rd.net.dns-backend=dnsconfd
 }
 
+prepare() {
+    local ks=$1
+
+    # This is a private slirp network, so we can pick any config we like
+    sed -i -e 's#@KSTEST_STATIC_IP@#10.0.2.200#g' -e 's#@KSTEST_STATIC_NETMASK@#255.255.255.0#g' -e 's#@KSTEST_STATIC_GATEWAY@#10.0.2.2#g' ${ks}
+
+    echo ${ks}
+}
+
 additional_runner_args() {
     # Wait for reboot and shutdown of the VM,
     # but exit after the specified timeout.

--- a/dns-global-exclusive-tls-ksnet.sh
+++ b/dns-global-exclusive-tls-ksnet.sh
@@ -1,0 +1,44 @@
+#
+# Copyright (C) 2025  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
+
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
+TESTTYPE=${TESTTYPE:-"network dns"}
+
+. ${KSTESTDIR}/functions.sh
+
+kernel_args() {
+    echo ${DEFAULT_BOOTOPTS} rd.net.dns=dns+tls://10.0.196.143#edns-idmops.psi.redhat.com rd.net.dns-resolve-mode=exclusive rd.net.dns-backend=dnsconfd
+}
+
+additional_runner_args() {
+    # Wait for reboot and shutdown of the VM,
+    # but exit after the specified timeout.
+    echo "--wait $(get_timeout)"
+}
+
+# Installer image is defined in kickstart via url command
+stage2_from_ks() {
+    echo "true"
+}
+
+# The test needs more RAM because installer image is downloaded from network
+get_required_ram() {
+    echo "2750"
+}


### PR DESCRIPTION
In this test only global dns is set via boot options. Everything else comes from kickstart, including default dhcp network.

Related: INSTALLER-4096