### PR TITLE
Replace KSTEST_WEBUI with KSTEST_OS_VARIANT

### DIFF
--- a/.github/workflows/scenarios-permian.yml
+++ b/.github/workflows/scenarios-permian.yml
@@ -26,8 +26,7 @@ jobs:
       # The timeout should be ~20 minutes less then the job's timeout-minutes
       # so that we get partial results and logs in case of the timeout.
       LAUNCHER_TIMEOUT_MINUTES: 540
-      # Webui tests need more resources
-      KSTEST_WEBUI: ${{ matrix.scenario == 'daily-iso-webui' && 'true' || '' }}
+      KSTEST_OS_VARIANT: ${{ matrix.scenario }}
 
     steps:
       # self-hosted runners don't do this automatically; also useful to keep stuff around for debugging

--- a/.github/workflows/scenarios-permian.yml
+++ b/.github/workflows/scenarios-permian.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Run scenario ${{ matrix.scenario }} in container
         working-directory: ./permian
         run: |
-          sudo --preserve-env=TEST_JOBS \
+          sudo --preserve-env=TEST_JOBS,KSTEST_OS_VARIANT \
           PYTHONPATH=${PYTHONPATH:-}:${{ github.workspace }}/tplib \
           ./pipeline --debug-log permian.log \
             --settings settings.ini \

--- a/.github/workflows/test-os-variants.yml
+++ b/.github/workflows/test-os-variants.yml
@@ -115,6 +115,7 @@ jobs:
       TARGET_BRANCH: ${{ needs.pr-info.outputs.base_ref }}
       TEST_JOBS: 16
       GITHUB_TOKEN: /home/github/github-token
+      KSTEST_OS_VARIANT: ${{ matrix.os-variant }}
     strategy:
       matrix:
         os-variant: [daily-iso, daily-iso-webui, rawhide, fedora-eln, rhel9, rhel10, centos10]

--- a/.github/workflows/test-os-variants.yml
+++ b/.github/workflows/test-os-variants.yml
@@ -279,7 +279,7 @@ jobs:
       - name: Run kickstart tests in container
         working-directory: ./permian
         run: |
-          sudo --preserve-env=TEST_JOBS \
+          sudo --preserve-env=TEST_JOBS,KSTEST_OS_VARIANT \
           PYTHONPATH=${PYTHONPATH:-}:${{ github.workspace }}/tplib \
           ./run_subset --debug-log permian.log \
             --settings settings.ini \

--- a/functions.sh
+++ b/functions.sh
@@ -479,7 +479,7 @@ stage2_from_ks() {
 
 # RAM size of VM for the test in MiB
 get_required_ram() {
-    if [ "${KSTEST_WEBUI}" = "true" ]; then
+    if [ "${KSTEST_OS_VARIANT}" = "daily-iso-webui" ]; then
         echo "2560"
     else
         echo "2048"


### PR DESCRIPTION
Pass the full os-variant/scenario name instead of a webui-specific boolean so functions.sh can derive per-variant behavior without requiring each workflow to set a dedicated flag.