### PR TITLE
Fix RAID tests: find rootfs device directly

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -173,6 +173,15 @@ copy_out ${file} ${dir}
 "
 }
 
+# Find the device with the rootfs label. The by-label symlink may not
+# be available in libguestfs appliance until after mounting, so we need to
+# find the device directly. Use virt-filesystems to list filesystems with
+# labels, which doesn't require mounting.
+find_rootfs_device() {
+    local args="$1"
+    run_with_timeout ${COPY_FROM_IMAGE_TIMEOUT} "virt-filesystems --long ${args}" 2>&1 | awk '/rootfs/ {print $1}' | head -1
+}
+
 copy_interesting_files_from_system() {
     local disksdir="$1"
 

--- a/lvm-raid-1.sh
+++ b/lvm-raid-1.sh
@@ -35,3 +35,19 @@ prepare_disks() {
     echo ${tmpdir}/disk-b.img
     echo ${tmpdir}/disk-c.img
 }
+
+validate() {
+    disksdir=$1
+    args=$(for d in ${disksdir}/disk-*img; do echo -a ${d}; done)
+
+    rootfs_device=$(find_rootfs_device "${args}")
+
+    # Use virt-copy-out with explicit mount point since inspection mode may fail
+    # to find the root filesystem on RAID+LVM setups.
+    if [[ -n "$rootfs_device" ]]; then
+        run_with_timeout ${COPY_FROM_IMAGE_TIMEOUT} "virt-copy-out ${args} -m ${rootfs_device} /root/RESULT ${disksdir}" 2>/dev/null
+    fi
+
+    validate_RESULT ${disksdir}
+    return $?
+}

--- a/raid-1.sh
+++ b/raid-1.sh
@@ -35,10 +35,12 @@ validate() {
     disksdir=$1
     args=$(for d in ${disksdir}/disk-*img; do echo -a ${d}; done)
 
+    rootfs_device=$(find_rootfs_device "${args}")
+
     # There should be a /root/RESULT file with results in it.  Check
     # its contents and decide whether the test finally succeeded or
     # not.
-    result=$(run_with_timeout ${COPY_FROM_IMAGE_TIMEOUT} "virt-cat ${args} -m /dev/disk/by-label/rootfs /root/RESULT")
+    result=$(run_with_timeout ${COPY_FROM_IMAGE_TIMEOUT} "virt-cat ${args} -m ${rootfs_device} /root/RESULT")
     if [[ $? != 0 ]]; then
         status=1
         echo '*** /root/RESULT does not exist in VM image.'


### PR DESCRIPTION
/dev/disk/by-label/rootfs is not available in libguestfs appliance.

For non-encrypted RAID tests (raid-1, lvm-raid-1):
- Use virt-filesystems to find the device with rootfs label directly