### PR TITLE
Revert "Disable packages-ignorebroken instead of skipping on rhel"

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -60,7 +60,6 @@ rhel9_disabled_array=(
   gh595       # proxy-cmdline failing on all scenarios
   gh804       # tests requiring dvd iso failing
   gh1536      # groups-and-envs-* failing
-  gh1538      # packages-ignorebroken not implemented
 )
 
 rhel10_centos10_disabled_array=(
@@ -70,7 +69,6 @@ rhel10_centos10_disabled_array=(
   gh1207      # packages-multilib failing
   gh1213      # harddrive-iso-single failing
   gh1536      # groups-and-envs-* failing
-  gh1538      # packages-ignorebroken not implemented
 )
 
 rhel10_skip_array=(
@@ -107,7 +105,6 @@ fedora_eln_disabled_array=(
   gh1533      # rpm-ostree-container-* tests failing
   gh1534      # proxy-cmdline
   gh1536      # groups-and-envs-* failing
-  gh1538      # packages-ignorebroken not implemented
   gh1541      # flatpak-preinstall-* not implemented
   gh1574      # bootc-* failing
   gh1586      # raid tests failing

--- a/packages-ignorebroken.sh
+++ b/packages-ignorebroken.sh
@@ -18,7 +18,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging payload gh1538"
+TESTTYPE="packaging payload skip-on-rhel skip-on-centos skip-on-fedora-eln"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
This reverts commit 5226c38c660679a99e0652382146ce05a7693b53.

The feature is not implemented on rhel on purpose: https://github.com/pykickstart/pykickstart/commit/f3e05227190f609e4185c14b05511b07f36bb0f4