### PR TITLE
Force restorecon on /etc/X11/xorg.conf.d for container iso builds (gh…

### DIFF
--- a/reboot-initial-setup-gui.ks.in
+++ b/reboot-initial-setup-gui.ks.in
@@ -36,6 +36,13 @@ gdm
 
 %post
 
+# FIXME - https://github.com/rhinstaller/kickstart-tests/issues/1607
+@KSINCLUDE@ scripts-lib.sh
+platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
+if [ "${platform}" == "rhel9" ]; then
+  restorecon -irF /etc/X11/xorg.conf.d
+fi
+
 # Remove EULA if any.
 rm /usr/share/redhat-release/EULA
 

--- a/reboot-initial-setup-tui.ks.in
+++ b/reboot-initial-setup-tui.ks.in
@@ -23,6 +23,13 @@ initial-setup
 
 %post
 
+# FIXME - https://github.com/rhinstaller/kickstart-tests/issues/1607
+@KSINCLUDE@ scripts-lib.sh
+platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
+if [ "${platform}" == "rhel9" ]; then
+  restorecon -irF /etc/X11/xorg.conf.d
+fi
+
 # Remove EULA if any.
 rm /usr/share/redhat-release/EULA
 


### PR DESCRIPTION
…1607)

Obsoletes: https://github.com/rhinstaller/anaconda/pull/6916
Issue for build-time (Lorax) approach: https://github.com/weldr/lorax/issues/1506

If boot.iso is created (by lorax) in a container the /etc/X11/xorg.conf.d directory created in the image has container_file_t and therefore /etc/X11/xorg.conf.d/00-keyboard.conf created during installation will have the same type. This type will require forcing by -F option when restoring selinux context at the end of installation. Otherwise it would not be applied with "not reset as customized by admin" message.

In non-container / official builds the file would have (as all files in
the image) system_u:object_r:var_lib_t:s0 which would be restored at the
end of installation without the need of -F option.

Related: INSTALLER-4605