### PR TITLE
Add bootc UEFI kickstart test

### DIFF
--- a/bootc-uefi.ks.in
+++ b/bootc-uefi.ks.in
@@ -1,0 +1,49 @@
+# Test the UEFI entry is created correctly and the system is bootable with bootc.
+#
+
+# Use the default settings.
+%ksappend common/common_no_storage_and_payload.ks
+# On Fedora enforce lvm scheme (overriding btrfs default)
+%ksappend storage/ostreecontainer_autopart.ks
+
+# Setup the bootc image source.
+bootc --source-imgref=registry:@KSTEST_OSTREECONTAINER_URL@ --stateroot=test-stateroot
+
+# Reboot the installed system.
+reboot
+
+# Validate on the first boot.
+%ksappend validation/success_on_first_boot.ks
+
+%post
+# Checks after boot
+cat >> /var/lib/extensions/kickstart-tests/usr/libexec/kickstart-test.sh << 'EOF'
+
+# propagate any errors from %post validations
+if [ -e /root/RESULT ]; then
+    cat /root/RESULT
+fi
+
+# Check that state root 'test-stateroot' exists
+if [ ! -d /ostree/deploy/test-stateroot ]; then
+    echo "Couldn't find 'test-stateroot' stateroot"
+fi
+
+# Check that bootupd information is present
+if [ ! -e /boot/bootupd-state.json ]; then
+    echo "/boot/bootupd-state.json not found on installed system after booting"
+fi
+
+bootupctl --help &> /dev/null || echo "bootupctl command not available after booting"
+bootc --help &> /dev/null || echo "bootc command not available after booting"
+
+# We need to use tr because sometimes there is newline inside of the efibootmgr entry line :(
+# Normalize whitespace (tabs/newlines) to spaces, then squeeze multiple spaces to single space
+efibootmgr | tr '\n\t' ' ' | tr -s ' ' | grep -qiE 'Boot0001.*(Fedora|Red Hat Enterprise Linux|CentOS Stream)'
+if [ $? -ne 0 ]; then
+    echo -e "EFI boot entry wasn't created properly:\n$(efibootmgr)"
+fi
+
+EOF
+%end
+

--- a/bootc-uefi.sh
+++ b/bootc-uefi.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+#
+# Copyright (C) 2025  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
+TESTTYPE="skip-on-rhel-9 payload uefi bootc reboot rhel58215 gh1574"
+
+. ${KSTESTDIR}/functions.sh
+
+enable_uefi() {
+    echo "true"
+}
+
+copy_interesting_files_from_system() {
+    local disksdir
+    disksdir="${1}"
+
+    # Find disks.
+    local args
+    args=$(for d in ${disksdir}/disk-*img; do echo -a ${d}; done)
+
+    # Use also iscsi disk if there is any.
+    if [[ -n ${iscsi_disk_img} ]]; then
+        args="${args} -a ${disksdir}/${iscsi_disk_img}"
+    fi
+
+    # Grab files out of the installed system while it still exists.
+    # Grab these files:
+    #
+    # logs from Anaconda - whole /var/log/anaconda/ directory is copied out,
+    #                      this can be used for saving specific test output
+    # original-ks.cfg - the kickstart used for the test
+    # anaconda-ks.cfg - the kickstart saved after installation, useful for
+    #                   debugging
+    # RESULT - file from the test
+    #
+    # The location of aforementioned files is different in an ostree system
+
+    root_device=$(guestfish ${args} <<< "
+        launch
+        lvs" | \
+        grep root)
+
+    for item in /ostree/deploy/test-stateroot/var/roothome/original-ks.cfg \
+                /ostree/deploy/test-stateroot/var/roothome/anaconda-ks.cfg \
+                /ostree/deploy/test-stateroot/var/roothome/anabot.log \
+                /ostree/deploy/test-stateroot/var/log/anaconda/ \
+                /ostree/deploy/test-stateroot/var/roothome/RESULT
+    do
+        guestfish ${args} <<< "
+            launch
+            mount ${root_device} /
+            copy-out '${item}' '${disksdir}'
+            " 2>/dev/null
+    done
+}
+
+additional_runner_args() {
+   # Wait for reboot and shutdown of the VM,
+   # but exit after the specified timeout.
+   echo "--wait $(get_timeout)"
+}
+


### PR DESCRIPTION
Similar to rpm-ostree-container-uefi.sh, this test validates that bootc installations create UEFI boot entries correctly and the system is bootable. The test uses the bootc command instead of ostreecontainer and validates UEFI boot entry creation, bootc/bootupd availability, and vconsole kernel arguments.

Note: Fedora boot entry is third on the efibootmgr list.
<img width="943" height="707" alt="Screenshot 2026-01-12 at 16-48-10 Virtual machines - kkoukiou@easy box" src="https://github.com/user-attachments/assets/012f284e-6ee3-4dc7-900b-e337a2a8d68d" />
