### PR TITLE
Reduce TEST_JOBS for daily-iso-webui for test-os-variants

### DIFF
--- a/.github/workflows/test-os-variants.yml
+++ b/.github/workflows/test-os-variants.yml
@@ -315,6 +315,9 @@ jobs:
       - name: Run kickstart tests in container
         working-directory: ./permian
         run: |
+          if [ "${{ matrix.os-variant }}" == "daily-iso-webui" ]; then
+            TEST_JOBS=12
+          fi
           sudo --preserve-env=TEST_JOBS,KSTEST_OS_VARIANT \
           PYTHONPATH=${PYTHONPATH:-}:${{ github.workspace }}/tplib \
           ./run_subset --debug-log permian.log \


### PR DESCRIPTION
My intention is to create a baseline as we have in daily workflow and then play a bit more with RAM in https://github.com/rhinstaller/kickstart-tests/pull/1711