### PR TITLE
Enable virt-viewer connect without root

### DIFF
--- a/containers/runner/README.md
+++ b/containers/runner/README.md
@@ -127,19 +127,23 @@ stored one first!
 It's essential to know how to connect to the running tests to see why they are failing. For these
 situations you should follow this guide.
 
-Run tests as **root** to have bridging instead of using SLIRP and having IP address for the
+You can run tests as **root** to have bridging instead of using SLIRP and having IP address for the
 container so we know where to connect.
 
     sudo containers/runner/launch keyboard
+
+However, it is also possible to run tests as user which will share a host IP for the container, so
+you can connect to 127.0.0.1 localhost. The virt-viewer comment (below) should be correct in
+this situation.
 
 
 Before the tests are started you should see something like this.
 
     ************************************************************************
     You can connect to this container's libvirt with this connection string:
-   
+
        virt-viewer -c qemu+tcp://<IP>/session
-   
+
     ************************************************************************
 
 Then you can copy the hypervisor connection URI (`qemu+tcp://<IP>/session`) and display
@@ -156,7 +160,7 @@ Sometimes it could be helpful to run the test in the container manually to be ab
 container after the run. To do that:
 
 1. Run `containers/runner/launch` with `-c` argument in addition to other arguments. This will
-open shell of the container where you can do what you want to before starting the test. 
+open shell of the container where you can do what you want to before starting the test.
 2. Start the test(s) execution with `/kickstart-tests/containers/runner/run-kstest`.
 
 ## Debugging test failures

--- a/containers/runner/launch
+++ b/containers/runner/launch
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Run a set of tests (positional command line arguments) in the runner container in podman or docker.
 # Tests are taken from the current kickstart-tests checkout
-# If data/images/boot.iso exists, that is tested, otherwise it downloads the current image for given 
+# If data/images/boot.iso exists, that is tested, otherwise it downloads the current image for given
 # platform and stores it in data/images/boot-<platform>.iso.
 # Runs --recommended-jobs number of parallel tests by default, which can be changed by setting $TEST_JOBS.
 
@@ -13,6 +13,11 @@ CONTAINER=${CONTAINER:-quay.io/rhinstaller/kstest-runner}
 # Podman in rootless mode does not have access to /dev/kvm socket https://bugzilla.redhat.com/show_bug.cgi?id=1901462
 # disable selinux container separation when podman is executed as user
 PODMAN_SELINUX_FIX=
+# The virt-viewer can be used to connect to the installation even when not started under root
+# but it needs to have --network set to 'host'. This will also allow you to easily share VPN
+# connection with the container. This will net be used when started under sudo as the bridging
+# is expected to be used.
+USE_HOST_NETWORKING="--network=host"
 RUN_COMMAND=/kickstart-tests/containers/runner/run-kstest
 SCENARIO=${SCENARIO:-unknown}
 BOOT_ISO="boot.iso"
@@ -157,6 +162,11 @@ if [ "${CRUN%podman*}" != "$CRUN" ] && [ $(id -u) -ne 0 ]; then
     PODMAN_SELINUX_FIX="--security-opt label=disable"
 fi
 
+# Do not use 'host' networking when started under root
+if [ "$(id -u)" -eq 0 ]; then
+    USE_HOST_NETWORKING=""
+fi
+
 # Build up a list of KSTEST_* environment variables to be passed into the container
 TEST_ENV_VARS=$(printenv | while read line; do
     key="$(echo $line | cut -d'=' -f1)"
@@ -179,6 +189,7 @@ $CRUN run -it --rm --device=/dev/kvm --publish 127.0.0.1::16509 $PODMAN_SELINUX_
     --env TEST_JOBS="$TEST_JOBS" --env PLATFORM_NAME="${PLATFORM:-}" --env TEST_RETRY="${TEST_RETRY:-}" ${UPDATES_IMG_ARGS:-} ${CONTAINER_RUN_ARGS:-} \
     --env KSTESTS_KEEP=${KSTESTS_KEEP:-1} \
     --env BOOT_ISO=${BOOT_ISO} \
+    ${USE_HOST_NETWORKING:-} ${USE_HOST_NETWORKING:+--env USE_HOST_NETWORKING=true}\
     ${TEST_ENV_VARS} \
     ${VAR_TMP:-} \
     ${DEFAULTS_SH_ARGS:-} \

--- a/containers/runner/run-kstest
+++ b/containers/runner/run-kstest
@@ -65,16 +65,23 @@ mkdir -p ~/.config/libvirt
 printf 'listen_tls = 0\nlisten_tcp = 1\nauth_tcp = "none"\n' > ~/.config/libvirt/virtproxyd.conf
 virtproxyd -f ~/.config/libvirt/virtproxyd.conf &
 
-# this only works with a bridged network; user containers use SLIRP and only have a tun0 interface
-if MY_IP=$(ip -4 -c a show dev eth0 2>/dev/null | grep -Eo '[0-9.]+\.[0-9]+' | grep -v '\.255'); then
+print_viewer_help() {
+    IP="$1"
     set +x
     echo "************************************************************************"
     echo "You can connect to this container's libvirt with this connection string:"
     echo
-    echo "   virt-viewer -c qemu+tcp://${MY_IP}/session"
+    echo "   virt-viewer -c qemu+tcp://${IP}/session"
     echo
     echo "************************************************************************"
     set -x
+}
+
+if test -n "$USE_HOST_NETWORKING"; then
+    print_viewer_help "127.0.0.1"
+# this only works with a bridged network; user containers use SLIRP and only have a tun0 interface
+elif MY_IP=$(ip -4 -c a show dev eth0 2>/dev/null | grep -Eo '[0-9.]+\.[0-9]+' | grep -v '\.255'); then
+    print_viewer_help $MY_IP
 fi
 
 # Run the test, capture the output for run_report.sh


### PR DESCRIPTION
The original reason why we have root, maybe not the only one, was that podman under root is using bridging which add us possibility to connect to this IP by virt-viewer to see the VM. This is must have for reasonable debugging. However, it is not great from security point and you are forced to deal with files created under root. Also the bridging will make consuming VPN resources harder.

The default connection under user is using slirp4netns solution which creates internal network stack. Which makes it harder to reach.

However, there is also solution to use 'host' network which is sharing network with the host. That is considered unsecure because it will allow access to DBus resources etc..., however, we are not providing server and the container is under our control.

This solution will allow us to connect to 127.0.0.1 network.