### PR TITLE
Revert "Disable lvm-cache-* on daily-iso temporarily (gh1437)"

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -21,7 +21,6 @@ fedora_skip_array=(
   gh975       # packages-default failing
   gh1023      # rpm-ostree failing
   gh1335      # image-deployment-2 failing
-  gh1437      # lvm-cache-* failing
 )
 
 daily_iso_skip_array=(

--- a/lvm-cache-1.sh
+++ b/lvm-cache-1.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="lvm storage gh1437"
+TESTTYPE="lvm storage"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/lvm-cache-2.sh
+++ b/lvm-cache-2.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="lvm storage gh1437"
+TESTTYPE="lvm storage"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
STILL BROKEN DO NOT MERGE
waiting for /test-os-variants to pass some time (or for the issue fix: https://github.com/rhinstaller/kickstart-tests/issues/1437)

This reverts commit 512cfdaff75858c3331ea0c9b69364dc8a146968.
