### PR TITLE
Enable edns e2e tests on rhel 10

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -71,7 +71,6 @@ rhel10_skip_array=(
   gh1110      # storage-multipath-autopart failing
   gh1207      # packages-multilib failing
   gh1213      # harddrive-iso-single failing
-  gh1379      # dns-global-exclusive* features not in yet
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/dns-global-bootopts.sh
+++ b/dns-global-bootopts.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"network dns gh1380 gh1379"}
+TESTTYPE=${TESTTYPE:-"network dns gh1380"}
 
 . ${KSTESTDIR}/functions.sh
 

--- a/dns-global-exclusive-tls-httpks.sh
+++ b/dns-global-exclusive-tls-httpks.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"network dns gh1380 gh1379"}
+TESTTYPE=${TESTTYPE:-"network dns gh1380"}
 KICKSTART_NAME=dns-global-exclusive-tls
 
 . ${KSTESTDIR}/functions.sh

--- a/dns-global-exclusive-tls-initramfs.sh
+++ b/dns-global-exclusive-tls-initramfs.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"network dns gh1380 gh1379"}
+TESTTYPE=${TESTTYPE:-"network dns gh1380"}
 KICKSTART_NAME=dns-global-exclusive-tls
 
 . ${KSTESTDIR}/functions.sh

--- a/dns-global-exclusive-tls-ksnet.sh
+++ b/dns-global-exclusive-tls-ksnet.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"network dns gh1380 gh1379"}
+TESTTYPE=${TESTTYPE:-"network dns gh1380"}
 
 . ${KSTESTDIR}/functions.sh
 

--- a/dns-global-exclusive-tls.sh
+++ b/dns-global-exclusive-tls.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"network dns gh1380 gh1379"}
+TESTTYPE=${TESTTYPE:-"network dns gh1380"}
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
The feature is in rhel 10 nightly