### PR TITLE
Use RHEL bootc containers instead of CentOS Stream

### DIFF
--- a/rpm-ostree-container-uefi.ks.in
+++ b/rpm-ostree-container-uefi.ks.in
@@ -25,7 +25,7 @@ reboot
 
 %post
 # We need to use tr because sometimes there is newline inside of the efibootmgr entry line :(
-efibootmgr | tr -s '\n' ' ' | grep -E 'Boot0001\* Fedora\s+HD\(1'
+efibootmgr | tr -s '\n' ' ' | grep -E 'Boot0001\* (Fedora|Red Hat Enterprise Linux)\s+'
 if [ $? -ne 0 ]; then
     echo -e "EFI boot entry wasn't created properly:\n$(efibootmgr)"  >> /root/RESULT
 fi

--- a/rpm-ostree-container-uefi.sh
+++ b/rpm-ostree-container-uefi.sh
@@ -18,7 +18,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="payload uefi ostree bootc keyboard reboot skip-on-rhel-8 skip-on-rhel-9 skip-on-rhel-10 skip-on-centos-10"
+TESTTYPE="payload uefi ostree bootc keyboard reboot skip-on-rhel-8"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/scripts/defaults-rhel10.sh
+++ b/scripts/defaults-rhel10.sh
@@ -7,4 +7,4 @@ export KSTEST_URL='http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/late
 export KSTEST_MODULAR_URL='http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/AppStream/x86_64/os/'
 export KSTEST_FTP_URL='ftp://download.devel.redhat.com/mnt/redhat/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/BaseOS/x86_64/os/'
 export KSTEST_FTP_APPSTREAM_URL='ftp://download.devel.redhat.com/mnt/redhat/rhel-10/nightly/RHEL-10/latest-RHEL-10.1/compose/AppStream/x86_64/os/'
-export KSTEST_OSTREECONTAINER_URL='quay.io/centos-bootc/centos-bootc:stream10'
+export KSTEST_OSTREECONTAINER_URL='images.paas.redhat.com/bootc/rhel-bootc:latest-10.1'

--- a/scripts/defaults-rhel9.sh
+++ b/scripts/defaults-rhel9.sh
@@ -5,4 +5,4 @@ export KSTEST_URL='http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest
 export KSTEST_MODULAR_URL='http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.7.0/compose/AppStream/x86_64/os/'
 export KSTEST_FTP_URL='ftp://download.devel.redhat.com/mnt/redhat/rhel-9/nightly/RHEL-9/latest-RHEL-9.7.0/compose/BaseOS/x86_64/os/'
 export KSTEST_FTP_APPSTREAM_URL='ftp://download.devel.redhat.com/mnt/redhat/rhel-9/nightly/RHEL-9/latest-RHEL-9.7.0/compose/AppStream/x86_64/os/'
-export KSTEST_OSTREECONTAINER_URL='quay.io/centos-bootc/centos-bootc:stream9'
+export KSTEST_OSTREECONTAINER_URL='images.paas.redhat.com/bootc/rhel-bootc:latest-9.7'


### PR DESCRIPTION
We used CentOS Stream containers for RHEL testing because the official RHEL containers are behind the authentication. However, these repositories are available behind the VPN which is true for most of the other installation sources we are using for RHEL.

This commit enables the bootc uefi test to work on RHEL. The CentOS Stream containers can't be used as they contain CentOS Stream bootloader configuration which is not compatible with RHEL.


Blocked by:
* https://github.com/rhinstaller/anaconda/pull/6493
* https://github.com/rhinstaller/anaconda/pull/6492