### PR TITLE
Increase test timeout for webui tests.

### DIFF
--- a/.github/workflows/scenarios-permian.yml
+++ b/.github/workflows/scenarios-permian.yml
@@ -19,13 +19,13 @@ jobs:
       fail-fast: false
 
     # these settings depend on the infrastructure; on upshift ocp-master-xxl they take about 4 hours
-    timeout-minutes: 560
+    timeout-minutes: 620
     env:
       TEST_JOBS: 16
       GITHUB_TOKEN: /home/github/github-token
       # The timeout should be ~20 minutes less then the job's timeout-minutes
       # so that we get partial results and logs in case of the timeout.
-      LAUNCHER_TIMEOUT_MINUTES: 540
+      LAUNCHER_TIMEOUT_MINUTES: 600
       KSTEST_OS_VARIANT: ${{ matrix.scenario }}
 
     steps:

--- a/functions.sh
+++ b/functions.sh
@@ -467,7 +467,11 @@ append_additional_repo_to_kernel_args() {
 }
 
 get_timeout() {
-    echo "30"
+    if [ "${KSTEST_OS_VARIANT}" = "daily-iso-webui" ]; then
+        echo "40"
+    else
+        echo "30"
+    fi
 }
 
 stage2_from_ks() {


### PR DESCRIPTION
After excluding the real issues tracked in
https://github.com/rhinstaller/kickstart-tests/issues/1716
https://github.com/rhinstaller/kickstart-tests/issues/1715
it seems that the remaining timeouts of daily tests are not hangs, but slower installations. Let's increase the timeout to confirm. Then we can work on investigation and potential optimization of webui installation runs.