### PR TITLE
Enable network bond pre tests on rhel-like platforms

### DIFF
--- a/bond-vlan-pre.sh
+++ b/bond-vlan-pre.sh
@@ -17,9 +17,8 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-# Upstream support was added in https://bugzilla.redhat.com/show_bug.cgi?id=1879480
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="network skip-on-rhel skip-on-centos"
+TESTTYPE="network"
 
 . ${KSTESTDIR}/bond-vlan-httpks.sh

--- a/bridged-bond-pre.sh
+++ b/bridged-bond-pre.sh
@@ -17,10 +17,9 @@
 #
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 
-# Upstream support was added in https://github.com/rhinstaller/anaconda/pull/2861
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="network skip-on-rhel skip-on-centos"
+TESTTYPE="network"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
The support for the configration has already arrived to rhel.