### PR TITLE
Re-enable packages-weakdeps test on RHEL

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -57,7 +57,6 @@ rhel9_skip_array=(
 rhel9_disabled_array=(
   gh576       # clearpart-4 test is flaky on all scenarios
   gh595       # proxy-cmdline failing on all scenarios
-  gh604       # packages-weakdeps: "gnupg2 --recommends has changed, test needs to be updated"
   gh804       # tests requiring dvd iso failing
   gh1536      # groups-and-envs-* failing
   gh1538      # packages-ignorebroken not implemented
@@ -71,7 +70,6 @@ rhel10_centos10_disabled_array=(
   gh1213      # harddrive-iso-single failing
   gh1536      # groups-and-envs-* failing
   gh1538      # packages-ignorebroken not implemented
-  gh604       # packages-weakdeps: "gnupg2 --recommends has changed, test needs to be updated"
 )
 
 rhel10_skip_array=(

--- a/packages-weakdeps.ks.in
+++ b/packages-weakdeps.ks.in
@@ -10,14 +10,24 @@
 %ksappend payload/packages_weakdeps.ks
 
 %post
-# Make sure the --recommends packages from gnupg2 are not installed
+@KSINCLUDE@ scripts-lib.sh
+platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
+
+# Make sure the weak dependencies from gnupg2 are not installed
 if rpm -q pinentry ; then
     echo "pinentry was installed" >> /root/RESULT
 fi
 
-# Check that gnupg2's --recommends did not change unexpectedly
-if ! ( rpm -q --recommends gnupg2 | grep -q pinentry ) ; then
-    echo "gnupg2 --recommends has changed, test needs to be updated" >> /root/RESULT
+# Check that gnupg2's weak dependencies include pinentry
+if [ "${platform:0:4}" == "rhel" ] || [ "${platform:0:6}" == "centos" ]; then
+    if ! ( rpm -q --suggests gnupg2 | grep -q pinentry ) ; then
+        echo "gnupg2 --suggests has changed, test needs to be updated" >> /root/RESULT
+    fi
+else
+    # Fedora and Fedora ELN
+    if ! ( rpm -q --recommends gnupg2 | grep -q pinentry ) ; then
+        echo "gnupg2 --recommends has changed, test needs to be updated" >> /root/RESULT
+    fi
 fi
 
 %ksappend validation/success_if_result_empty.ks

--- a/packages-weakdeps.sh
+++ b/packages-weakdeps.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging payload gh604"
+TESTTYPE="packaging payload"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Update the packages-weakdeps test to check --suggests on RHEL/CentOS instead of --recommends for pinentry.

Resolves: #604