### PR TITLE
Re-enable rootpw-basic and rootpw-lock tests on ELN

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -98,7 +98,6 @@ fedora_eln_skip_array=(
 fedora_eln_disabled_array=(
   gh1213      # harddrive-iso-single failing
   gh1090      # raid-1-reqpart failing
-  gh1527      # rootpw-basic and rootpw-lock failing
   gh1207      # packages-multilib failing
   gh975       # packages-default failing
   gh1530      # dns-global-exclusive-tls-* stage2-from-compose failing

--- a/fragments/platform/fedora-eln/payload/python_crypt_packages.ks
+++ b/fragments/platform/fedora-eln/payload/python_crypt_packages.ks
@@ -1,3 +1,0 @@
-%packages
-python3
-%end

--- a/rootpw-basic.sh
+++ b/rootpw-basic.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="users coverage gh1527"
+TESTTYPE="users coverage"
 
 . ${KSTESTDIR}/functions.sh

--- a/rootpw-lock.sh
+++ b/rootpw-lock.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="users coverage gh1527"
+TESTTYPE="users coverage"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Related: https://github.com/rhinstaller/anaconda/pull/6889
Resolves: gh1527