### PR TITLE
fix: add DRACUT_NO_XATTR=1 workaround for boot.iso builds

### DIFF
--- a/.github/workflows/daily-boot-iso-rawhide.yml
+++ b/.github/workflows/daily-boot-iso-rawhide.yml
@@ -57,6 +57,10 @@ jobs:
           # build boot.iso with our rpms
           echo "::group::Build boot.iso with the RPMs"
           . /etc/os-release
+          # Workaround for dracut xattr issues in containers
+          # See https://bugzilla.redhat.com/show_bug.cgi?id=2358683#c14
+          # and https://github.com/dracut-ng/dracut-ng/issues/443
+          export DRACUT_NO_XATTR=1
           # The download.fedoraproject.org automatic redirector often selects download-ib01.f.o. for GitHub's cloud, which is too unreliable; use a mirror
           # The --volid argument can cause different network interface naming: https://github.com/rhinstaller/kickstart-tests/issues/448
           # FIXME: remove the dnf5-unstable when the stuff goes into stable repo


### PR DESCRIPTION
Add DRACUT_NO_XATTR=1 environment variable before lorax command to fix dracut xattr issues in containers that prevent systemd-sysroot-fstab-check from being included in the initramfs, causing bootc test failures.

This matches the fix applied in anaconda-iso-creator container's lorax-build script. See https://github.com/rhinstaller/anaconda/pull/6876