### PR TITLE
Revert "Disable image-deployment-2 on fedora for gh1335"

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -20,7 +20,6 @@ fedora_disabled_array=(
   rhbz1853668 # multipath device not constructed back after installation
   gh975       # packages-default failing
   gh1023      # rpm-ostree failing
-  gh1335      # image-deployment-2 failing
   gh1437      # lvm-cache-* failing
   gh1493      # dns-global-exclusive-tls-* failing
   gh1530      # dns-global-exclusive-tls-* stage2-from-compose failing

--- a/image-deployment-2.sh
+++ b/image-deployment-2.sh
@@ -17,7 +17,7 @@
 #
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="image-deployment skip-on-rhel-8 skip-on-rhel-9 gh1335"
+TESTTYPE="image-deployment skip-on-rhel-8 skip-on-rhel-9"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
This reverts commit 270e5c0698a7e7df2069dd28a47070f4961b009a.

Passes when checking disabled tests: https://github.com/rhinstaller/kickstart-tests/actions/runs/19023832839/job/54323909239, fixed by https://github.com/rhinstaller/kickstart-tests/pull/1546 I think