### PR TITLE
Enable some of the edns tests on centos10

### DIFF
--- a/dns-global-exclusive-tls-2.sh
+++ b/dns-global-exclusive-tls-2.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"network dns skip-on-rhel skip-on-centos"}
+TESTTYPE=${TESTTYPE:-"network dns skip-on-rhel"}
 
 . ${KSTESTDIR}/functions.sh
 

--- a/dns-global-exclusive-tls-httpks-2.sh
+++ b/dns-global-exclusive-tls-httpks-2.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"network dns skip-on-rhel skip-on-centos"}
+TESTTYPE=${TESTTYPE:-"network dns skip-on-rhel"}
 KICKSTART_NAME=dns-global-exclusive-tls-2
 # FIXME: the test would ideally require name resolution to fetch the kickstart
 


### PR DESCRIPTION
Unlike for rhel10 the tests can use public dns server to access installer image.