### PR TITLE
Reenable packages-multilib test on some variants (gh641)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -15,7 +15,6 @@ fedora_skip_array=(
 fedora_disabled_array=(
   gh576       # clearpart-4 test is flaky on all scenarios
   gh595       # proxy-cmdline failing on all scenarios
-  gh641       # packages-multilib failing on systemd conflict
   gh777       # raid-1-reqpart failing
   gh890       # default-systemd-target-vnc-graphical-provides flaking too much
   rhbz1853668 # multipath device not constructed back after installation
@@ -61,7 +60,6 @@ rhel9_disabled_array=(
   gh576       # clearpart-4 test is flaky on all scenarios
   gh595       # proxy-cmdline failing on all scenarios
   gh604       # packages-weakdeps: "gnupg2 --recommends has changed, test needs to be updated"
-  gh641       # packages-multilib failing on systemd conflict
   gh804       # tests requiring dvd iso failing
   rhel16355   # mountpoint-assigment-plain waiting for feature release
 )

--- a/packages-multilib.sh
+++ b/packages-multilib.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging payload skip-on-rhel-8 gh641 gh1207"
+TESTTYPE="packaging payload skip-on-rhel-8 gh1207"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
One of the issues seems to be fixed now.
The gh1207 still applies (on rhel-10 and centos-10)