### PR TITLE
Add kickstart test for read-only fstab on OSTree installations

### DIFF
--- a/ostree-readonly-fstab.ks.in
+++ b/ostree-readonly-fstab.ks.in
@@ -1,0 +1,43 @@
+# Test that RPM OSTree installations get read-only mount options
+# in /etc/fstab for root and boot filesystems.
+
+# Use the default settings.
+%ksappend common/common_no_storage_and_payload.ks
+# On Fedora enforce lvm scheme (overriding btrfs default)
+%ksappend storage/ostreecontainer_autopart.ks
+
+ostreecontainer --no-signature-verification --remote=test-remote --stateroot=test-stateroot --url=@KSTEST_OSTREECONTAINER_URL@
+
+# Reboot the installed system.
+reboot
+
+# Validate on the first boot.
+%ksappend validation/success_on_first_boot.ks
+
+%post
+# Checks after boot
+cat >> /var/lib/extensions/kickstart-tests/usr/libexec/kickstart-test.sh << 'EOF'
+
+# Check that / is mounted read-only in fstab
+root_opts=$(awk '$2 == "/" {print $4}' /etc/fstab)
+if ! echo "${root_opts}" | grep -q '\bro\b'; then
+    echo "Root (/) fstab options missing 'ro': ${root_opts}"
+fi
+
+# Check that /boot is mounted read-only in fstab (if separate)
+boot_line=$(awk '$2 == "/boot"' /etc/fstab)
+if [ -n "${boot_line}" ]; then
+    boot_opts=$(echo "${boot_line}" | awk '{print $4}')
+    if ! echo "${boot_opts}" | grep -q '\bro\b'; then
+        echo "Boot (/boot) fstab options missing 'ro': ${boot_opts}"
+    fi
+fi
+
+# Verify the system actually booted with root read-only
+root_mount_opts=$(awk '$2 == "/" {print $4}' /proc/mounts | head -1)
+if ! echo "${root_mount_opts}" | grep -q '\bro\b'; then
+    echo "Root is not mounted read-only at runtime: ${root_mount_opts}"
+fi
+
+EOF
+%end

--- a/ostree-readonly-fstab.sh
+++ b/ostree-readonly-fstab.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Copyright (C) 2026  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
+TESTTYPE="payload ostree reboot"
+
+. ${KSTESTDIR}/functions.sh
+
+copy_interesting_files_from_system() {
+    local disksdir
+    disksdir="${1}"
+
+    local args
+    args=$(for d in ${disksdir}/disk-*img; do echo -a ${d}; done)
+
+    root_device=$(guestfish ${args} <<< "
+        launch
+        lvs" | \
+        grep root)
+
+    for item in /ostree/deploy/test-stateroot/var/roothome/original-ks.cfg \
+                /ostree/deploy/test-stateroot/var/roothome/anaconda-ks.cfg \
+                /ostree/deploy/test-stateroot/var/log/anaconda/ \
+                /ostree/deploy/test-stateroot/var/roothome/RESULT
+    do
+        guestfish ${args} <<< "
+            launch
+            mount ${root_device} /
+            copy-out '${item}' '${disksdir}'
+            " 2>/dev/null
+    done
+}
+
+additional_runner_args() {
+   echo "--wait $(get_timeout)"
+}


### PR DESCRIPTION
Test made for this [PR](https://github.com/rhinstaller/anaconda/pull/7171)

Do not merge until the conversation in the PR is not resolved.