### PR TITLE
Reenable luks tests

### DIFF
--- a/autopart-encrypted-1.sh
+++ b/autopart-encrypted-1.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage coverage smoke gh1637"
+TESTTYPE="autopart storage coverage smoke"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/autopart-encrypted-2.sh
+++ b/autopart-encrypted-2.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage gh1637"
+TESTTYPE="autopart storage"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/autopart-encrypted-3.sh
+++ b/autopart-encrypted-3.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage gh1637"
+TESTTYPE="autopart storage"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/autopart-luks-1.sh
+++ b/autopart-luks-1.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage luks gh1637"
+TESTTYPE="autopart storage luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/autopart-luks-2.sh
+++ b/autopart-luks-2.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage luks gh1637"
+TESTTYPE="autopart storage luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/autopart-luks-3.sh
+++ b/autopart-luks-3.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage luks gh1637"
+TESTTYPE="autopart storage luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/autopart-luks-4.sh
+++ b/autopart-luks-4.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage luks gh1637"
+TESTTYPE="autopart storage luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/autopart-luks-5.sh
+++ b/autopart-luks-5.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage luks gh1637"
+TESTTYPE="autopart storage luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -58,7 +58,6 @@ rhel9_disabled_array=(
   gh595       # proxy-cmdline failing on all scenarios
   gh804       # tests requiring dvd iso failing
   gh1633      # rpm-ostree-container-uefi failing with Fedora 44 runner container
-  gh1637      # LUKS copy_file_encrypted: guestfish -i / crypttab inspect (rhbz#2452937)
 )
 
 rhel10_centos10_disabled_array=(
@@ -68,7 +67,6 @@ rhel10_centos10_disabled_array=(
   gh1207      # packages-multilib failing
   gh1213      # harddrive-iso-single failing
   gh1633      # rpm-ostree-container-uefi failing with Fedora 44 runner container
-  gh1637      # LUKS copy_file_encrypted: guestfish -i / crypttab inspect (rhbz#2452937); CentOS 10 shares this list
 )
 
 rhel10_skip_array=(

--- a/lvm-luks-1.sh
+++ b/lvm-luks-1.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage lvm luks gh1637"
+TESTTYPE="storage lvm luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/lvm-luks-2.sh
+++ b/lvm-luks-2.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage lvm luks gh1637"
+TESTTYPE="storage lvm luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/lvm-luks-3.sh
+++ b/lvm-luks-3.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage lvm luks gh1637"
+TESTTYPE="storage lvm luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/lvm-luks-4.sh
+++ b/lvm-luks-4.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage lvm luks gh1637"
+TESTTYPE="storage lvm luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/part-luks-1.sh
+++ b/part-luks-1.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage partition luks gh1637"
+TESTTYPE="storage partition luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/part-luks-2.sh
+++ b/part-luks-2.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage partition luks gh1637"
+TESTTYPE="storage partition luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/part-luks-3.sh
+++ b/part-luks-3.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage partition luks gh1637"
+TESTTYPE="storage partition luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/part-luks-4.sh
+++ b/part-luks-4.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage partition luks gh1637"
+TESTTYPE="storage partition luks"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
~Draft to test if the f44 build of augeas from https://bugzilla.redhat.com/show_bug.cgi?id=2452937 already hit our F44 base container.
When it is so it will be updated to enable other luks tests.~

https://bugzilla.redhat.com/show_bug.cgi?id=2452937 fix is now in the Fedora 44 base container.