### PR TITLE
Fix rootpw-crypted.ks.in: use proper crypted password hash

### DIFF
--- a/rootpw-crypted.ks.in
+++ b/rootpw-crypted.ks.in
@@ -14,7 +14,7 @@ lang en
 timezone America/New_York
 
 # let's consider this password to be an laready crypted string
-rootpw --iscrypted qweqwe
+rootpw --iscrypted $6$s81m..s71YQx7ynQ$v.iLP4CEzCduq4X.L2ALM6XfjTk0GrBrAi3q1Eiqhaimvlf5jjCfiE5uzz4EzaKQcu1NtB/bSchcxexrQez4U1
 
 shutdown
 
@@ -38,7 +38,8 @@ with open("/root/RESULT", "wt") as result:
             print("Unable to find root password", file=result)
             sys.exit(0)
 
-    if "qweqwe" != shadow_fields[1]:
+    expected_hash = "$6$s81m..s71YQx7ynQ$v.iLP4CEzCduq4X.L2ALM6XfjTk0GrBrAi3q1Eiqhaimvlf5jjCfiE5uzz4EzaKQcu1NtB/bSchcxexrQez4U1"
+    if expected_hash != shadow_fields[1]:
         print("Root password is not correct: %s" % shadow_fields[1], file=result)
         sys.exit(0)
 


### PR DESCRIPTION
Replace the invalid plaintext 'qweqwe' with a proper SHA-512 crypted password hash. The crypted password was generated using Python's crypt module with SHA-512 method:

  python3 -c "import crypt; print(crypt.crypt('qweqwe', crypt.mksalt(crypt.METHOD_SHA512)))"

This generates a hash in the format: $6$salt$hash

Some recent release from shadow-utils has made password validation checks tighter.