### PR TITLE
Re-enable RAID tests

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -21,7 +21,6 @@ fedora_disabled_array=(
   gh975       # packages-default failing
   gh1023      # rpm-ostree failing
   gh1530      # dns-global-exclusive-tls-* stage2-from-compose failing
-  gh1586      # raid tests failing
   gh1618      # packages-multilib failing on daily-iso
   gh1633      # rpm-ostree-container-uefi failing with Fedora 44 runner container
 )
@@ -106,7 +105,6 @@ fedora_eln_disabled_array=(
   gh1534      # proxy-cmdline
   gh1541      # flatpak-preinstall-* not implemented
   gh1574      # bootc-* failing
-  gh1586      # raid tests failing
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/lvm-raid-1.sh
+++ b/lvm-raid-1.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="lvm storage gh1586"
+TESTTYPE="lvm storage"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/lvm-raid-2.sh
+++ b/lvm-raid-2.sh
@@ -21,7 +21,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="lvm storage gh1414 gh1586"
+TESTTYPE="lvm storage gh1414"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-1.sh
+++ b/raid-1.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"raid storage coverage smoke gh1586"}
+TESTTYPE=${TESTTYPE:-"raid storage coverage smoke"}
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-luks-1.sh
+++ b/raid-luks-1.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage raid luks gh1586"
+TESTTYPE="storage raid luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-luks-2.sh
+++ b/raid-luks-2.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage raid luks gh1586"
+TESTTYPE="storage raid luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-luks-3.sh
+++ b/raid-luks-3.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage raid luks gh1586"
+TESTTYPE="storage raid luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-luks-4.sh
+++ b/raid-luks-4.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage raid luks gh1586"
+TESTTYPE="storage raid luks"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
With the runner container now based on F44 the RAID tests should now work again, so lets re-enable them.