### PR TITLE
Do not report failed checks to RESULT after reboot

### DIFF
--- a/rpm-ostree-container-bootc.ks.in
+++ b/rpm-ostree-container-bootc.ks.in
@@ -50,13 +50,12 @@ bootc --help &> /dev/null || echo "bootc command not available after booting"
 expected_url="@KSTEST_OSTREECONTAINER_URL@"
 remote_url="$(ostree remote show-url test-remote)"
 if [ ${?} -ne 0 ]; then
-    echo "Couldn't list remote URL for 'test-remote'" >> /root/RESULT
+    echo "Couldn't list remote URL for 'test-remote'"
 fi
 
 if [ "${remote_url}" != "${expected_url}" ]; then
-    echo "Unexpected URL: ${remote_url}, expected ${expected_url}"" >> /root/RESULT
+    echo "Unexpected URL: ${remote_url}, expected ${expected_url}"
 fi
-
 
 EOF
 %end

--- a/rpm-ostree-container-uefi.ks.in
+++ b/rpm-ostree-container-uefi.ks.in
@@ -54,18 +54,18 @@ bootc --help &> /dev/null || echo "bootc command not available after booting"
 expected_url="@KSTEST_OSTREECONTAINER_URL@"
 remote_url="$(ostree remote show-url test-remote)"
 if [ ${?} -ne 0 ]; then
-    echo "Couldn't list remote URL for 'test-remote'" >> /root/RESULT
+    echo "Couldn't list remote URL for 'test-remote'"
 fi
 
 if [ "${remote_url}" != "${expected_url}" ]; then
-    echo "Unexpected URL: ${remote_url}, expected ${expected_url}" >> /root/RESULT
+    echo "Unexpected URL: ${remote_url}, expected ${expected_url}"
 fi
 
 # Test for vconsole kernel argument (specific to ostree installations)
 # https://bugzilla.redhat.com/show_bug.cgi?id=1890085
 journalctl | grep -q "vconsole.keymap=us"
 if [ $? -ne 0 ]; then
-    echo "Kernel argument 'vconsole.keymap' is not used in the installed system!" >> /root/RESULT
+    echo "Kernel argument 'vconsole.keymap' is not used in the installed system!"
 fi
 
 EOF


### PR DESCRIPTION
Checks after reboot have to report errors to stdout instead of standard /root/RESULT. These outputs are then processed by the `success_on_first_boot` fragment. Outputs written to /root/RESULT seems to be ignored.