### PR TITLE
Disable groups-and-envs-* on rhel instead of skipping (gh1536)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -64,6 +64,7 @@ rhel9_disabled_array=(
   gh641       # packages-multilib failing on systemd conflict
   gh804       # tests requiring dvd iso failing
   rhel16355   # mountpoint-assigment-plain waiting for feature release
+  gh1536      # groups-and-envs-* failing
 )
 
 rhel10_centos10_disabled_array=(
@@ -72,6 +73,7 @@ rhel10_centos10_disabled_array=(
   gh1090      # raid-1-reqpart failing
   gh1207      # packages-multilib failing
   gh1213      # harddrive-iso-single failing
+  gh1536      # groups-and-envs-* failing
 )
 
 rhel10_skip_array=(
@@ -105,6 +107,7 @@ fedora_eln_disabled_array=(
   gh1335      # image-deployment-2 failing
   gh1533      # rpm-ostree-container-* tests failing
   gh1534      # proxy-cmdline
+  gh1536      # groups-and-envs-* failing
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/groups-and-envs-1.sh
+++ b/groups-and-envs-1.sh
@@ -20,6 +20,6 @@
 # FIXME: times out on rhel8
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging payload skip-on-rhel skip-on-centos skip-on-fedora-eln"
+TESTTYPE="packaging payload gh1536"
 
 . ${KSTESTDIR}/functions.sh

--- a/groups-and-envs-2.sh
+++ b/groups-and-envs-2.sh
@@ -20,7 +20,7 @@
 # FIXME: times out on rhel8
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging payload skip-on-rhel skip-on-centos skip-on-fedora-eln gh1514"
+TESTTYPE="packaging payload gh1536 gh1514"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/groups-and-envs-3.sh
+++ b/groups-and-envs-3.sh
@@ -21,6 +21,6 @@
 # "Fedora Server default environment was not installed"
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging payload skip-on-rhel skip-on-centos skip-on-fedora-eln"
+TESTTYPE="packaging payload gh1536"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Part of [INSTALLER-4419](https://issues.redhat.com/browse/INSTALLER-4419)