### PR TITLE
Add kickstart tests for the bootc based source

### DIFF
--- a/basic-bootc.ks.in
+++ b/basic-bootc.ks.in
@@ -1,0 +1,20 @@
+# Substitute something in for REPO or this will all come crashing down.
+bootc --source-imgref=registry:quay.io/fedora-testing/fedora-bootc:rawhide-standard --stateroot=default
+
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%post --nochroot
+mkdir -p /mnt/sysimage/root/
+echo SUCCESS > /mnt/sysimage/root/RESULT
+%end

--- a/basic-bootc.sh
+++ b/basic-bootc.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Copyright (C) 2025  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Paweł Poławski <ppolawsk@redhat.com> 
+
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
+TESTTYPE="knownfailure payload"
+
+. ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Bootc is a new way of deploying images added to the Anaconda. Those tests cover basic testing schema validating the installed system image.