### PR TITLE
Reenable harddrive payload tests on rhel 10 variants

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -66,7 +66,6 @@ rhel9_disabled_array=(
 
 rhel10_centos10_disabled_array=(
   gh576       # clearpart-4 test is flaky on all scenarios
-  gh804       # tests requiring dvd iso failing
   gh1090      # raid-1-reqpart failing
   gh1207      # packages-multilib failing
   gh1213      # harddrive-iso-single failing


### PR DESCRIPTION
Based on results of [regular disabled test runs](https://github.com/rhinstaller/kickstart-tests/actions/workflows/disabled-tests.yml) let's try to re-enable the tests at least on rhel 10 variants. We should have covered those against regressions.