### PR TITLE
Revert "Disable rpm-ostree-container-bootc on rhel10 temporarily."

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -71,7 +71,6 @@ rhel10_skip_array=(
   gh1207      # packages-multilib failing
   gh1213      # harddrive-iso-single failing
   rhel80086   # pykickstart removes md_ prefix from new MD devices
-  rhel84110   # rpm-container-ostree-bootc fix waiting for merge in RHEL 10.1
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/rpm-ostree-container-bootc.sh
+++ b/rpm-ostree-container-bootc.sh
@@ -18,7 +18,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="payload ostree bootc coverage reboot skip-on-rhel-8 rhel84110"
+TESTTYPE="payload ostree bootc coverage reboot skip-on-rhel-8"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHEL-84110 is included in RHEL-10.1 nightly.

This reverts commit db5a3ac2b08a7ed3d0b9df5d7ca1964697ae4823.