### PR TITLE
Revert "Disable raid-ddf for gh1646"

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -22,7 +22,6 @@ fedora_disabled_array=(
   gh1530      # dns-global-exclusive-tls-* stage2-from-compose failing
   gh1618      # packages-multilib failing on daily-iso
   gh1633      # rpm-ostree-container-uefi failing with Fedora 44 runner container
-  gh1646      # raid-ddf failing
 )
 
 daily_iso_disabled_array=(
@@ -106,7 +105,6 @@ fedora_eln_disabled_array=(
   gh1534      # proxy-cmdline
   gh1541      # flatpak-preinstall-* not implemented
   gh1574      # bootc-* failing
-  gh1646      # raid-ddf failing
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml

--- a/raid-ddf.sh
+++ b/raid-ddf.sh
@@ -21,7 +21,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="raid storage gh1646"
+TESTTYPE="raid storage"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
This reverts commit 74fb65e2b48b1df6373c05df9a36f86d18f2d8b2.

According to latest [disabled test runs](https://github.com/rhinstaller/kickstart-tests/actions/workflows/disabled-tests.yml) the issue seems to be gone.