### PR TITLE
Revert "Remove lorax-lmc-virt from Dockerfile"

### DIFF
--- a/containers/runner/Dockerfile
+++ b/containers/runner/Dockerfile
@@ -12,6 +12,7 @@ RUN dnf -y update && \
     libvirt-daemon-proxy \
     guestfs-tools \
     genisoimage \
+    lorax-lmc-virt \
     parallel \
     python3-libvirt \
     createrepo_c \


### PR DESCRIPTION
This reverts commit 29505b33ba8243cd8260485cbf02a773ddb2c951.

The package is needed, pylorax is imported.