### PR TITLE
Remove lorax-lmc-virt from Dockerfile

### DIFF
--- a/containers/runner/Dockerfile
+++ b/containers/runner/Dockerfile
@@ -12,7 +12,6 @@ RUN dnf -y update && \
     libvirt-daemon-proxy \
     guestfs-tools \
     genisoimage \
-    lorax-lmc-virt \
     parallel \
     python3-libvirt \
     createrepo_c \


### PR DESCRIPTION
This package is not used, therefore removed.