### PR TITLE
Disable reboot-initial-setup-* on daily-iso (gh1434)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -27,6 +27,7 @@ fedora_skip_array=(
 )
 
 daily_iso_skip_array=(
+  gh1434      # reboot-inital-setup-* failing
 )
 
 rawhide_skip_array=(

--- a/reboot-initial-setup-gui.sh
+++ b/reboot-initial-setup-gui.sh
@@ -17,7 +17,7 @@
 #
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="reboot initial-setup smoke skip-on-rhel-10"
+TESTTYPE="reboot initial-setup smoke skip-on-rhel-10 gh1434"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/reboot-initial-setup-tui.sh
+++ b/reboot-initial-setup-tui.sh
@@ -18,7 +18,7 @@
 # The fix requires https://github.com/rhinstaller/anaconda/commit/6b80b7b.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="reboot initial-setup smoke skip-on-rhel-8 skip-on-rhel-10"
+TESTTYPE="reboot initial-setup smoke skip-on-rhel-8 skip-on-rhel-10 gh1434"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
The tests are part of smoke tests so it is fairly acceptable to not to have them tested via daily tests.