### PR TITLE
Reenable dns-global-exclusive-tls-* tests disabled for gh1493

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -21,7 +21,6 @@ fedora_disabled_array=(
   gh975       # packages-default failing
   gh1023      # rpm-ostree failing
   gh1437      # lvm-cache-* failing
-  gh1493      # dns-global-exclusive-tls-* failing
   gh1530      # dns-global-exclusive-tls-* stage2-from-compose failing
 )
 

--- a/dns-global-exclusive-tls-2.sh
+++ b/dns-global-exclusive-tls-2.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"network dns skip-on-rhel gh1493"}
+TESTTYPE=${TESTTYPE:-"network dns skip-on-rhel"}
 
 . ${KSTESTDIR}/functions.sh
 

--- a/dns-global-exclusive-tls-httpks-2.sh
+++ b/dns-global-exclusive-tls-httpks-2.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"network dns skip-on-rhel gh1493"}
+TESTTYPE=${TESTTYPE:-"network dns skip-on-rhel"}
 KICKSTART_NAME=dns-global-exclusive-tls-2
 # FIXME: the test would ideally require name resolution to fetch the kickstart
 

--- a/dns-global-exclusive-tls-httpks.sh
+++ b/dns-global-exclusive-tls-httpks.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"network dns gh1493"}
+TESTTYPE=${TESTTYPE:-"network dns"}
 KICKSTART_NAME=dns-global-exclusive-tls
 
 . ${KSTESTDIR}/functions.sh

--- a/dns-global-exclusive-tls.sh
+++ b/dns-global-exclusive-tls.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"network dns gh1493"}
+TESTTYPE=${TESTTYPE:-"network dns"}
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
According to the latest disabled tests run the issue seems to be fixed (https://github.com/rhinstaller/kickstart-tests/issues/1493#issuecomment-3737422773).