### PR TITLE
Enable keyboard-bootopt-only on rhel like platforms.

### DIFF
--- a/keyboard-bootopt-only.sh
+++ b/keyboard-bootopt-only.sh
@@ -20,7 +20,7 @@
 # On RHEL, boot option is not enough for unattended installation
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="keyboard i18n skip-on-rhel skip-on-centos"
+TESTTYPE="keyboard i18n"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
It become supported since rhel9.