### PR TITLE
Run disabled tests regularly only on Sunday and Monday (4 AM)

### DIFF
--- a/.github/workflows/disabled-tests.yml
+++ b/.github/workflows/disabled-tests.yml
@@ -3,7 +3,7 @@ name: Run disabled tests
 on:
   schedule:
     # run after daily-boot-iso.yml
-    - cron: 0 4 * * *
+    - cron: 0 4 * * 0,1
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Given we have 4 runners and 6 os variants now with fedora-eln, we should think twice how to use our resources. The test would block all 4 runners when run. It runs ~1h per runner/os variant.

It is always possible to trigger the run manually if we want for example check flakiness of some test more closely.

Thank you @jstodola for suggesting smaller frequency.