### PR TITLE
infra: Fix WebUI daily boot.iso CI rename and artifact names

### DIFF
--- a/.github/workflows/daily-boot-iso-rawhide-reusable.yml
+++ b/.github/workflows/daily-boot-iso-rawhide-reusable.yml
@@ -78,7 +78,7 @@ jobs:
             -s https://copr-be.cloud.fedoraproject.org/results/@storage/blivet-daily/fedora-rawhide-x86_64/ \
             -s https://copr-be.cloud.fedoraproject.org/results/@storage/udisks-daily/fedora-rawhide-x86_64/
           if [ "${{ inputs.webui }}" = "true" ]; then
-            mv /tmp/lorax-images/boot.iso /tmp/lorax-images/webui-boot.iso
+            sudo mv /tmp/lorax-images/boot.iso /tmp/lorax-images/webui-boot.iso
           fi
           echo "::endgroup::"
 

--- a/.github/workflows/daily-boot-iso-webui-rawhide.yml
+++ b/.github/workflows/daily-boot-iso-webui-rawhide.yml
@@ -11,3 +11,5 @@ jobs:
     uses: ./.github/workflows/daily-boot-iso-rawhide-reusable.yml
     with:
       webui: true
+      images_artifact_name: images-webui
+      logs_artifact_name: logs-webui


### PR DESCRIPTION
Use sudo mv, otherwise we get permission errors.
Also upload WebUI builds under images-webui with logs artifact being logs-webui. These parameters where created in commit 98b3e58f9eaedb73a39bccd500227833a834d9f1 but we forgot to set them.

Assisted-by: Cursor (Auto)