### PR TITLE
Update doc for test-os-variants workflow

### DIFF
--- a/.github/workflows/test-os-variants.yml
+++ b/.github/workflows/test-os-variants.yml
@@ -10,6 +10,10 @@
 #
 #  /test-os-variants --testtype TESTTYPE --testtypes TYPE[,TYPE..] --skip-testtypes TYPE[,TYPE..] TEST1 TEST2
 #
+# In this case disabled or platform-skipped tests are not excluded
+# automatically.  To exclude them you can generate respective --skip-testtypes
+# update by generate-launch-args script.
+#
 # Examples:
 #
 # /test-os-variants keyboard lang


### PR DESCRIPTION
Document the current behavior.
Potential change of the behavior, for example skipping disabled and platform-skipped tests automatically also in case of explicit parameters setting (same as when bare `/test-os-variants` is called), with the option of adding `--force` by user to the comment to get the current behavior is for another task.