### PR TITLE
Revert "Disable certificate anchor tests on eln until in compose (rhe…

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -104,7 +104,6 @@ fedora_eln_disabled_array=(
   gh1534      # proxy-cmdline
   gh1541      # flatpak-preinstall-* not implemented
   gh1574      # bootc-* failing
-  rhel143387  # certificate-anchor* waiting for eln compose
 )
 
 # used in workflows/daily-boot-iso-rhel8.yml


### PR DESCRIPTION
…l143387)"

This reverts commit ecdb5ffe59768bc4086d1a9bcdfc9d8be2aa0e62.