### PR TITLE
Re-enable lvm-thinp-1 on WebUI boot.iso

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -56,7 +56,6 @@ daily_iso_webui_only_skip_array=(
 )
 
 daily_iso_webui_disabled_array=(
-  gh1683      # lvm-thinp-1 times out on WebUI boot.iso
   gh1716      # tests failing on not enough free space
 )
 

--- a/lvm-thinp-1.sh
+++ b/lvm-thinp-1.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="lvm storage coverage smoke gh1683"
+TESTTYPE="lvm storage coverage smoke"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
The gh1683 skip tag is no longer needed. Remove it from the test type and from the daily_iso_webui_disabled_array.