### PR TITLE
Synchronize classify script issues with the repo (open/closed)

### DIFF
--- a/.claude/commands/classify-sync-with-repo.md
+++ b/.claude/commands/classify-sync-with-repo.md
@@ -1,0 +1,21 @@
+# classify-sync-with-repo
+
+## Description
+Synchronize the classify-failures script with the current state of repository issues by moving closed issues from ISSUES list to CLOSED_ISSUES list and open issues from CLOSED_ISSUES list to ISSUES list.
+
+## Usage
+```
+classify-sync-with-repo
+```
+
+## What it does
+1. Reads the current classify-failures script to understand the ISSUES and CLOSED_ISSUES lists
+2. Checks the current repository issues to identify which are open vs closed
+3. Compares the script lists with the actual repository state
+4. Creates a patch to move issues between ISSUES and CLOSED_ISSUES lists as needed
+
+The script ensures that:
+- ISSUES list contains only open repository issues
+- CLOSED_ISSUES list contains only closed repository issues
+
+This maintains the accuracy of the classify-failures script for test failure classification.

--- a/scripts/classify-failures
+++ b/scripts/classify-failures
@@ -45,40 +45,12 @@ ISSUES = [
         "first_grep": "Nothing useful found for Hard drive ISO",
     },
     {
-        "description": "[992] https://github.com/rhinstaller/kickstart-tests/issues/992 - or it can some more recent issue, the string is pretty generic.",
-        "first_grep": "Started Process Core Dump",
-    },
-    {
-        "description": "[846] on rhel8 ([26]) https://github.com/rhinstaller/kickstart-tests/issues/846",
-        "first_grep": "raise.*Failed to activate service 'org.freedesktop.hostname1'",
-    },
-    {
         "description": "[767] ([758]) https://github.com/rhinstaller/kickstart-tests/issues/767",
         "first_grep": "Payload error.*Failed to download metadata for repo",
     },
     {
-        "description": "[846] on rhel8 ([26]) https://github.com/rhinstaller/kickstart-tests/issues/846",
-        "first_grep": "Network.*Failed to activate service 'org.freedesktop.hostname1'",
-    },
-    {
         "description": "[786] https://github.com/rhinstaller/kickstart-tests/issues/786",
         "first_grep": "Traceback.*Failed to activate swap on /dev/md/test-raid-ddf_0p2: No such file or directory",
-    },
-    {
-        "description": "[859] https://github.com/rhinstaller/kickstart-tests/issues/859",
-        "first_grep": "Failed to activate filesystems: invalid device specification",
-    },
-    {
-        "description": "[845] https://github.com/rhinstaller/kickstart-tests/issues/845",
-        "first_grep": "INFO lvmdbusd:KeyError: 'pv_uuid'",
-    },
-    {
-        "description": "[889] raid-ddf https://github.com/rhinstaller/kickstart-tests/issues/889",
-        "first_grep": "SwapError: Failed to open the device '/dev/md/test-raid-ddf_0p2'",
-    },
-    {
-        "description": "[890] default-systemd-target-vnc-graphical https://github.com/rhinstaller/kickstart-tests/issues/890",
-        "first_grep": "gnome-kiosk exited on signal 11",
     },
     {
         "description": "[857] resource to create this format lvmpv is unavailable https://github.com/rhinstaller/kickstart-tests/issues/857",
@@ -105,22 +77,6 @@ ISSUES = [
         "first_grep": "/root/RESULT does not exist in VM image.",
     },
     {
-        "description": "[930] [939] [794] [782] https://github.com/rhinstaller/kickstart-tests/issues/930",
-        "first_grep": "lvmdbusd:json.decoder.JSONDecodeError:",
-    },
-    {
-        "description": "[985] https://github.com/rhinstaller/kickstart-tests/issues/985",
-        "first_grep": "WARNING.*Problem 1.*python3-dnf",
-    },
-    {
-        "description": "[984] https://github.com/rhinstaller/kickstart-tests/issues/984",
-        "first_grep": "RESULT.*CRIT.*Anaconda crashed on signal 11",
-    },
-    {
-        "description": "[983] https://github.com/rhinstaller/kickstart-tests/issues/983",
-        "first_grep": "CRIT.*argument of type 'NoneType' is not iterable",
-    },
-    {
         "description": "[993] https://github.com/rhinstaller/kickstart-tests/issues/993",
         "first_grep": "WARNING.*nothing provides.*getent",
     },
@@ -141,10 +97,6 @@ ISSUES = [
         "first_grep": "CRIT.*dasbus.error.DBusError: Process reported exit code 2: mdadm: /dev/vda3 is busy - skipping",
     },
     {
-        "description": "[1060] https://github.com/rhinstaller/kickstart-tests/issues/1060",
-        "first_grep": "CRIT.*pyanaconda.ui.gui.xkl_wrapper.XklWrapperError: Failed to initialize layouts",
-    },
-    {
         "description": "[907] https://github.com/rhinstaller/kickstart-tests/issues/907",
         "first_grep": "ERROR:anaconda.modules.storage.partitioning.base_partitioning:Storage configuration has failed: No usable disks.",
     },
@@ -157,28 +109,8 @@ ISSUES = [
         "first_grep": "org.fedoraproject.Anaconda.Modules.Localization.GetCompositorSelectedLayout has failed with an exception",
     },
     {
-        "description": "[1261] https://github.com/rhinstaller/kickstart-tests/issues/1261",
-        "first_grep": "anaconda:anaconda: display: Wayland startup failed: systemd exited with status 1",
-    },
-    {
-        "description": "[1261] https://github.com/rhinstaller/kickstart-tests/issues/1261",
-        "first_grep": "anaconda:anaconda: display: Wayland startup failed: /usr/libexec/anaconda/run-in-new-session exited with status 1",
-    },
-    {
-        "description": "[11] https://github.com/rhinstaller/kickstart-tests/issues/795",
-        "first_grep": "ERR.*Timeout trying to start Xorg",
-    },
-    {
-        "description": "[1296] https://github.com/rhinstaller/kickstart-tests/issues/1296",
-        "first_grep": "ERR anaconda:Exception ignored in atexit callback",
-    },
-    {
         "description": "[1303] https://github.com/rhinstaller/kickstart-tests/issues/1303",
         "first_grep": "WARNING gnome-kiosk:Lost or failed to acquire name org.gnome.Mutter.ServiceChannel",
-    },
-    {
-        "description": "[886] https://github.com/rhinstaller/kickstart-tests/issues/886",
-        "first_grep": "/dev/vda4 shouldn't be mounted at",
     },
     {
         "description": "[1311] https://github.com/rhinstaller/kickstart-tests/issues/1311",
@@ -199,10 +131,6 @@ ISSUES = [
     {
         "description": "[1318] https://github.com/rhinstaller/kickstart-tests/issues/1318",
         "first_grep": "anaconda:anaconda: display: X or window manager startup failed: systemd exited with status 1",
-    },
-    {
-        "description": "[1346] https://github.com/rhinstaller/kickstart-tests/issues/1346",
-        "last_matching_re": (".*org.fedoraproject.Anaconda.Modules.*", ".*grub2-mkconfig.*")
     },
     {
         "description": "[1438] https://github.com/rhinstaller/kickstart-tests/issues/1438",
@@ -260,6 +188,78 @@ CLOSED_ISSUES = [
     {
         "description": "[980] https://github.com/rhinstaller/kickstart-tests/issues/980",
         "first_grep": "Payloads:  - nothing provides libperl",
+    },
+    {
+        "description": "[992] https://github.com/rhinstaller/kickstart-tests/issues/992 - or it can some more recent issue, the string is pretty generic.",
+        "first_grep": "Started Process Core Dump",
+    },
+    {
+        "description": "[846] on rhel8 ([26]) https://github.com/rhinstaller/kickstart-tests/issues/846",
+        "first_grep": "raise.*Failed to activate service 'org.freedesktop.hostname1'",
+    },
+    {
+        "description": "[846] on rhel8 ([26]) https://github.com/rhinstaller/kickstart-tests/issues/846",
+        "first_grep": "Network.*Failed to activate service 'org.freedesktop.hostname1'",
+    },
+    {
+        "description": "[859] https://github.com/rhinstaller/kickstart-tests/issues/859",
+        "first_grep": "Failed to activate filesystems: invalid device specification",
+    },
+    {
+        "description": "[845] https://github.com/rhinstaller/kickstart-tests/issues/845",
+        "first_grep": "INFO lvmdbusd:KeyError: 'pv_uuid'",
+    },
+    {
+        "description": "[889] raid-ddf https://github.com/rhinstaller/kickstart-tests/issues/889",
+        "first_grep": "SwapError: Failed to open the device '/dev/md/test-raid-ddf_0p2'",
+    },
+    {
+        "description": "[890] default-systemd-target-vnc-graphical https://github.com/rhinstaller/kickstart-tests/issues/890",
+        "first_grep": "gnome-kiosk exited on signal 11",
+    },
+    {
+        "description": "[930] [939] [794] [782] https://github.com/rhinstaller/kickstart-tests/issues/930",
+        "first_grep": "lvmdbusd:json.decoder.JSONDecodeError:",
+    },
+    {
+        "description": "[985] https://github.com/rhinstaller/kickstart-tests/issues/985",
+        "first_grep": "WARNING.*Problem 1.*python3-dnf",
+    },
+    {
+        "description": "[984] https://github.com/rhinstaller/kickstart-tests/issues/984",
+        "first_grep": "RESULT.*CRIT.*Anaconda crashed on signal 11",
+    },
+    {
+        "description": "[983] https://github.com/rhinstaller/kickstart-tests/issues/983",
+        "first_grep": "CRIT.*argument of type 'NoneType' is not iterable",
+    },
+    {
+        "description": "[1060] https://github.com/rhinstaller/kickstart-tests/issues/1060",
+        "first_grep": "CRIT.*pyanaconda.ui.gui.xkl_wrapper.XklWrapperError: Failed to initialize layouts",
+    },
+    {
+        "description": "[1261] https://github.com/rhinstaller/kickstart-tests/issues/1261",
+        "first_grep": "anaconda:anaconda: display: Wayland startup failed: systemd exited with status 1",
+    },
+    {
+        "description": "[1261] https://github.com/rhinstaller/kickstart-tests/issues/1261",
+        "first_grep": "anaconda:anaconda: display: Wayland startup failed: /usr/libexec/anaconda/run-in-new-session exited with status 1",
+    },
+    {
+        "description": "[11] https://github.com/rhinstaller/kickstart-tests/issues/795",
+        "first_grep": "ERR.*Timeout trying to start Xorg",
+    },
+    {
+        "description": "[1296] https://github.com/rhinstaller/kickstart-tests/issues/1296",
+        "first_grep": "ERR anaconda:Exception ignored in atexit callback",
+    },
+    {
+        "description": "[886] https://github.com/rhinstaller/kickstart-tests/issues/886",
+        "first_grep": "/dev/vda4 shouldn't be mounted at",
+    },
+    {
+        "description": "[1346] https://github.com/rhinstaller/kickstart-tests/issues/1346",
+        "last_matching_re": (".*org.fedoraproject.Anaconda.Modules.*", ".*grub2-mkconfig.*")
     },
 ]
 


### PR DESCRIPTION
Assisted by: claude

Created by these prompts:

The scripts/classify-failures script contains two lists of issues. ISSUES list should contain only the repository issues that are open, the CLOSED_ISSUES list should contain olny the repository issues that are closed. Can you check with the repository issues and suggest a patch for the classify-failures script that would reflect current state of the repository issues?

Save the last prompt as a command named classify-sync-with-repo