### PR TITLE
Revert "Disable mountpoint-assignment-plain on rhel-9 (rhel16355)"

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -59,7 +59,6 @@ rhel9_disabled_array=(
   gh595       # proxy-cmdline failing on all scenarios
   gh604       # packages-weakdeps: "gnupg2 --recommends has changed, test needs to be updated"
   gh804       # tests requiring dvd iso failing
-  rhel16355   # mountpoint-assigment-plain waiting for feature release
   gh1536      # groups-and-envs-* failing
   gh1538      # packages-ignorebroken not implemented
 )

--- a/mountpoint-assignment-plain.sh
+++ b/mountpoint-assignment-plain.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="mount storage rhel16355"
+TESTTYPE="mount storage"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
This reverts commit c31f0bfeeec9bf0334a0ed6227a84ac422aad5ee.