### PR TITLE
Fix fedora-live-image-build.ks.in: remove --iscrypted from locked rootpw

### DIFF
--- a/fedora-live-image-build.ks.in
+++ b/fedora-live-image-build.ks.in
@@ -14,7 +14,7 @@ xconfig  --startxonboot
 # Keyboard layouts
 keyboard 'us'
 # Root password
-rootpw --iscrypted --lock locked
+rootpw --lock
 # System language
 lang en_US.UTF-8
 # Shutdown after installation


### PR DESCRIPTION
The rootpw command was using both --iscrypted and --lock flags together, which is invalid. The --iscrypted flag requires a password hash value, but --lock is used to lock the account without setting a password.

Recent releases from shadow-utils may have made password validation checks tighter, causing 'Unable to set password for new user: status=1' errors when --iscrypted is used without a valid password hash.

Fix by removing --iscrypted and using only --lock.