### PR TITLE
Revert "Disable ftp source tests on centos10 (gh1466)"

### DIFF
--- a/basic-ftp.sh
+++ b/basic-ftp.sh
@@ -20,6 +20,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="payload gh1466"
+TESTTYPE="payload"
 
 . ${KSTESTDIR}/functions.sh

--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -73,7 +73,6 @@ rhel10_skip_array=(
 centos10_skip_array=(
   skip-on-centos
   skip-on-centos-10
-  gh1466      # ftp source tests failing
   gh1467      # flatpak-preinstall failing
 )
 

--- a/flatpak-preinstall-ftp.sh
+++ b/flatpak-preinstall-ftp.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging payload skip-on-fedora skip-on-rhel-9 gh1466"
+TESTTYPE="packaging payload skip-on-fedora skip-on-rhel-9"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
This reverts commit 4ff488d6e9e8652ffd8cc8bdd7bf4970b8fe6e6d.

A PR to check that the issue is still present.