### PR TITLE
Disable LUKS tests on RHEL / CentOS (gh#1637)

### DIFF
--- a/autopart-encrypted-1.sh
+++ b/autopart-encrypted-1.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage coverage smoke"
+TESTTYPE="autopart storage coverage smoke gh1637"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/autopart-encrypted-2.sh
+++ b/autopart-encrypted-2.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage"
+TESTTYPE="autopart storage gh1637"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/autopart-encrypted-3.sh
+++ b/autopart-encrypted-3.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage"
+TESTTYPE="autopart storage gh1637"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/autopart-luks-1.sh
+++ b/autopart-luks-1.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage luks"
+TESTTYPE="autopart storage luks gh1637"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/autopart-luks-2.sh
+++ b/autopart-luks-2.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage luks"
+TESTTYPE="autopart storage luks gh1637"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/autopart-luks-3.sh
+++ b/autopart-luks-3.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage luks"
+TESTTYPE="autopart storage luks gh1637"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/autopart-luks-4.sh
+++ b/autopart-luks-4.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage luks"
+TESTTYPE="autopart storage luks gh1637"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/autopart-luks-5.sh
+++ b/autopart-luks-5.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage luks"
+TESTTYPE="autopart storage luks gh1637"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -60,6 +60,7 @@ rhel9_disabled_array=(
   gh595       # proxy-cmdline failing on all scenarios
   gh804       # tests requiring dvd iso failing
   gh1633      # rpm-ostree-container-uefi failing with Fedora 44 runner container
+  gh1637      # LUKS copy_file_encrypted: guestfish -i / crypttab inspect (rhbz#2452937)
 )
 
 rhel10_centos10_disabled_array=(
@@ -69,6 +70,7 @@ rhel10_centos10_disabled_array=(
   gh1207      # packages-multilib failing
   gh1213      # harddrive-iso-single failing
   gh1633      # rpm-ostree-container-uefi failing with Fedora 44 runner container
+  gh1637      # LUKS copy_file_encrypted: guestfish -i / crypttab inspect (rhbz#2452937); CentOS 10 shares this list
 )
 
 rhel10_skip_array=(

--- a/lvm-luks-1.sh
+++ b/lvm-luks-1.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage lvm luks"
+TESTTYPE="storage lvm luks gh1637"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/lvm-luks-2.sh
+++ b/lvm-luks-2.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage lvm luks"
+TESTTYPE="storage lvm luks gh1637"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/lvm-luks-3.sh
+++ b/lvm-luks-3.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage lvm luks"
+TESTTYPE="storage lvm luks gh1637"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/lvm-luks-4.sh
+++ b/lvm-luks-4.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage lvm luks"
+TESTTYPE="storage lvm luks gh1637"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/part-luks-1.sh
+++ b/part-luks-1.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage partition luks"
+TESTTYPE="storage partition luks gh1637"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/part-luks-2.sh
+++ b/part-luks-2.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage partition luks"
+TESTTYPE="storage partition luks gh1637"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/part-luks-3.sh
+++ b/part-luks-3.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage partition luks"
+TESTTYPE="storage partition luks gh1637"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/part-luks-4.sh
+++ b/part-luks-4.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage partition luks"
+TESTTYPE="storage partition luks gh1637"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Tag scripts that use copy_file_encrypted with gh1637 and add gh1637 to rhel10_centos10 disabled test types in containers/runner/skip-testtypes.

Guestfish -i / inspect fails on RHEL crypttab with link-volume-key=... (rhbz#2452937).

Tracked in https://github.com/rhinstaller/kickstart-tests/issues/1637