### PR TITLE
Fix lsinitrd check for images with kernel version different from repo

### DIFF
--- a/dns-global-exclusive-tls.ks.in
+++ b/dns-global-exclusive-tls.ks.in
@@ -69,7 +69,13 @@ if [[ $? -ne 0 ]]; then
 fi
 
 # Check that the certificate is in installed system initramfs
-if ! lsinitrd | grep -q " etc/pki/dns/extracted/pem/tls-ca-bundle.pem"; then
+
+# We need to specify the file name if repository and installer image kernel
+# version differs, for example when generating image in anaconda PR CI
+if ! lsinitrd -m >/dev/null 2>&1; then
+    initrd_name=/boot/$(ls /boot | grep initramfs | grep -v rescue)
+fi
+if ! lsinitrd ${initrd_name} | grep -q " etc/pki/dns/extracted/pem/tls-ca-bundle.pem"; then
     echo "*** Failed check: certificate found in installed system intimrafs" >> /root/RESULT
 fi
 


### PR DESCRIPTION
For example images generated on anaocnda PR CI.
Like https://github.com/rhinstaller/anaconda/pull/6338#issuecomment-2786199341