### PR TITLE
Add new testtype tag stage2-from-compose (gh1397)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -78,6 +78,10 @@ rhel8_daily_skip_array=(
   skip-on-rhel-8
 )
 
+anaconda_pr_skip_array=(
+  stage2-from-compose
+)
+
 _join_args_by_comma(){
   local IFS=","
   echo "$*"
@@ -92,4 +96,4 @@ SKIP_TESTTYPES_RHEL9=$(_join_args_by_comma "${common_skip_array[@]}" "${rhel9_sk
 SKIP_TESTTYPES_RHEL10=$(_join_args_by_comma "${common_skip_array[@]}" "${rhel10_skip_array[@]}")
 SKIP_TESTTYPES_RHEL8_DAILY=$(_join_args_by_comma "${common_skip_array[@]}" "${rhel8_daily_skip_array[@]}")
 # Tests run on an anaconda pull request by comment
-SKIP_TESTTYPES_ANACONDA_PR=$(_join_args_by_comma "${common_skip_array[@]}")
+SKIP_TESTTYPES_ANACONDA_PR=$(_join_args_by_comma "${common_skip_array[@]}" "${anaconda_pr_skip_array[@]}")

--- a/dns-global-exclusive-tls-initramfs.sh
+++ b/dns-global-exclusive-tls-initramfs.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"network dns"}
+TESTTYPE=${TESTTYPE:-"network dns stage2-from-compose"}
 KICKSTART_NAME=dns-global-exclusive-tls
 
 . ${KSTESTDIR}/functions.sh

--- a/dns-global-exclusive-tls-ksnet.sh
+++ b/dns-global-exclusive-tls-ksnet.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"network dns"}
+TESTTYPE=${TESTTYPE:-"network dns stage2-from-compose"}
 
 . ${KSTESTDIR}/functions.sh
 

--- a/scripts/generate-launch-args.py
+++ b/scripts/generate-launch-args.py
@@ -88,6 +88,8 @@ def parse_args():
                          help="do not skip any tests based on os variant or branch")
     _parser.add_argument("--skip-file", type=str, metavar="PATH",
                          help="file containing data about disabled tests")
+    _parser.add_argument("--anaconda-pr", "-p", action="store_true",
+                         help="skip tests not working on anaconda PR")
     return _parser.parse_args()
 
 
@@ -111,6 +113,9 @@ if __name__ == "__main__":
         platform, disabled_testtypes = get_arguments_for_branch(args.branch, skip_file)
         if not platform:
             raise ValueError("Platform for branch {} is not defined".format(args.branch))
+
+    if args.anaconda_pr:
+        disabled_testtypes.extend(get_skip_testtypes(skip_file, "SKIP_TESTTYPES_ANACONDA_PR"))
 
     if platform:
         platform_args = ["--platform", platform]

--- a/stage2-from-ks.sh
+++ b/stage2-from-ks.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="network gh910"
+TESTTYPE="network gh910 stage2-from-compose"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
This type of tests would work only with boot.iso (initramfs/kernel) fetched from the compose where the repository (`url` kickstart command) points to (Which is defined in `scripts/defaults*.sh`). The reason is these tests are using stage2 fetched from the repo location and initramfs and stage2 needs to originate from the same boot.iso build. Otherwise there would be typically a traceback on tty1 after switchroot saying something about xfs filesystem.