### PR TITLE
Update VM RAM for tests downloading installer image (gh1420) (gh1389)

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -67,7 +67,7 @@ USER_NET_HOST_IP=10.0.2.2
 COPY_FROM_IMAGE_TIMEOUT=300s
 
 # The RAM required in case stage2_from_ks is used
-export STAGE2_FROM_COMPOSE_RAM_SIZE=3400
+export STAGE2_FROM_COMPOSE_RAM_SIZE=3700
 
 kernel_args() {
     echo $DEFAULT_BOOTOPTS


### PR DESCRIPTION
The stage2 image has increased:
current 9.8 size: 1454MiB

The last update: commit 26a07458afe75e6b2fde65709f79bf6af29b7f93