### PR TITLE
Switch kickstart tests to UEFI by default.

### DIFF
--- a/bootc-uefi.sh
+++ b/bootc-uefi.sh
@@ -23,10 +23,6 @@ TESTTYPE="skip-on-rhel-9 payload uefi bootc reboot gh1574"
 
 . ${KSTESTDIR}/functions.sh
 
-enable_uefi() {
-    echo "true"
-}
-
 copy_interesting_files_from_system() {
     local disksdir
     disksdir="${1}"

--- a/bootloader-2.sh
+++ b/bootloader-2.sh
@@ -22,3 +22,7 @@
 TESTTYPE="bootloader storage"
 
 . ${KSTESTDIR}/functions.sh
+
+enable_uefi() {
+    echo "false"
+}

--- a/bootloader-2.sh
+++ b/bootloader-2.sh
@@ -26,3 +26,7 @@ TESTTYPE="bootloader storage"
 enable_uefi() {
     echo "false"
 }
+
+kernel_args() {
+    echo ${DEFAULT_BOOTOPTS} inst.disklabel=mbr
+}

--- a/bootloader-3.sh
+++ b/bootloader-3.sh
@@ -22,3 +22,7 @@
 TESTTYPE="bootloader storage"
 
 . ${KSTESTDIR}/functions.sh
+
+enable_uefi() {
+    echo "false"
+}

--- a/bootloader-3.sh
+++ b/bootloader-3.sh
@@ -26,3 +26,7 @@ TESTTYPE="bootloader storage"
 enable_uefi() {
     echo "false"
 }
+
+kernel_args() {
+    echo ${DEFAULT_BOOTOPTS} inst.disklabel=mbr
+}

--- a/bootloader-4.sh
+++ b/bootloader-4.sh
@@ -23,6 +23,10 @@ TESTTYPE="bootloader storage"
 
 . ${KSTESTDIR}/functions.sh
 
+enable_uefi() {
+    echo "false"
+}
+
 prepare_disks() {
     tmpdir=$1
 

--- a/bootloader-4.sh
+++ b/bootloader-4.sh
@@ -27,6 +27,10 @@ enable_uefi() {
     echo "false"
 }
 
+kernel_args() {
+    echo ${DEFAULT_BOOTOPTS} inst.disklabel=mbr
+}
+
 prepare_disks() {
     tmpdir=$1
 

--- a/bootloader-5.sh
+++ b/bootloader-5.sh
@@ -23,6 +23,10 @@ TESTTYPE="bootloader storage"
 
 . ${KSTESTDIR}/functions.sh
 
+enable_uefi() {
+    echo "false"
+}
+
 prepare_disks() {
     tmpdir=$1
 

--- a/bootloader-5.sh
+++ b/bootloader-5.sh
@@ -27,6 +27,10 @@ enable_uefi() {
     echo "false"
 }
 
+kernel_args() {
+    echo ${DEFAULT_BOOTOPTS} inst.disklabel=mbr
+}
+
 prepare_disks() {
     tmpdir=$1
 

--- a/containers/runner/Dockerfile
+++ b/containers/runner/Dockerfile
@@ -21,6 +21,7 @@ RUN dnf -y update && \
     python3-rpm \
     squid \
     make \
+    edk2-ovmf \
     openssh-clients && \
     dnf -y clean all
 

--- a/disklabel-mbr.sh
+++ b/disklabel-mbr.sh
@@ -24,6 +24,10 @@ TESTTYPE="storage disklabel skip-on-rhel-8 skip-on-rhel-9"
 
 . ${KSTESTDIR}/functions.sh
 
+enable_uefi() {
+    echo "false"
+}
+
 kernel_args() {
     echo ${DEFAULT_BOOTOPTS} inst.disklabel=mbr
 }

--- a/functions.sh
+++ b/functions.sh
@@ -50,7 +50,7 @@ enable_uefi() {
     # Run the VM in the UEFI mode.
     # This will add '--boot uefi' argument to the virt-install script
     # returns: "true" or "false"
-    echo "false"
+    echo "true"
 }
 
 EXTRA_BOOTOPTS=$(echo "${KSTEST_EXTRA_BOOTOPTS}" | tr ';' ' ')

--- a/ibft.sh
+++ b/ibft.sh
@@ -30,6 +30,10 @@ TESTTYPE="knownfailure iscsi"
 
 . ${KSTESTDIR}/functions.sh
 
+enable_uefi() {
+    echo "false"
+}
+
 iscsi_disk_img=iscsi-disk.img
 ipxe_image="/usr/share/ipxe/ipxe.lkrn"
 ipxe_script="ibft.ipxe"

--- a/mountpoint-assignment-1.sh
+++ b/mountpoint-assignment-1.sh
@@ -22,3 +22,7 @@
 TESTTYPE="mount storage coverage"
 
 . ${KSTESTDIR}/functions.sh
+
+enable_uefi() {
+    echo "false"
+}

--- a/mountpoint-assignment-plain.sh
+++ b/mountpoint-assignment-plain.sh
@@ -22,3 +22,7 @@
 TESTTYPE="mount storage"
 
 . ${KSTESTDIR}/functions.sh
+
+enable_uefi() {
+    echo "false"
+}

--- a/packages-and-groups-1.sh
+++ b/packages-and-groups-1.sh
@@ -22,3 +22,7 @@
 TESTTYPE="packaging payload"
 
 . ${KSTESTDIR}/functions.sh
+
+enable_uefi() {
+    echo "false"
+}

--- a/raid-1.sh
+++ b/raid-1.sh
@@ -23,6 +23,10 @@ TESTTYPE=${TESTTYPE:-"raid storage coverage smoke"}
 
 . ${KSTESTDIR}/functions.sh
 
+enable_uefi() {
+    echo "false"
+}
+
 prepare_disks() {
     tmpdir=$1
 

--- a/reboot-uefi.sh
+++ b/reboot-uefi.sh
@@ -21,10 +21,6 @@ TESTTYPE="reboot uefi coverage smoke"
 
 . ${KSTESTDIR}/functions.sh
 
-enable_uefi() {
-    echo "true"
-}
-
 additional_runner_args() {
     # Wait for reboot and shutdown of the VM,
     # but exit after the specified timeout.

--- a/rpm-ostree-container-leavebootorder.sh
+++ b/rpm-ostree-container-leavebootorder.sh
@@ -22,10 +22,6 @@ TESTTYPE="payload uefi ostree bootc reboot skip-on-rhel-8 gh1533"
 
 . ${KSTESTDIR}/functions.sh
 
-enable_uefi() {
-    echo "true"
-}
-
 copy_interesting_files_from_system() {
     local disksdir
     disksdir="${1}"

--- a/rpm-ostree-container-uefi.sh
+++ b/rpm-ostree-container-uefi.sh
@@ -22,10 +22,6 @@ TESTTYPE="payload uefi ostree bootc keyboard reboot skip-on-rhel-8 gh1533 gh1633
 
 . ${KSTESTDIR}/functions.sh
 
-enable_uefi() {
-    echo "true"
-}
-
 copy_interesting_files_from_system() {
     local disksdir
     disksdir="${1}"

--- a/scripts/launcher/lib/conf/configuration.py
+++ b/scripts/launcher/lib/conf/configuration.py
@@ -184,7 +184,7 @@ class VirtualConfiguration(BaseConfiguration):
         self._timeout = None
         self._runner_args = []
         self._stage2_from_ks = False
-        self._enable_uefi = False
+        self._enable_uefi = True
 
     @property
     def test_name(self):

--- a/snapshot-pre.sh
+++ b/snapshot-pre.sh
@@ -22,3 +22,7 @@
 TESTTYPE="snapshot lvm storage"
 
 . ${KSTESTDIR}/functions.sh
+
+enable_uefi() {
+    echo "false"
+}


### PR DESCRIPTION
Run VMs with UEFI firmware by default and pin BIOS-dependent tests that rely on MBR or biosboot behavior. Add edk2-ovmf to the runner container so virt-install can boot UEFI guests.