### PR TITLE
Force restorecon on 00-keyboard.conf for container iso builds (gh1607)

### DIFF
--- a/reboot-initial-setup-gui.ks.in
+++ b/reboot-initial-setup-gui.ks.in
@@ -40,7 +40,7 @@ gdm
 @KSINCLUDE@ scripts-lib.sh
 platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
 if [ "${platform}" == "rhel9" ]; then
-  restorecon -irF /etc/X11/xorg.conf.d
+  restore_container_file_context /etc/X11/xorg.conf.d/00-keyboard.conf
 fi
 
 # Remove EULA if any.

--- a/reboot-initial-setup-tui.ks.in
+++ b/reboot-initial-setup-tui.ks.in
@@ -27,7 +27,7 @@ initial-setup
 @KSINCLUDE@ scripts-lib.sh
 platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
 if [ "${platform}" == "rhel9" ]; then
-  restorecon -irF /etc/X11/xorg.conf.d
+  restore_container_file_context /etc/X11/xorg.conf.d/00-keyboard.conf
 fi
 
 # Remove EULA if any.

--- a/scripts-lib.sh
+++ b/scripts-lib.sh
@@ -38,3 +38,18 @@ function dumps_default_cons {
         echo "no"
     fi
 }
+
+# restore_container_file_context PATH
+# Conditionally restore SELinux context if file or directory has container_file_t context.
+# This addresses gh1607 where container builds cause incorrect contexts.
+function restore_container_file_context {
+    local path=$1
+
+    # Check if file or directory exists and has container_file_t context
+    if [ -e "${path}" ]; then
+        current_context=$(stat -c %C "${path}" 2>/dev/null || echo "")
+        if echo "$current_context" | grep -q "container_file_t"; then
+            restorecon -irF "${path}"
+        fi
+    fi
+}

--- a/selinux-contexts.ks.in
+++ b/selinux-contexts.ks.in
@@ -12,6 +12,14 @@ reboot
 # Set up the actual test.
 %post
 
+# Force restorecon on selected container_file_t contexts.
+# https://github.com/rhinstaller/kickstart-tests/issues/1607
+@KSINCLUDE@ scripts-lib.sh
+platform="$(get_platform @KSTEST_OS_NAME@ @KSTEST_OS_VERSION@)"
+if [ "${platform}" == "rhel9" ]; then
+  restore_container_file_context /etc/X11/xorg.conf.d/00-keyboard.conf
+fi
+
 # Make sure something doesn't fix the labels before we can check them.
 systemctl disable selinux-autorelabel.service
 


### PR DESCRIPTION
If boot.iso is created (by lorax) in a container the
/etc/X11/xorg.conf.d directory created in the image has container_file_t
and therefore /etc/X11/xorg.conf.d/00-keyboard.conf created during
installation will have the same type. This type will require forcing by
-F option when restoring selinux context at the end of installation.
Otherwise it would not be applied with "not reset as customized by
admin" message.

In non-container / official builds the file would have (as all files in
the image) system_u:object_r:var_lib_t:s0 which would be restored at the
end of installation without the need of -F option.

Related: INSTALLER-4605