### PR TITLE
runner: use Fedora registry and always pull fresh base image

### DIFF
--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           TAG=$(date --iso-8601)
           NAME=quay.io/rhinstaller/kstest-runner
-          docker build -t $NAME:$TAG containers/runner
+          docker build --pull -t $NAME:$TAG containers/runner
           docker tag $NAME:$TAG $NAME:latest
 
           docker push $NAME:$TAG

--- a/containers/runner/Dockerfile
+++ b/containers/runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:44
+FROM registry.fedoraproject.org/fedora:44
 LABEL maintainer='anaconda-devel-list@redhat.com'
 
 RUN dnf -y update && \


### PR DESCRIPTION
The docker.io/library/fedora:44 image on Docker Hub still ships pre-GA fedora-repos-44-0.3 with updates-testing enabled, while registry.fedoraproject.org/fedora:44 has the GA fedora-repos-44-1. Using the explicit Fedora registry ensures a consistent base image regardless of whether the build uses Docker or Podman.

Also add --pull to the docker build command to always fetch the latest base image instead of using a potentially stale cached one.

Fixes failing kstest container builds: https://github.com/rhinstaller/kickstart-tests/actions/workflows/container-autoupdate.yml
Tested on a branch: https://github.com/rhinstaller/kickstart-tests/actions/runs/24984740265/job/73155104120