### PR TITLE
Reenable autopart-luks-1 (gh774)

### DIFF
--- a/autopart-luks-1.sh
+++ b/autopart-luks-1.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage luks gh774"
+TESTTYPE="autopart storage luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -13,7 +13,6 @@ fedora_skip_array=(
   gh576       # clearpart-4 test is flaky on all scenarios
   gh595       # proxy-cmdline failing on all scenarios
   gh641       # packages-multilib failing on systemd conflict
-  gh774       # autopart-luks-1 failing
   gh777       # raid-1-reqpart failing
   gh910       # stage2-from-ks test needs to be fixed for daily-iso
   gh890       # default-systemd-target-vnc-graphical-provides flaking too much
@@ -42,7 +41,6 @@ rhel8_skip_array=(
   skip-on-rhel-8
   gh576       # clearpart-4 test is flaky on all scenarios
   gh595       # proxy-cmdline failing on all scenarios
-  gh774       # autopart-luks-1 failing
   gh1018      # bridge-no-bootopts-net failing
   gh804       # tests requiring dvd iso failing
 )
@@ -54,7 +52,6 @@ rhel9_skip_array=(
   gh595       # proxy-cmdline failing on all scenarios
   gh604       # packages-weakdeps: "gnupg2 --recommends has changed, test needs to be updated"
   gh641       # packages-multilib failing on systemd conflict
-  gh774       # autopart-luks-1 failing
   gh804       # tests requiring dvd iso failing
 )
 


### PR DESCRIPTION
The test flakiness seems to have disappeared.