### PR TITLE
Revert "Disable packages-and-groups-1 on fedora-eln (gh1622)"

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -104,7 +104,6 @@ fedora_eln_disabled_array=(
   gh1541      # flatpak-preinstall-* not implemented
   gh1574      # bootc-* failing
   gh1586      # raid tests failing
-  gh1622      # packages-and-groups-1 failing
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/packages-and-groups-1.sh
+++ b/packages-and-groups-1.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging payload gh1622"
+TESTTYPE="packaging payload"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
This reverts commit bfdb23ea2ee6e96f99b17ea8dd31c5d072d95591.

Seems to got fixed, it is passing now in "Disabled tests run" https://github.com/rhinstaller/kickstart-tests/actions/runs/23422830640/job/68131423094