### PR TITLE
Add console boot options validation test

### DIFF
--- a/bootopts-console.ks.in
+++ b/bootopts-console.ks.in
@@ -1,0 +1,24 @@
+# Test coverage for https://redhat.atlassian.net/browse/RHEL-101787
+# and https://redhat.atlassian.net/browse/RHEL-101789
+# Verify that all console= boot options are passed to the installed system
+# kernel boot configuration.
+
+%ksappend repos/default.ks
+%ksappend common/common_no_payload.ks
+%ksappend payload/default_packages.ks
+
+%post
+
+grub_cmdline="$(grep "^GRUB_CMDLINE_LINUX=" /etc/default/grub)"
+
+for console_opt in console=ttyS0,115200 console=tty1; do
+    echo "${grub_cmdline}" | grep -q "${console_opt}"
+    if [[ $? -ne 0 ]]; then
+        echo "*** Failed check: ${console_opt} is not passed to installed system boot arguments" >> /root/RESULT
+        echo "*** GRUB_CMDLINE_LINUX=${grub_cmdline}" >> /root/RESULT
+    fi
+done
+
+%ksappend validation/success_if_result_empty.ks
+
+%end

--- a/bootopts-console.sh
+++ b/bootopts-console.sh
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2026  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Jan Stodola <jstodola@redhat.com>
+
+# Test coverage for https://redhat.atlassian.net/browse/RHEL-101787
+# and https://redhat.atlassian.net/browse/RHEL-101789
+
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
+TESTTYPE="bootloader"
+
+. ${KSTESTDIR}/functions.sh
+
+kernel_args() {
+    echo ${DEFAULT_BOOTOPTS} console=ttyS0,115200 console=tty1
+}


### PR DESCRIPTION
This test ensures that all specified console= boot options are properly propagated to the installed system's kernel boot configuration. Covers Jira tickets:
- RHEL-101787
- RHEL-101789

Co-authored-by: Cursor