### PR TITLE
Remove obsolete gh640 from skip-testtypes

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -61,7 +61,6 @@ rhel10_centos10_skip_array=(
   gh576       # clearpart-4 test is flaky on all scenarios
   gh804       # tests requiring dvd iso failing
   gh1090      # raid-1-reqpart failing
-  gh1107      # rpm-ostree-container failing
   gh1207      # packages-multilib failing
   gh1213      # harddrive-iso-single failing
 )

--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -59,7 +59,6 @@ rhel9_skip_array=(
 
 rhel10_centos10_skip_array=(
   gh576       # clearpart-4 test is flaky on all scenarios
-  gh640       # authselect-not-set failing
   gh804       # tests requiring dvd iso failing
   gh1090      # raid-1-reqpart failing
   gh1107      # rpm-ostree-container failing


### PR DESCRIPTION
The issue has already been resolved no tests are tagged with it anymore.