### PR TITLE
Ensure firewalld state matches systemd preset

### DIFF
--- a/firewall-use-system-defaults.ks.in
+++ b/firewall-use-system-defaults.ks.in
@@ -10,7 +10,6 @@
 %ksappend common/common_no_payload.ks
 %ksappend payload/default_packages.ks
 
-# disable firewall
 firewall --use-system-defaults
 
 %post
@@ -21,10 +20,11 @@ if [[ $? != 0 ]]; then
     echo '*** firewalld package should have been installed' >> /root/RESULT
 fi
 
-# On Fedora firewall is enabled by default.
-systemctl is-enabled firewall
-if [[ $? -eq 0 ]]; then
-    echo "*** firewall should be enabled" >> /root/RESULT
+# firewalld should match the distro systemd preset (not be changed by anaconda).
+preset=$(systemctl show firewalld.service -p UnitFilePreset --value)
+state=$(systemctl show firewalld.service -p UnitFileState --value)
+if [[ "${state}" != "${preset}" ]]; then
+    echo "*** firewalld.service state (${state}) should match preset (${preset})" >> /root/RESULT
 fi
 
 %ksappend validation/success_if_result_empty.ks


### PR DESCRIPTION
The previous check was incorrect (checking a non-existing firewall service, insead of the firewalld service).
Removed the previous check for firewall enabling and added a validation to ensure that the firewalld service state aligns with its systemd preset.

Generated-by: Cursor