### PR TITLE
Check that allow-discards flag is set by default on LUKS2 devices

### DIFF
--- a/autopart-luks-2.ks.in
+++ b/autopart-luks-2.ks.in
@@ -36,6 +36,14 @@ if [[ "$result" != "2" ]] ; then
     exit 1
 fi
 
+# Check if the 'allow-discards' flag is set.
+result=$(cryptsetup luksDump ${crypted} | grep "Flags" | cut -d: -f2 | tr -d "\t\n ")
+
+if [[ "$result" != "allow-discards" ]] ; then
+    echo "*** unexpected flags set for ${crypted}: ${result}" > /root/RESULT
+    exit 1
+fi
+
 # Try to use the passphrase.
 echo "passphrase" | cryptsetup luksOpen --test-passphrase "${crypted}"
 


### PR DESCRIPTION
We'll need to wait for `python-blivet-3.12.0-2.fc43` to make it through rawhide build magic for this to work (it should be available in tomorrows compose).

Depends on https://github.com/storaged-project/blivet/pull/1347 and https://github.com/storaged-project/libblockdev/pull/1095