### PR TITLE
Revert "Disable groups-and-envs-2 on daily-iso (gh1613)"

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -22,7 +22,6 @@ fedora_disabled_array=(
   gh1023      # rpm-ostree failing
   gh1530      # dns-global-exclusive-tls-* stage2-from-compose failing
   gh1586      # raid tests failing
-  gh1613      # groups-and-envs-2 failing
   gh1612      # script-pre-install heavy flaking
 )
 

--- a/groups-and-envs-2.sh
+++ b/groups-and-envs-2.sh
@@ -20,7 +20,7 @@
 # FIXME: times out on rhel8
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging payload gh1536 gh1613"
+TESTTYPE="packaging payload gh1536"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
This reverts commit e079b1e9e0cfa60bc3d9c656a235e6728c2a4d8e.

The disabled test started passing: github.com/rhinstaller/kickstart-tests/actions/runs/e079b1e9e0cfa22562359145/job/65351423276

The issue is fixed: https://bugzilla.redhat.com/show_bug.cgi?id=2439813