### PR TITLE
Reduce TEST_JOBS for daily-iso-webui from 16 to 12

### DIFF
--- a/.github/workflows/scenarios-permian.yml
+++ b/.github/workflows/scenarios-permian.yml
@@ -167,6 +167,9 @@ jobs:
       - name: Run scenario ${{ matrix.scenario }} in container
         working-directory: ./permian
         run: |
+          if [ "${{ matrix.scenario }}" == "daily-iso-webui" ]; then
+            TEST_JOBS=12
+          fi
           sudo --preserve-env=TEST_JOBS,KSTEST_OS_VARIANT \
           PYTHONPATH=${PYTHONPATH:-}:${{ github.workspace }}/tplib \
           ./pipeline --debug-log permian.log \


### PR DESCRIPTION
The webui boot.iso requires 25% more RAM per test (commit d73dcd55f6d839170607acfc979b9c4901415b6b) so reduce number of parallel jobs from 16 to 12.