### PR TITLE
Update docs for network-bootopts-noautodefault

### DIFF
--- a/network-bootopts-noautodefault.ks.in
+++ b/network-bootopts-noautodefault.ks.in
@@ -1,4 +1,8 @@
-#Test option to disable default autoconnections
+# Test option to disable default autoconnections
+#
+# On RHEL and CentOS the autoconnetions are turned off for kickstart
+# installation so to test the option we'd need to test interactive
+# installation.
 
 # Use defaults, but no network that could activate the other device
 # because of device --link

--- a/network-bootopts-noautodefault.sh
+++ b/network-bootopts-noautodefault.sh
@@ -17,11 +17,6 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-# This is a variation of onboot-activate test.
-# In this case, kickstart is fetched via http instead of injecting in initrd.
-# The latter is causing that kickstart network commands are not applied (ifcfg
-# files created) in initramfs.
-
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
 TESTTYPE="network skip-on-rhel skip-on-centos"


### PR DESCRIPTION
Remove copy&paste artifact and add note about RHEL and CentOS specifics.