### PR TITLE
Revert "Disable script-pre-install on daily-iso and fedora-eln (gh1612)"

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -22,7 +22,6 @@ fedora_disabled_array=(
   gh1023      # rpm-ostree failing
   gh1530      # dns-global-exclusive-tls-* stage2-from-compose failing
   gh1586      # raid tests failing
-  gh1612      # script-pre-install heavy flaking
   gh1618      # packages-multilib failing on daily-iso
 )
 
@@ -112,7 +111,6 @@ fedora_eln_disabled_array=(
   gh1541      # flatpak-preinstall-* not implemented
   gh1574      # bootc-* failing
   gh1586      # raid tests failing
-  gh1612      # script-pre-install heavy flaking
   gh1622      # packages-and-groups-1 failing
 )
 

--- a/script-pre-install.sh
+++ b/script-pre-install.sh
@@ -20,7 +20,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="ksscript gh1612"
+TESTTYPE="ksscript"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
This reverts commit 68a15713e5bfb5961327910602ff9c6131577023.

rhinstaller/anaconda#6958 fixed the issue, so this commit is no longer needed.