### PR TITLE
Revert "Disable groups-and-envs-2 until gh1514 is fixed"

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -24,7 +24,6 @@ fedora_disabled_array=(
   gh1437      # lvm-cache-* failing
   gh1493      # dns-global-exclusive-tls-* failing
   gh1530      # dns-global-exclusive-tls-* stage2-from-compose failing
-  gh1514      # groups-and-envs-2 failing
 )
 
 daily_iso_disabled_array=(

--- a/groups-and-envs-2.sh
+++ b/groups-and-envs-2.sh
@@ -20,7 +20,7 @@
 # FIXME: times out on rhel8
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging payload gh1536 gh1514"
+TESTTYPE="packaging payload gh1536"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
This reverts commit d118d24e298245ac8af2efe600e3d2887010180f.

Passes when checking disabled tests: https://github.com/rhinstaller/kickstart-tests/actions/runs/19023832839/job/54323909239