### PR TITLE
Enable packages-default test on centos10

### DIFF
--- a/packages-default.sh
+++ b/packages-default.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging payload skip-on-rhel skip-on-centos gh975"
+TESTTYPE="packaging payload skip-on-rhel gh975"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Unlike on RHEL the default environment installed on CentOS can be checked via dnf in the same way as on Fedora.