### PR TITLE
Fix --force option of generate-launch-args script

### DIFF
--- a/scripts/generate-launch-args.py
+++ b/scripts/generate-launch-args.py
@@ -151,9 +151,11 @@ if __name__ == "__main__":
     if testtypes:
         testtypes_args = ["--testtypes", ",".join(testtypes)]
 
-    skip_testtypes = [] if args.force else skipped_testtypes
+    skip_testtypes = skipped_testtypes
     if not args.disabled:
         skip_testtypes.extend(disabled_testtypes)
+    if args.force:
+        skip_testtypes = []
     if args.skip_testtypes:
         skip_testtypes.extend(args.skip_testtypes.split(','))
     if skip_testtypes:


### PR DESCRIPTION
The option was broken by commit aae9d5103e21cdb8138dc97069da4323af328fb5 which made it skipping disabled tests.

Related: INSTALLER-4293