### PR TITLE
Disable more part-luks tests for gh1715

### DIFF
--- a/part-luks-1.sh
+++ b/part-luks-1.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage partition luks"
+TESTTYPE="storage partition luks gh1715"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/part-luks-2.sh
+++ b/part-luks-2.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage partition luks"
+TESTTYPE="storage partition luks gh1715"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Based on daily run results we should disable also part-luks-1 and part-luks-2.

The daily: https://github.com/rhinstaller/kickstart-tests/actions/runs/30409904244/job/90443486265