### PR TITLE
Disable mountpoint-assignment-plain on rhel-9 (rhel16355)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -62,6 +62,7 @@ rhel9_disabled_array=(
   gh604       # packages-weakdeps: "gnupg2 --recommends has changed, test needs to be updated"
   gh641       # packages-multilib failing on systemd conflict
   gh804       # tests requiring dvd iso failing
+  rhel16355   # mountpoint-assigment-plain waiting for feature release
 )
 
 rhel10_centos10_disabled_array=(

--- a/mountpoint-assignment-plain.sh
+++ b/mountpoint-assignment-plain.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="mount storage"
+TESTTYPE="mount storage rhel16355"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Until RHEL-16355 is released