### PR TITLE
Update disabled tests for centos10

### DIFF
--- a/basic-ftp.sh
+++ b/basic-ftp.sh
@@ -20,6 +20,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="payload"
+TESTTYPE="payload gh1466"
 
 . ${KSTESTDIR}/functions.sh

--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -78,6 +78,7 @@ rhel10_skip_array=(
 centos10_skip_array=(
   skip-on-centos
   skip-on-centos-10
+  gh1466      # ftp source tests failing
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -76,6 +76,8 @@ rhel10_skip_array=(
 )
 
 centos10_skip_array=(
+  skip-on-centos
+  skip-on-centos-10
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml
@@ -100,7 +102,7 @@ SKIP_TESTTYPES_DAILY_ISO=$(_join_args_by_comma "${common_skip_array[@]}" "${fedo
 SKIP_TESTTYPES_RHEL8=$(_join_args_by_comma "${common_skip_array[@]}" "${rhel8_skip_array[@]}")
 SKIP_TESTTYPES_RHEL9=$(_join_args_by_comma "${common_skip_array[@]}" "${rhel9_skip_array[@]}")
 SKIP_TESTTYPES_RHEL10=$(_join_args_by_comma "${common_skip_array[@]}" "${rhel10_centos10_skip_array[@]}" "${rhel10_skip_array[@]}")
-SKIP_TESTTYPES_CENTOS10=$(_join_args_by_comma "${common_skip_array[@]}" "${centos10_skip_array[@]}")
+SKIP_TESTTYPES_CENTOS10=$(_join_args_by_comma "${common_skip_array[@]}" "${rhel10_centos10_skip_array[@]}" "${centos10_skip_array[@]}")
 SKIP_TESTTYPES_RHEL8_DAILY=$(_join_args_by_comma "${common_skip_array[@]}" "${rhel8_daily_skip_array[@]}")
 # Tests run on an anaconda pull request by comment
 SKIP_TESTTYPES_ANACONDA_PR=$(_join_args_by_comma "${common_skip_array[@]}" "${anaconda_pr_skip_array[@]}")

--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -79,6 +79,7 @@ centos10_skip_array=(
   skip-on-centos
   skip-on-centos-10
   gh1466      # ftp source tests failing
+  gh1467      # flatpak-preinstall failing
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/flatpak-preinstall-ftp.sh
+++ b/flatpak-preinstall-ftp.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging payload skip-on-fedora skip-on-rhel-9"
+TESTTYPE="packaging payload skip-on-fedora skip-on-rhel-9 gh1466"
 
 . ${KSTESTDIR}/functions.sh

--- a/flatpak-preinstall.sh
+++ b/flatpak-preinstall.sh
@@ -18,6 +18,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging payload skip-on-fedora skip-on-rhel-9"
+TESTTYPE="packaging payload skip-on-fedora skip-on-rhel-9 gh1467"
 
 . ${KSTESTDIR}/functions.sh

--- a/fragments/platform/centos10/repos/default-ftp.ks
+++ b/fragments/platform/centos10/repos/default-ftp.ks
@@ -1,0 +1,3 @@
+# Default FTP CentOS 10 repositories - BeseOS + AppStream
+url --url @KSTEST_FTP_URL@
+repo --name=appstream --baseurl @KSTEST_FTP_APPSTREAM_URL@

--- a/network-autoconnections-httpks.ks.in
+++ b/network-autoconnections-httpks.ks.in
@@ -131,7 +131,7 @@ fi
 
 # Test per-platform autoconnection configuration
 # It is configured by anaconda-nm-disable-autocons-rhel.service
-if [ "${platform:0:4}" == "rhel" ]; then
+if [ "${platform:0:4}" == "rhel" ] || [ "${platform:0:6}" == "centos" ]; then
     if [ $nm_has_autoconnections_off -ne 0 ]; then
         echo "*** autoconnections are on on platform ${platform}" >> /root/RESULT
     fi

--- a/scripts/defaults-centos10.sh
+++ b/scripts/defaults-centos10.sh
@@ -6,4 +6,5 @@ source ./network-device-names.cfg
 export KSTEST_URL='https://mirror.stream.centos.org/10-stream/BaseOS/x86_64/os/'
 export KSTEST_MODULAR_URL='https://mirror.stream.centos.org/10-stream/AppStream/x86_64/os/'
 export KSTEST_FTP_URL='ftp://download.stream.rdu2.redhat.com/stream-10/production/latest-CentOS-Stream/compose/BaseOS/x86_64/os/'
+export KSTEST_FTP_APPSTREAM_URL='ftp://download.stream.rdu2.redhat.com/stream-10/production/latest-CentOS-Stream/compose/AppStream/x86_64/os/'
 export KSTEST_OSTREECONTAINER_URL='quay.io/centos-bootc/centos-bootc:stream10'


### PR DESCRIPTION
The PR should make the next daily run on centos10 green.
(the last, red, daily: https://github.com/rhinstaller/kickstart-tests/actions/runs/16710588945/job/47294891112)