### PR TITLE
Disable flatpak tests on centos10 (gh1467)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -74,7 +74,6 @@ centos10_skip_array=(
   skip-on-centos
   skip-on-centos-10
   gh1466      # ftp source tests failing
-  gh1467      # flatpak-preinstall failing
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/flatpak-preinstall-ftp.sh
+++ b/flatpak-preinstall-ftp.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging payload skip-on-fedora skip-on-rhel-9 gh1466"
+TESTTYPE="packaging payload skip-on-fedora skip-on-rhel-9 skip-on-centos gh1466"
 
 . ${KSTESTDIR}/functions.sh

--- a/flatpak-preinstall.sh
+++ b/flatpak-preinstall.sh
@@ -18,6 +18,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging payload skip-on-fedora skip-on-rhel-9 gh1467"
+TESTTYPE="packaging payload skip-on-fedora skip-on-rhel-9 skip-on-centos"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Flatpaks are not supported on centos10.