### PR TITLE
Disable proxy-cmdline failing on centos10 (gh1474)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -74,6 +74,7 @@ centos10_skip_array=(
   skip-on-centos
   skip-on-centos-10
   gh1466      # ftp source tests failing
+  gh1474      # proxy-cmdline failing
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/proxy-cmdline.sh
+++ b/proxy-cmdline.sh
@@ -20,7 +20,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="payload proxy"
+TESTTYPE="payload proxy gh1474"
 
 . ${KSTESTDIR}/functions.sh
 . ${KSTESTDIR}/functions-proxy.sh


### PR DESCRIPTION
Disable until gh1474 is fixed.