### PR TITLE
Disable raid-ddf failing on rhel 10 (gh1700)

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -98,6 +98,7 @@ rhel10_centos10_disabled_array=(
   gh1207      # packages-multilib failing
   gh1213      # harddrive-iso-single failing
   gh1633      # rpm-ostree-container-uefi failing with Fedora 44 runner container
+  gh1700      # raid-ddf failing after migration to UEFI
 )
 
 rhel10_skip_array=(

--- a/raid-ddf.sh
+++ b/raid-ddf.sh
@@ -21,7 +21,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="raid storage"
+TESTTYPE="raid storage gh1700"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
The test is failing after test migration to UEFI