### PR TITLE
Simplify test query generation

### DIFF
--- a/scripts/generate-permian-query.py
+++ b/scripts/generate-permian-query.py
@@ -38,9 +38,7 @@ if __name__ == "__main__":
     conditions = []
     if args.tests:
         conditions = [
-            "("
-            + " or ".join(['tc.name == "{}"'.format(test) for test in args.tests])
-            + ")"
+            "(tc.name in " + str(args.tests).replace('\'', '"') + ")"
         ]
         if args.skip_testtypes:
             skiptypes = ','.join(itertools.chain(*args.skip_testtypes)).split(',')


### PR DESCRIPTION
When there was a high number of tests to run, the query got very long and the final Permian query statement contained too many nested parentheses after evaluation, which subsequently resulted in `SyntaxError: too many nested parentheses` exception.

Originally I bumped into this issue when running `/test-os-variants` on PR #1517 (see https://github.com/rhinstaller/kickstart-tests/actions/runs/18127133313/job/51584849615#step:15:104).

When applied tentatively on PR #1517 (will be removed), the resulting query worked fine (see https://github.com/rhinstaller/kickstart-tests/actions/runs/18158778499/job/51684711139#step:15:37)