### PR TITLE
Reenable certificate-anchor tests on centos-10

### DIFF
--- a/certificate-anchor-curl.sh
+++ b/certificate-anchor-curl.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="security skip-on-rhel-9 rhel143387"
+TESTTYPE="security skip-on-rhel-9"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/certificate-anchor.sh
+++ b/certificate-anchor.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="security skip-on-rhel-9 rhel143387"
+TESTTYPE="security skip-on-rhel-9"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -113,7 +113,6 @@ centos10_skip_array=(
 centos10_disabled_array=(
   gh1466      # ftp source tests failing
   gh1474      # proxy-cmdline failing
-  rhel143387  # certificate-anchor* waiting for feature in centos 10
 )
 
 rhel10_disabled_array=(


### PR DESCRIPTION
The feature reached the composes.