### PR TITLE
Remove failing raid-1 from smoke tests (gh1414)

### DIFF
--- a/raid-1.sh
+++ b/raid-1.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"raid storage coverage smoke"}
+TESTTYPE=${TESTTYPE:-"raid storage coverage"}
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Remove temporarily until
https://github.com/rhinstaller/kickstart-tests/issues/1414 is fixed.