### PR TITLE
Disable raid KS tests because of gh1586

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -22,6 +22,7 @@ fedora_disabled_array=(
   gh1023      # rpm-ostree failing
   gh1437      # lvm-cache-* failing
   gh1530      # dns-global-exclusive-tls-* stage2-from-compose failing
+  gh1586      # raid tests failing
 )
 
 daily_iso_disabled_array=(
@@ -112,6 +113,7 @@ fedora_eln_disabled_array=(
   gh1538      # packages-ignorebroken not implemented
   gh1541      # flatpak-preinstall-* not implemented
   gh1574      # bootc-* failing
+  gh1586      # raid tests failing
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/lvm-raid-1.sh
+++ b/lvm-raid-1.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="lvm storage"
+TESTTYPE="lvm storage gh1586"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/lvm-raid-2.sh
+++ b/lvm-raid-2.sh
@@ -21,7 +21,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="lvm storage gh1414"
+TESTTYPE="lvm storage gh1414 gh1586"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-1.sh
+++ b/raid-1.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"raid storage coverage smoke"}
+TESTTYPE=${TESTTYPE:-"raid storage coverage smoke gh1586"}
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-luks-1.sh
+++ b/raid-luks-1.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage raid luks"
+TESTTYPE="storage raid luks gh1586"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-luks-2.sh
+++ b/raid-luks-2.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage raid luks"
+TESTTYPE="storage raid luks gh1586"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-luks-3.sh
+++ b/raid-luks-3.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage raid luks"
+TESTTYPE="storage raid luks gh1586"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-luks-4.sh
+++ b/raid-luks-4.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage raid luks"
+TESTTYPE="storage raid luks gh1586"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Tests are failing on daily-iso and fedora-eln scenarios since Jan 23 2026. Affected tests:
- lvm-raid-1
- lvm-raid-2
- raid-1
- raid-luks-1
- raid-luks-2
- raid-luks-3
- raid-luks-4

Related: https://github.com/rhinstaller/kickstart-tests/issues/1586