### PR TITLE
container-autoupdate: always pull fresh base image for build

### DIFF
--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           TAG=$(date --iso-8601)
           NAME=quay.io/rhinstaller/kstest-runner
-          docker build -t $NAME:$TAG containers/runner
+          docker build --pull -t $NAME:$TAG containers/runner
           docker tag $NAME:$TAG $NAME:latest
 
           docker push $NAME:$TAG


### PR DESCRIPTION
A stale cached fedora:44 base image with pre-release fedora-repos (44-0.3) had updates-testing enabled, causing elfutils-libelf to be upgraded then downgraded during the build, breaking dracut's initramfs generation with "could not locate dependency libelf.so.1".