### PR TITLE
launch: add --run-arg option to support arguments with spaces (gh#803)

### DIFF
--- a/containers/runner/README.md
+++ b/containers/runner/README.md
@@ -147,8 +147,16 @@ the graphical console for a virtual machine with a command:
 
     virt-viewer -c qemu+tcp://<IP>/session
 
-To change of the boot options for the tests (for example to add `inst.text`), please use
-`--run-args="--env KSTEST_EXTRA_BOOTOPTS=inst.text"` parameter for the `launch` script.
+To change the boot options for the tests (for example to add `inst.text`), please use
+the `--run-arg` parameter for the `launch` script:
+
+    containers/runner/launch --run-arg="--env=KSTEST_EXTRA_BOOTOPTS=inst.text" keyboard
+
+To pass values containing spaces, use `--run-arg` (can be repeated):
+
+    containers/runner/launch --run-arg="--env=KSTEST_EXTRA_BOOTOPTS=inst.text inst.sshd" keyboard
+
+The legacy `--run-args` option is still supported for simple cases without spaces in values.
 
 ## Running test manually from the container
 

--- a/containers/runner/README.md
+++ b/containers/runner/README.md
@@ -147,8 +147,20 @@ the graphical console for a virtual machine with a command:
 
     virt-viewer -c qemu+tcp://<IP>/session
 
-To change of the boot options for the tests (for example to add `inst.text`), please use
-`--run-args="--env KSTEST_EXTRA_BOOTOPTS=inst.text"` parameter for the `launch` script.
+To change the boot options for the tests (for example to add `inst.text`), please use
+the `--run-arg` parameter for the `launch` script:
+
+    containers/runner/launch --run-arg="--env=KSTEST_EXTRA_BOOTOPTS=inst.text" keyboard
+
+Several options belong in one variable separated by **semicolons** (not spaces), as
+documented for `KSTEST_EXTRA_BOOTOPTS` above—for example text mode and sshd on the
+installer:
+
+    containers/runner/launch --run-arg="--env=KSTEST_EXTRA_BOOTOPTS=inst.text;inst.sshd" keyboard
+
+Use `--run-arg` (can be repeated) when the extra container argument must not be split on
+spaces; the legacy `--run-args` option splits its value on spaces, so it is only suitable
+for simple values without spaces in the full `--env=...` string.
 
 ## Running test manually from the container
 

--- a/containers/runner/launch
+++ b/containers/runner/launch
@@ -16,6 +16,7 @@ PODMAN_SELINUX_FIX=
 RUN_COMMAND=/kickstart-tests/containers/runner/run-kstest
 SCENARIO=${SCENARIO:-unknown}
 BOOT_ISO="boot.iso"
+CONTAINER_RUN_ARGS=()
 
 # Get number of jobs to be run in parallel based on number of CPUs and amount of RAM
 recommended_jobs() {
@@ -63,7 +64,9 @@ Options:
  --defaults DEFAULTS_SH_FILE          Path to a file with custom shell script to override
                                       defaults. The base defaults will be platform
                                       specific (scripts/defaults*.sh).
- --run-args ARGUMENTS                 Extra $CRUN options/arguments (space separated)
+ --run-args ARGUMENTS                 Extra $CRUN options/arguments (space separated, legacy)
+ --run-arg  ARGUMENT                  Extra $CRUN option/argument (can be repeated, supports
+                                      values with spaces; use --run-arg=--flag for each flag)
  --recommended-jobs                   Print the number of jobs (--jobs option) used
                                       by default and exit. It is calulated from the number
                                       of CPUs and the size of RAM.
@@ -75,7 +78,7 @@ EOF
 }
 
 # parse options
-eval set -- "$(getopt -o j:p:t:T:s:u:rch --long jobs:,platform:,testtype:,testtypes:,skip-testtypes:,updates:,retry,connect-shell,daily-iso:,defaults:,run-args:,recommended-jobs,scenario:,timeout:,dry-run,help -- "$@")"
+eval set -- "$(getopt -o j:p:t:T:s:u:rch --long jobs:,platform:,testtype:,testtypes:,skip-testtypes:,updates:,retry,connect-shell,daily-iso:,defaults:,run-args:,run-arg:,recommended-jobs,scenario:,timeout:,dry-run,help -- "$@")"
 
 while true; do
     case "${1:-}" in
@@ -89,7 +92,8 @@ while true; do
         -c|--connect-shell) RUN_COMMAND=/bin/bash ;;
         --daily-iso) shift; DAILY_ISO_TOKEN="$1" ;;
         --defaults) shift; DEFAULTS_SH="$1" ;;
-        --run-args) shift; CONTAINER_RUN_ARGS="$1" ;;
+        --run-args) shift; IFS=' ' read -ra _args <<< "$1"; CONTAINER_RUN_ARGS+=("${_args[@]}") ;;
+        --run-arg)  shift; CONTAINER_RUN_ARGS+=("$1") ;;
         --recommended-jobs) recommended_jobs; exit 0 ;;
         --timeout) shift; TIMEOUT="$1" ;;
         --scenario) shift; SCENARIO="$1" ;;
@@ -225,7 +229,7 @@ $CRUN run -it --rm --device=/dev/kvm --publish 127.0.0.1::16509 $PODMAN_SELINUX_
     --env DRY_RUN="${DRY_RUN:-}" \
     --env KSTESTS_TEST="$KSTESTS_TEST" --env TESTTYPE="${TESTTYPE:-}" --env TESTTYPES="${TESTTYPES:-}" --env SKIP_TESTTYPES="${SKIP_TESTTYPES:-}" \
     --env KSTESTS_RUN_TIMEOUT="${TIMEOUT:-}" \
-    --env TEST_JOBS="$TEST_JOBS" --env PLATFORM_NAME="${PLATFORM:-}" --env TEST_RETRY="${TEST_RETRY:-}" ${UPDATES_IMG_ARGS:-} ${CONTAINER_RUN_ARGS:-} \
+    --env TEST_JOBS="$TEST_JOBS" --env PLATFORM_NAME="${PLATFORM:-}" --env TEST_RETRY="${TEST_RETRY:-}" ${UPDATES_IMG_ARGS:-} ${CONTAINER_RUN_ARGS[@]+"${CONTAINER_RUN_ARGS[@]}"} \
     --env KSTESTS_KEEP=${KSTESTS_KEEP:-1} \
     --env BOOT_ISO=${BOOT_ISO} \
     ${TEST_ENV_VARS} \


### PR DESCRIPTION
The existing --run-args option word-splits its value, making it impossible to pass container runtime arguments whose values contain spaces (e.g. --env=KSTEST_EXTRA_BOOTOPTS="inst.text inst.sshd").

Add a new --run-arg (singular) option that preserves quoting: each --run-arg value is appended as a single element to a bash array, so spaces in values are not lost. The option can be repeated.

The legacy --run-args is kept for backward compatibility; it still word-splits, but now also accumulates into the same array, so it can be specified multiple times as well.

issue: [803](https://github.com/rhinstaller/kickstart-tests/issues/803) 