### PR TITLE
Update VM RAM for stage2-from-ks (gh1389)

### DIFF
--- a/dns-global-exclusive-tls-initramfs.sh
+++ b/dns-global-exclusive-tls-initramfs.sh
@@ -41,5 +41,5 @@ stage2_from_ks() {
 
 # The test needs more RAM because installer image is downloaded from network
 get_required_ram() {
-    echo "2750"
+    echo "2900"
 }

--- a/dns-global-exclusive-tls-ksnet.sh
+++ b/dns-global-exclusive-tls-ksnet.sh
@@ -49,5 +49,5 @@ stage2_from_ks() {
 
 # The test needs more RAM because installer image is downloaded from network
 get_required_ram() {
-    echo "2750"
+    echo "2900"
 }

--- a/stage2-from-ks.sh
+++ b/stage2-from-ks.sh
@@ -30,5 +30,5 @@ stage2_from_ks() {
 
 # The test needs more RAM because installer image is downloaded from network
 get_required_ram() {
-    echo "2750"
+    echo "2900"
 }


### PR DESCRIPTION
The stage2 image has increased:
rhel 9.5: 889MB
current 9.6: 991MB

Note: not having too big buffer in the size is intentional so that the test can make us aware the size has increased significantly again.