### PR TITLE
Disable raid tests on fedora (gh1414)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -24,6 +24,7 @@ fedora_skip_array=(
   gh1237      # container failing
   gh1335      # image-deployment-2 failing
   gh1357      # selinux-context failing
+  gh1414      # raid tests failing rhbz2362273
 )
 
 daily_iso_skip_array=(

--- a/encrypt-swap.sh
+++ b/encrypt-swap.sh
@@ -17,7 +17,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage"
+TESTTYPE="storage gh1414"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/lvm-raid-1.sh
+++ b/lvm-raid-1.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="lvm storage"
+TESTTYPE="lvm storage gh1414"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-1.sh
+++ b/raid-1.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"raid storage coverage"}
+TESTTYPE=${TESTTYPE:-"raid storage coverage gh1414"}
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-ddf.sh
+++ b/raid-ddf.sh
@@ -21,7 +21,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="raid storage"
+TESTTYPE="raid storage gh1414"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-luks-1.sh
+++ b/raid-luks-1.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage raid luks"
+TESTTYPE="storage raid luks gh1414"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-luks-2.sh
+++ b/raid-luks-2.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage raid luks"
+TESTTYPE="storage raid luks gh1414"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-luks-3.sh
+++ b/raid-luks-3.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage raid luks"
+TESTTYPE="storage raid luks gh1414"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-luks-4.sh
+++ b/raid-luks-4.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage raid luks"
+TESTTYPE="storage raid luks gh1414"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Disable raid tests on fedora until gh1414 is fixed. Reported as https://bugzilla.redhat.com/show_bug.cgi?id=2362273