### PR TITLE
Fix proxy-cmdline test on fedora-eln

### DIFF
--- a/functions-proxy.sh
+++ b/functions-proxy.sh
@@ -16,7 +16,7 @@ function check_proxy_settings() {
 
     if [ "$httpslist" ]; then
         # check for CONNECT request to mirrorlist host
-        grep -q "CONNECT $httpslist " $tmpdir/proxy/access.log
+        grep -q "CONNECT ${httpslist}[: ]" $tmpdir/proxy/access.log
         if [[ $? -ne 0 ]]; then
             echo 'Connection to TLS mirrorlist server was not proxied' >> $tmpdir/RESULT
         fi
@@ -32,7 +32,7 @@ function check_proxy_settings() {
         fi
     elif [ "$httpsdir" ]; then
         # check for CONNECT request to mirror
-        grep -q "CONNECT $httpsdir " $tmpdir/proxy/access.log
+        grep -q "CONNECT ${httpsdir}[: ]" $tmpdir/proxy/access.log
         if [[ $? -ne 0 ]]; then
             echo 'Connection to TLS repository server was not proxied' >> $tmpdir/RESULT
         fi

--- a/functions-proxy.sh
+++ b/functions-proxy.sh
@@ -16,6 +16,7 @@ function check_proxy_settings() {
 
     if [ "$httpslist" ]; then
         # check for CONNECT request to mirrorlist host
+        # shellcheck disable=SC1087  # [: ] is grep regex, not array index
         grep -q "CONNECT ${httpslist}[: ]" $tmpdir/proxy/access.log
         if [[ $? -ne 0 ]]; then
             echo 'Connection to TLS mirrorlist server was not proxied' >> $tmpdir/RESULT
@@ -32,6 +33,7 @@ function check_proxy_settings() {
         fi
     elif [ "$httpsdir" ]; then
         # check for CONNECT request to mirror
+        # shellcheck disable=SC1087  # [: ] is grep regex, not array index
         grep -q "CONNECT ${httpsdir}[: ]" $tmpdir/proxy/access.log
         if [[ $? -ne 0 ]]; then
             echo 'Connection to TLS repository server was not proxied' >> $tmpdir/RESULT

--- a/proxy-cmdline.ks.in
+++ b/proxy-cmdline.ks.in
@@ -1,6 +1,8 @@
 %ksappend repos/default.ks
 network --bootproto=dhcp
 
+cmdline
+
 bootloader --timeout=1
 zerombr
 clearpart --all


### PR DESCRIPTION
The test fails on fedora-eln in two ways:

1. GUI SoftwareSelectionSpoke hang: anaconda in GUI mode never completes the spoke, causing a 30-minute timeout. Fixed by switching to cmdline mode.

2. Package download failures through proxy: the download.fedoraproject.org redirector sends anaconda to mirrors that return 403 through the HTTPS CONNECT proxy tunnel. Fixed by rewriting ELN repo URLs to use a direct HTTPS mirror (ftp-stud.hs-esslingen.de) in prepare(), with a dedicated check_proxy_settings_for_host() validation function.

Resolves: gh1534