### PR TITLE
Revert "Disable selinux-context on fedora for gh1357"

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -21,7 +21,6 @@ fedora_skip_array=(
   gh975       # packages-default failing
   gh1023      # rpm-ostree failing
   gh1335      # image-deployment-2 failing
-  gh1357      # selinux-context failing
   gh1437      # lvm-cache-* failing
 )
 

--- a/selinux-contexts.sh
+++ b/selinux-contexts.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="security selinux gh1357"
+TESTTYPE="security selinux"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
This reverts commit f57f68c75b61e3ed9a3f495247c7c3f51f369a57.

The issue was fixed in `filesystem` package