### PR TITLE
Fix changed tests detection in /test-tmt workflow

### DIFF
--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -6,7 +6,7 @@ git remote get-url upstream >/dev/null 2>&1 || git remote add upstream https://g
 git fetch upstream
 git rebase upstream/main
 
-# list of tests that are changed by the current PR; ignore non-executable *.sh as these are helpers, not tests
+# list of tests that are changed by the current PR
 CHANGED_TESTS=$(scripts/get-changed-tests.py upstream/main HEAD | tr ' ' '\n')
 
 TESTS=$CHANGED_TESTS

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -7,7 +7,7 @@ git fetch upstream
 git rebase upstream/main
 
 # list of tests that are changed by the current PR; ignore non-executable *.sh as these are helpers, not tests
-CHANGED_TESTS=$(scripts/get-changed-tests.py upstream/main HEAD)
+CHANGED_TESTS=$(scripts/get-changed-tests.py upstream/main HEAD | tr ' ' '\n')
 
 TESTS=$CHANGED_TESTS
 


### PR DESCRIPTION
Related: INSTALLER-4140

Originally the detected tests were newline separated in the `CHANGED_TESTS`.

Fixup of commit 4d0d72ee962f99ce2d4d900dc316eecc5e1fe416