### PR TITLE
infra: Add daily-iso-webui to test-os-variants workflow

### DIFF
--- a/.github/workflows/test-os-variants.yml
+++ b/.github/workflows/test-os-variants.yml
@@ -117,7 +117,7 @@ jobs:
       GITHUB_TOKEN: /home/github/github-token
     strategy:
       matrix:
-        os-variant: [daily-iso, rawhide, fedora-eln, rhel9, rhel10, centos10]
+        os-variant: [daily-iso, daily-iso-webui, rawhide, fedora-eln, rhel9, rhel10, centos10]
       fail-fast: false
 
     steps:
@@ -227,6 +227,9 @@ jobs:
           BOOT_ISO_URL="file://$BOOT_ISO_PATH"
           if [ "${{ matrix.os-variant }}" == "daily-iso" ]; then
             ${{ github.workspace }}/kickstart-tests/containers/runner/fetch_daily_iso.sh $GITHUB_TOKEN $BOOT_ISO_PATH
+            echo "boot_iso=\"bootIso\":{\"x86_64\":\"${BOOT_ISO_URL}\"}," >> $GITHUB_OUTPUT
+          elif [ "${{ matrix.os-variant }}" == "daily-iso-webui" ]; then
+            ${{ github.workspace }}/kickstart-tests/containers/runner/fetch_daily_iso.sh $GITHUB_TOKEN $BOOT_ISO_PATH images-webui webui-boot.iso
             echo "boot_iso=\"bootIso\":{\"x86_64\":\"${BOOT_ISO_URL}\"}," >> $GITHUB_OUTPUT
           elif [ "${{ matrix.os-variant }}" == "rawhide" ]; then
             curl -L https://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/images/boot.iso --output $BOOT_ISO_PATH

--- a/README.rst
+++ b/README.rst
@@ -426,6 +426,11 @@ Service jobs
   anaconda, dnf, or blivet before they get released. This is consumed by the
   ``daily-iso`` scenario.
 
+* The `daily-boot-iso-webui`_ workflow creates a WebUI ``boot.iso`` with the
+  same COPR stacks plus ``anaconda-webui``. This is consumed by the
+  ``daily-iso-webui`` scenario and the ``daily-iso-webui`` matrix job in
+  `test-os-variants`_.
+
 These jobs don't have any particular infrastructure requirements. They run on
 GitHub's infrastructure and can be run manually by a developer.
 
@@ -452,6 +457,7 @@ https://gitlab.cee.redhat.com/rtt/rpm-test-repos.
 .. _test-platforms: ./.github/workflows/test-platforms.yml
 .. _quay.io/rhinstaller/kstest-runner: https://quay.io/repository/rhinstaller/kstest-runner
 .. _daily-boot-iso: ./.github/workflows/daily-boot-iso.yml
+.. _daily-boot-iso-webui: ./.github/workflows/daily-boot-iso-webui-rawhide.yml
 .. _generate-launch-args.py: ./scripts/generate-launch-args.py
 .. _Weekly Summary: https://github.com/rhinstaller/kickstart-tests/actions/workflows/weekly-summary.yml
 .. _classify-failures: ./scripts/classify-failures

--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -29,6 +29,37 @@ daily_iso_disabled_array=(
   gh910       # stage2-from-ks test needs to be fixed for daily-iso
 )
 
+# FIXME: The following test types are expected to be re-enabled or disabled with a reasoning
+daily_iso_webui_skip_array=(
+  addon
+  addons
+  anabot
+  anaconda
+  disklabel
+  driverdisk
+  image-deployment
+  initial-setup
+  keyboard
+  kickstart
+  ksscript
+  logs
+  modularity
+  network
+  packaging
+  payload
+  reboot
+  repo
+  security
+  selinux
+  services
+  stage2-from-compose
+  storage
+  time
+  ui
+  url
+  users
+)
+
 rawhide_disabled_array=(
 )
 
