### PR TITLE
Revert "Disable selinux-contexts on daily-iso (gh1596)"

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -29,7 +29,6 @@ fedora_disabled_array=(
 daily_iso_disabled_array=(
   gh1434      # reboot-inital-setup-* failing
   gh910       # stage2-from-ks test needs to be fixed for daily-iso
-  gh1596      # selinux-contexts failing
 )
 
 rawhide_disabled_array=(

--- a/selinux-contexts.sh
+++ b/selinux-contexts.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="security selinux gh1596"
+TESTTYPE="security selinux"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
This reverts commit 2fd4bf175a835fb50f62d378444af1721aabcbb3.

The https://github.com/rhinstaller/kickstart-tests/issues/1596 was fixed.