### PR TITLE
Fix cleanup of /tmp/lorax-images before boot.iso build

### DIFF
--- a/.github/workflows/daily-boot-iso-rawhide-reusable.yml
+++ b/.github/workflows/daily-boot-iso-rawhide-reusable.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Build boot.iso
         run: |
-          rm -rf /tmp/lorax-images
+          sudo rm -rf /tmp/lorax-images
           mkdir -p /tmp/lorax-images
           # /var/tmp tmpfs speeds up lorax and avoids https://bugzilla.redhat.com/show_bug.cgi?id=1906364
           # The container's /lorax-build script already includes the base Fedora rawhide repo


### PR DESCRIPTION
The rm -rf was introduced in 98b3e58f when extracting the reusable workflow (because now we might have leftovers in that directory from WebUI or non WebUI job and we don't want to mix these artifacts) but ran without sudo.