### PR TITLE
Enable network-bootopts-noautodefault on fedora-eln

### DIFF
--- a/network-bootopts-noautodefault.sh
+++ b/network-bootopts-noautodefault.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="network skip-on-rhel skip-on-centos skip-on-fedora-eln"
+TESTTYPE="network skip-on-rhel skip-on-centos"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
The inst.noautodefault should work on Fedora ELN (for N==11)

Part of [INSTALLER-4419](https://issues.redhat.com/browse/INSTALLER-4419)