@@ -125,6 +156,7 @@ _join_args_by_comma(){
 SKIPPED_TESTTYPES_RAWHIDE=$(_join_args_by_comma "${common_skip_array[@]}" "${fedora_skip_array[@]}")
 SKIPPED_TESTTYPES_RAWHIDE_TEXT=$(_join_args_by_comma "${common_skip_array[@]}" "${fedora_skip_array[@]}")
 SKIPPED_TESTTYPES_DAILY_ISO=$(_join_args_by_comma "${common_skip_array[@]}" "${fedora_skip_array[@]}")
+SKIPPED_TESTTYPES_DAILY_ISO_WEBUI=$(_join_args_by_comma "${common_skip_array[@]}" "${fedora_skip_array[@]}" "${daily_iso_webui_skip_array[@]}")
 SKIPPED_TESTTYPES_RHEL8=$(_join_args_by_comma "${common_skip_array[@]}" "${rhel8_skip_array[@]}")
 SKIPPED_TESTTYPES_RHEL9=$(_join_args_by_comma "${common_skip_array[@]}" "${rhel9_skip_array[@]}")
 SKIPPED_TESTTYPES_RHEL10=$(_join_args_by_comma "${common_skip_array[@]}" "${rhel10_skip_array[@]}")
@@ -136,6 +168,7 @@ SKIPPED_TESTTYPES_FEDORA_ELN=$(_join_args_by_comma "${common_skip_array[@]}" "${
 SKIPPED_TESTTYPES_ANACONDA_PR=$(_join_args_by_comma "${common_skip_array[@]}" "${anaconda_pr_skip_array[@]}")
 
 DISABLED_TESTTYPES_DAILY_ISO=$(_join_args_by_comma "${fedora_disabled_array[@]}" "${daily_iso_disabled_array[@]}")
+DISABLED_TESTTYPES_DAILY_ISO_WEBUI=$(_join_args_by_comma "${fedora_disabled_array[@]}" "${daily_iso_disabled_array[@]}")
 DISABLED_TESTTYPES_RAWHIDE=$(_join_args_by_comma "${fedora_disabled_array[@]}" "${rawhide_disabled_array[@]}")
 DISABLED_TESTTYPES_RHEL8=$(_join_args_by_comma "${rhel8_disabled_array[@]}")
 DISABLED_TESTTYPES_RHEL9=$(_join_args_by_comma "${rhel9_disabled_array[@]}")

--- a/scripts/generate-launch-args.py
+++ b/scripts/generate-launch-args.py
@@ -8,6 +8,7 @@ import os
 
 OS_VARIANT_TO_PLATFORM = {
     'daily-iso': 'fedora_rawhide',
+    'daily-iso-webui': 'fedora_rawhide',
     'rawhide': 'fedora_rawhide',
     'rhel8': 'rhel8',
     'rhel9': 'rhel9',
@@ -18,6 +19,7 @@ OS_VARIANT_TO_PLATFORM = {
 
 OS_VARIANT_TO_SKIPPED = {
     'daily-iso': 'SKIPPED_TESTTYPES_DAILY_ISO',
+    'daily-iso-webui': 'SKIPPED_TESTTYPES_DAILY_ISO_WEBUI',
     'rawhide': 'SKIPPED_TESTTYPES_RAWHIDE',
     'rhel8': 'SKIPPED_TESTTYPES_RHEL8',
     'rhel9': 'SKIPPED_TESTTYPES_RHEL9',
@@ -28,6 +30,7 @@ OS_VARIANT_TO_SKIPPED = {
 
 OS_VARIANT_TO_DISABLED = {
     'daily-iso': 'DISABLED_TESTTYPES_DAILY_ISO',
+    'daily-iso-webui': 'DISABLED_TESTTYPES_DAILY_ISO_WEBUI',
     'rawhide': 'DISABLED_TESTTYPES_RAWHIDE',
     'rhel8': 'DISABLED_TESTTYPES_RHEL8',
     'rhel9': 'DISABLED_TESTTYPES_RHEL9',

--- a/scripts/generate-testplan.py
+++ b/scripts/generate-testplan.py
@@ -24,6 +24,7 @@ from jinja2 import Template
 
 OS_VARIANT_TO_SKIPPED = {
     'daily-iso': 'SKIPPED_TESTTYPES_DAILY_ISO',
+    'daily-iso-webui': 'SKIPPED_TESTTYPES_DAILY_ISO_WEBUI',
     'rawhide': 'SKIPPED_TESTTYPES_RAWHIDE',
     'rhel8': 'SKIPPED_TESTTYPES_RHEL8',
     'rhel9': 'SKIPPED_TESTTYPES_RHEL9',
@@ -34,6 +35,7 @@ OS_VARIANT_TO_SKIPPED = {
 
 OS_VARIANT_TO_DISABLED = {
     'daily-iso': 'DISABLED_TESTTYPES_DAILY_ISO',
+    'daily-iso-webui': 'DISABLED_TESTTYPES_DAILY_ISO_WEBUI',
     'rawhide': 'DISABLED_TESTTYPES_RAWHIDE',
     'rhel8': 'DISABLED_TESTTYPES_RHEL8',
     'rhel9': 'DISABLED_TESTTYPES_RHEL9',

--- a/testlib/test_plans/daily-daily-iso-webui.plan.yaml.j2
+++ b/testlib/test_plans/daily-daily-iso-webui.plan.yaml.j2
@@ -4,8 +4,11 @@ point_person: kkoukiou@redhat.com
 artifact_type: github.scheduled.daily.kstest.daily-iso-webui
 verified_by:
   test_cases:
-    direct_list:
-      - container
+    query: '
+{% for tag in skiptags %}
+            "{{ tag }}" not in tc.tags and
+{% endfor %}
+            True'
 configurations:
   - architecture: x86_64
 reporting:


### PR DESCRIPTION
Run PR /test-os-variants jobs against the daily WebUI boot.iso. For the daily-iso-webui variant, skip all tests except lang via skip-testtypes and generate the daily Permian test plan from a template, similar to `testlib/test_plans/daily-daily-iso.plan.yaml.j2` plan.

Assisted-by: Cursor (Auto)