### PR TITLE
Add bootc check to verify that console parameter is preserved

### DIFF
--- a/rpm-ostree-container-bootc.ks.in
+++ b/rpm-ostree-container-bootc.ks.in
@@ -57,5 +57,11 @@ if [ "${remote_url}" != "${expected_url}" ]; then
     echo "Unexpected URL: ${remote_url}, expected ${expected_url}"
 fi
 
+# Check if console argument is passed to the installed system
+rpm-ostree kargs | grep -q console=ttyS7 > /dev/null
+if [ ${?} -ne 0 ]; then
+    echo "The console kernel parameter was not preserved, current list: $(rpm-ostree kargs)"
+fi
+
 EOF
 %end

--- a/rpm-ostree-container-bootc.sh
+++ b/rpm-ostree-container-bootc.sh
@@ -66,6 +66,10 @@ copy_interesting_files_from_system() {
     done
 }
 
+kernel_args() {
+    echo "${DEFAULT_BOOTOPTS} console=ttyS7"
+}
+
 additional_runner_args() {
    # Wait for reboot and shutdown of the VM,
    # but exit after the specified timeout.


### PR DESCRIPTION
For ostree containers we are using bootupd which has different path for bootloader creation. For that reason we got a bug that console kernel boot parameter is not preserved to the installed system on bootc containers.

Test for https://issues.redhat.com/browse/RHEL-79961

Depends on:
* https://github.com/rhinstaller/anaconda/pull/6457
* https://github.com/rhinstaller/anaconda/pull/6476
* https://github.com/rhinstaller/anaconda/pull/6477