### PR TITLE
fedora-eln test fix/skip

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -92,6 +92,7 @@ fedora_eln_skip_array=(
 )
 
 fedora_eln_disabled_array=(
+  gh1213      # harddrive-iso-single failing
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/image-deployment-2-rhel8.sh
+++ b/image-deployment-2-rhel8.sh
@@ -17,7 +17,7 @@
 #
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="image-deployment skip-on-fedora skip-on-rhel-9 skip-on-rhel-10 skip-on-centos-10"
+TESTTYPE="image-deployment skip-on-fedora skip-on-rhel-9 skip-on-rhel-10 skip-on-centos-10 skip-on-fedora-eln"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/reqpart.ks.in
+++ b/reqpart.ks.in
@@ -31,7 +31,11 @@ cp /.buildstamp /mnt/sysroot
 platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
 
 expected_fstype="ext4"
-if [ "${platform:0:4}" == "rhel" ] || [ "${platform:0:6}" == "centos" ] || grep -qi '^variant=server' /.buildstamp; then
+if [ "${platform:0:4}" == "rhel" ] || \
+    [ "${platform:0:6}" == "centos" ] || \
+    [ "${platform}" == "fedora-eln" ] || \
+    grep -qi '^variant=server' /.buildstamp
+then
     expected_fstype="xfs"
 fi
 


### PR DESCRIPTION
- image-deployment-2-rhel8 is limited to RHEL-8 only
- harddrive-iso-single fails due to #1213 
- reqpart had to be fixed to work with fedora-eln (missed in the previous enablement)