### PR TITLE
infra: Enable smoke tests for daily-iso-webui scenario

### DIFF
--- a/.github/workflows/scenarios-permian.yml
+++ b/.github/workflows/scenarios-permian.yml
@@ -26,6 +26,8 @@ jobs:
       # The timeout should be ~20 minutes less then the job's timeout-minutes
       # so that we get partial results and logs in case of the timeout.
       LAUNCHER_TIMEOUT_MINUTES: 540
+      # Webui tests need more resources
+      KSTEST_WEBUI: ${{ matrix.scenario == 'daily-iso-webui' && 'true' || '' }}
 
     steps:
       # self-hosted runners don't do this automatically; also useful to keep stuff around for debugging

--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -55,6 +55,10 @@ daily_iso_webui_only_skip_array=(
   skip-on-daily-iso-webui
 )
 
+daily_iso_webui_disabled_array=(
+  gh1683      # lvm-thinp-1 times out on WebUI boot.iso
+)
+
 rawhide_disabled_array=(
 )
 

--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -38,25 +38,21 @@ daily_iso_webui_skip_array=(
   driverdisk
   image-deployment
   initial-setup
-  keyboard
   kickstart
   ksscript
   logs
   modularity
-  network
-  packaging
-  payload
-  reboot
   repo
   security
   selinux
   services
   stage2-from-compose
-  storage
   time
-  ui
   url
-  users
+)
+
+daily_iso_webui_only_skip_array=(
+  skip-on-daily-iso-webui
 )
 
 rawhide_disabled_array=(
@@ -153,7 +149,7 @@ _join_args_by_comma(){
 SKIPPED_TESTTYPES_RAWHIDE=$(_join_args_by_comma "${common_skip_array[@]}" "${fedora_skip_array[@]}")
 SKIPPED_TESTTYPES_RAWHIDE_TEXT=$(_join_args_by_comma "${common_skip_array[@]}" "${fedora_skip_array[@]}")
 SKIPPED_TESTTYPES_DAILY_ISO=$(_join_args_by_comma "${common_skip_array[@]}" "${fedora_skip_array[@]}")
-SKIPPED_TESTTYPES_DAILY_ISO_WEBUI=$(_join_args_by_comma "${common_skip_array[@]}" "${fedora_skip_array[@]}" "${daily_iso_webui_skip_array[@]}")
+SKIPPED_TESTTYPES_DAILY_ISO_WEBUI=$(_join_args_by_comma "${common_skip_array[@]}" "${fedora_skip_array[@]}" "${daily_iso_webui_skip_array[@]}" "${daily_iso_webui_only_skip_array[@]}")
 SKIPPED_TESTTYPES_RHEL8=$(_join_args_by_comma "${common_skip_array[@]}" "${rhel8_skip_array[@]}")
 SKIPPED_TESTTYPES_RHEL9=$(_join_args_by_comma "${common_skip_array[@]}" "${rhel9_skip_array[@]}")
 SKIPPED_TESTTYPES_RHEL10=$(_join_args_by_comma "${common_skip_array[@]}" "${rhel10_skip_array[@]}")

--- a/functions.sh
+++ b/functions.sh
@@ -479,5 +479,9 @@ stage2_from_ks() {
 
 # RAM size of VM for the test in MiB
 get_required_ram() {
-    echo "2048"
+    if [ "${KSTEST_WEBUI}" = "true" ]; then
+        echo "2560"
+    else
+        echo "2048"
+    fi
 }

--- a/lvm-thinp-1.sh
+++ b/lvm-thinp-1.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="lvm storage coverage smoke"
+TESTTYPE="lvm storage coverage smoke gh1683"
 
 . ${KSTESTDIR}/functions.sh

--- a/post-nochroot-lib-network.sh
+++ b/post-nochroot-lib-network.sh
@@ -23,6 +23,12 @@ function check_bridge_has_slave_nochroot() {
     fi
 }
 
+# anaconda_uses_webui
+# Return success if anaconda ran the WebUI instead of the GTK UI.
+function anaconda_uses_webui() {
+    grep -qE 'cockpit web view has been started' /tmp/anaconda.log
+}
+
 # check_gui_configurations
 # Works only for gui installations.
 # Checks that the connections configurable in Network Spoke are those corresponding to configuration files of devices
@@ -35,6 +41,10 @@ function check_gui_configurations() {
     # Pass the test if not in graphical mode
     grep -q "Display mode is set to.* graphical mode" /tmp/anaconda.log
     if [[ $? -ne 0 ]]; then
+        return
+    fi
+
+    if anaconda_uses_webui; then
         return
     fi
 

--- a/reboot-initial-setup-tui.sh
+++ b/reboot-initial-setup-tui.sh
@@ -18,7 +18,7 @@
 # The fix requires https://github.com/rhinstaller/anaconda/commit/6b80b7b.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="reboot initial-setup smoke skip-on-rhel-8 skip-on-rhel-10 skip-on-centos-10 skip-on-fedora-eln gh1434"
+TESTTYPE="reboot initial-setup smoke skip-on-daily-iso-webui skip-on-rhel-8 skip-on-rhel-10 skip-on-centos-10 skip-on-fedora-eln gh1434"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/ui_text_interactive.sh
+++ b/ui_text_interactive.sh
@@ -17,6 +17,6 @@
 #
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="ui smoke"
+TESTTYPE="ui smoke skip-on-daily-iso-webui"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Unblock smoke test categories on the WebUI daily ISO and skip TUI smoke tests that do not apply via skip-on-daily-iso-webui.