### PR TITLE
infra: Add daily-iso-webui Permian scenario for WebUI boot.iso

### DIFF
--- a/.github/workflows/scenarios-permian.yml
+++ b/.github/workflows/scenarios-permian.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: [self-hosted, kstest]
     strategy:
       matrix:
-        scenario: [daily-iso, rhel9, rhel10, centos10, fedora-eln]
+        scenario: [daily-iso, daily-iso-webui, rhel9, rhel10, centos10, fedora-eln]
       fail-fast: false
 
     # these settings depend on the infrastructure; on upshift ocp-master-xxl they take about 4 hours
@@ -88,7 +88,7 @@ jobs:
         id: platform_from_scenario
         run: |
           set -eux
-          if [ "${{ matrix.scenario }}" == "daily-iso" ] || [ "${{ matrix.scenario }}" == "minimal" ]; then
+          if [ "${{ matrix.scenario }}" == "daily-iso" ] || [ "${{ matrix.scenario }}" == "daily-iso-webui" ] || [ "${{ matrix.scenario }}" == "minimal" ]; then
             echo "platform=fedora_rawhide" >> $GITHUB_OUTPUT
           elif [ "${{ matrix.scenario }}" == "rhel8" ]; then
             echo "platform=rhel8" >> $GITHUB_OUTPUT
@@ -112,7 +112,10 @@ jobs:
           set -eux
           BOOT_ISO_PATH="${{ github.workspace }}/${{ matrix.scenario }}.boot.iso"
           BOOT_ISO_URL="file://$BOOT_ISO_PATH"
-          if [ "${{ matrix.scenario }}" == "daily-iso" ] || [ "${{ matrix.scenario }}" == "minimal" ]; then
+          if [ "${{ matrix.scenario }}" == "daily-iso-webui" ]; then
+            ${{ github.workspace }}/kickstart-tests/containers/runner/fetch_daily_iso.sh $GITHUB_TOKEN $BOOT_ISO_PATH images-webui webui-boot.iso
+            echo "boot_iso=\"bootIso\":{\"x86_64\":\"${BOOT_ISO_URL}\"}," >> $GITHUB_OUTPUT
+          elif [ "${{ matrix.scenario }}" == "daily-iso" ] || [ "${{ matrix.scenario }}" == "minimal" ]; then
             ${{ github.workspace }}/kickstart-tests/containers/runner/fetch_daily_iso.sh $GITHUB_TOKEN $BOOT_ISO_PATH
             echo "boot_iso=\"bootIso\":{\"x86_64\":\"${BOOT_ISO_URL}\"}," >> $GITHUB_OUTPUT
           else

--- a/containers/runner/fetch_daily_iso.sh
+++ b/containers/runner/fetch_daily_iso.sh
@@ -3,11 +3,13 @@ set -eux
 
 DAILY_ISO_TOKEN=$1
 OUTPUT_PATH=${2:-"boot.iso"}
+ARTIFACT_NAME=${3:-images}
+ISO_NAME=${4:-boot.iso}
 
 CURL="curl -u token:$(cat $DAILY_ISO_TOKEN) --show-error --fail"
-RESPONSE=$($CURL --silent https://api.github.com/repos/rhinstaller/kickstart-tests/actions/artifacts?name=images)
+RESPONSE=$($CURL --silent https://api.github.com/repos/rhinstaller/kickstart-tests/actions/artifacts?name=${ARTIFACT_NAME})
 ZIP=$(echo "$RESPONSE" | jq --raw-output '.artifacts[0].archive_download_url')
 echo "INFO: Downloading $ZIP ..."
 $CURL -L -o images.zip "$ZIP"
 unzip images.zip
-mv boot.iso ${OUTPUT_PATH}
+mv "${ISO_NAME}" "${OUTPUT_PATH}"

--- a/testlib/test_plans/daily-daily-iso-webui.plan.yaml
+++ b/testlib/test_plans/daily-daily-iso-webui.plan.yaml
@@ -1,0 +1,12 @@
+name: daily daily-iso-webui
+description: Daily run on WebUI boot.iso built from Rawhide with Anaconda and anaconda-webui COPR stacks
+point_person: kkoukiou@redhat.com
+artifact_type: github.scheduled.daily.kstest.daily-iso-webui
+verified_by:
+  test_cases:
+    direct_list:
+      - container
+configurations:
+  - architecture: x86_64
+reporting:
+  - type: xunit


### PR DESCRIPTION
Run the container test against webui-boot.iso from the images-webui artifact and teach fetch_daily_iso.sh to select artifact and ISO name.

Assisted-by: Cursor (Composer)