### PR TITLE
[RTT-5965] Add test for reserved space on VG

### DIFF
--- a/WORKLIST
+++ b/WORKLIST
@@ -48,8 +48,6 @@ MEDIUM TESTS
       be able to calculate that ahead of time given control over the VM and verify the created partition matches.
     - Tweaking the amount of memory/disk in the VM to be numbers that fall on boundaries of the recommended size algorithm can also be useful.
     - Add this to an existing test that does custom partitioning.
-* volgroup --reserved-space/--reserved-percent
-    - These options specify that space should be left free in a volgroup.  This can likely be verified somehow.
 
 HARD TESTS
 ==========

--- a/lvm-vg-reserved-space.ks.in
+++ b/lvm-vg-reserved-space.ks.in
@@ -1,0 +1,46 @@
+# Check whether volume groups are created with a requested amount of free space
+# (absolute amount and percentage).
+
+%ksappend repos/default.ks
+%ksappend common/common_no_storage_and_payload.ks
+%ksappend payload/default_packages.ks
+
+zerombr
+clearpart --all --initlabel
+
+reqpart --add-boot
+part pv.01 --size=6000
+part pv.02 --size=2000
+volgroup vg1 pv.01 --reserved-percent=10
+volgroup vg2 pv.02 --reserved-space=100
+logvol swap --fstype=swap --name=swap --vgname=vg1 --size=1000
+logvol / --name=root --vgname=vg1 --size=4000 --grow
+logvol /home --name=home --vgname=vg2 --size=1000 --grow
+
+%packages
+python3
+%end
+
+%post
+# verify sizes of reserved space/percentage in VGs
+vg1_free_expected_pct=10 # 10 %
+vg2_free_expected=100    # 100 MiB
+vg1_size=6000
+vg2_size=2000
+
+vg1_free=$(vgs --noheadings -o free --unit=m --nosuffix vg1)
+vg2_free=$(vgs --noheadings -o free --unit=m --nosuffix vg2)
+vg1_free_pct=$(python3 -c "print(int(round((${vg1_free}*100)/${vg1_size})))")
+
+if (( vg1_free_pct != vg1_free_expected_pct )); then
+    echo "*** Free space on vg1 is incorrect (${vg1_free} MiB -> ${vg1_free_pct} %, expected ${vg1_free_expected_pct} %)." >> /root/RESULT
+fi
+
+if (( ${vg2_free%.*} != vg2_free_expected )); then
+    echo "*** Free space on vg2 is incorrect (${vg2_free} MiB, expected ${vg2_free_expected} MiB)." >> /root/RESULT
+fi
+
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+%end

--- a/lvm-vg-reserved-space.sh
+++ b/lvm-vg-reserved-space.sh
@@ -1,0 +1,24 @@
+#
+# Copyright (C) 2025  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Jiri Kortus <jikortus@redhat.com>
+
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
+TESTTYPE="lvm storage"
+
+. ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
It covers both an absolute and relative (percentage) specification of the required amount of free space and replaces a downstream test.