### PR TITLE
Add kickstart tests for manual/custom partitioning with Stratis

### DIFF
--- a/stratis-1.ks.in
+++ b/stratis-1.ks.in
@@ -1,0 +1,89 @@
+# Basic test for Stratis with one disk and one filesystem for /.
+
+%ksappend repos/default.ks
+%ksappend common/common_no_storage_and_payload.ks
+%ksappend payload/default_packages.ks
+
+zerombr
+clearpart --all --initlabel
+
+reqpart
+part /boot --fstype=ext4 --size=500
+part stratis.01 --size=7500 --ondisk=vda
+stratispool fedora stratis.01
+stratisfs / --name=root --poolname=fedora --size=5000 --grow
+
+%post
+pool_name="fedora"
+
+# check that root is on stratis
+root_source=$(findmnt -n -o SOURCE /)
+if [[ "$root_source" != /dev/mapper/stratis* ]]; then
+    echo "*** root device is not a Stratis filesystem: $root_source" >> /root/RESULT
+    exit 1
+fi
+
+# check that the stratis pool 'fedora' exists
+if [ ! -d /dev/stratis/$pool_name ]; then
+    echo "*** Stratis pool $pool_name not found in /dev/stratis/" >> /root/RESULT
+    exit 1
+fi
+
+# check pool properties
+pool_info=$(stratis pool list --name "$pool_name")
+
+pool_encryption=$(echo "$pool_info" | awk -F: '/Encryption Enabled/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$pool_encryption" != "No" ]]; then
+    echo "*** unexpected pool encryption: $pool_encryption (expected No)" >> /root/RESULT
+fi
+
+pool_overprov=$(echo "$pool_info" | awk -F: '/Allows Overprovisioning/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$pool_overprov" != "No" ]]; then
+    echo "*** unexpected pool overprovisioning: $pool_overprov (expected No)" >> /root/RESULT
+fi
+
+# pool size: size of the entire underlying partition (7500 MiB, 7.32 GiB)
+pool_size=$(echo "$pool_info" | awk -F: '/Size/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$pool_size" != "7.32GiB" ]]; then
+    echo "*** unexpected pool size: $pool_size (expected 7.32GiB)" >> /root/RESULT
+fi
+
+# check root filesystem properties
+root_info=$(stratis filesystem list "$pool_name" --name root)
+
+root_name=$(echo "$root_info" | awk -F: '/^Name/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$root_name" != "root" ]]; then
+    echo "*** unexpected filesystem name: $root_name (expected root)" >> /root/RESULT
+fi
+
+root_pool=$(echo "$root_info" | awk -F: '/^Pool/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$root_pool" != "$pool_name" ]]; then
+    echo "*** filesystem pool mismatch: $root_pool (expected $pool_name)" >> /root/RESULT
+fi
+
+# verify root entry in /etc/fstab is correct
+root_uuid=$(echo "$root_info" | awk -F: '/^UUID/ { gsub(/ /,"",$2); print $2 }')
+root_entry=$(grep ^UUID=$root_uuid\\s\\+/\\s /etc/fstab)
+if [ -z "$root_entry" ] ; then
+    echo "*** root filesystem is not the root entry in /etc/fstab" >> /root/RESULT
+fi
+
+# verify that fstype for root entry is xfs
+root_fstype=$(echo "$root_entry" | awk '{print $3}')
+if [[ "$root_fstype" != "xfs" ]]; then
+    echo "*** root entry in /etc/fstab doesn't have correct fstype (expected xfs, has $root_fstype)" >> /root/RESULT
+fi
+
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+%end
+
+%post --nochroot
+
+@KSINCLUDE@ post-nochroot-lib-storage.sh
+
+# libguestfs does not support stratis, copy results and logs to /boot
+copy_results_to_boot
+
+%end

--- a/stratis-1.sh
+++ b/stratis-1.sh
@@ -1,0 +1,29 @@
+#
+# Copyright (C) 2026  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vojtech Trefny <vtrefny@redhat.com>
+
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
+TESTTYPE="storage stratis skip-on-rhel skip-on-centos"
+
+. ${KSTESTDIR}/functions.sh
+
+validate() {
+    validate_stratis $1
+    return $?
+}

--- a/stratis-2.ks.in
+++ b/stratis-2.ks.in
@@ -1,0 +1,85 @@
+# Basic test for Stratis with two disks and two filesystem for / and /home.
+
+%ksappend repos/default.ks
+%ksappend common/common_no_storage_and_payload.ks
+%ksappend payload/default_packages.ks
+
+zerombr
+clearpart --all --initlabel
+
+reqpart
+part /boot --fstype=ext4 --size=500
+part stratis.01 --size=1 --grow --ondisk=vda
+part stratis.02 --size=1 --grow --ondisk=vdb
+stratispool fedora stratis.01 stratis.02
+stratisfs / --name=root --poolname=fedora --size=5000
+stratisfs /home --name=home --poolname=fedora --size=1 --grow
+
+%post
+pool_name="fedora"
+
+# check that root is on stratis
+root_source=$(findmnt -n -o SOURCE /)
+if [[ "$root_source" != /dev/mapper/stratis* ]]; then
+    echo "*** root device is not a Stratis filesystem: $root_source" >> /root/RESULT
+    exit 1
+fi
+
+# check that the stratis pool 'fedora' exists
+if [ ! -d /dev/stratis/$pool_name ]; then
+    echo "*** Stratis pool $pool_name not found in /dev/stratis/" >> /root/RESULT
+    exit 1
+fi
+
+# check pool properties
+pool_info=$(stratis pool list --name "$pool_name")
+
+pool_encryption=$(echo "$pool_info" | awk -F: '/Encryption Enabled/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$pool_encryption" != "No" ]]; then
+    echo "*** unexpected pool encryption: $pool_encryption (expected No)" >> /root/RESULT
+fi
+
+pool_overprov=$(echo "$pool_info" | awk -F: '/Allows Overprovisioning/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$pool_overprov" != "No" ]]; then
+    echo "*** unexpected pool overprovisioning: $pool_overprov (expected No)" >> /root/RESULT
+fi
+
+# check root filesystem properties
+root_info=$(stratis filesystem list "$pool_name" --name root)
+
+root_name=$(echo "$root_info" | awk -F: '/^Name/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$root_name" != "root" ]]; then
+    echo "*** unexpected filesystem name: $root_name (expected root)" >> /root/RESULT
+fi
+
+root_pool=$(echo "$root_info" | awk -F: '/^Pool/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$root_pool" != "$pool_name" ]]; then
+    echo "*** filesystem pool mismatch: $root_pool (expected $pool_name)" >> /root/RESULT
+fi
+
+# check home filesystem properties
+home_info=$(stratis filesystem list "$pool_name" --name home)
+
+home_name=$(echo "$home_info" | awk -F: '/^Name/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$home_name" != "home" ]]; then
+    echo "*** unexpected filesystem name: $home_name (expected home)" >> /root/RESULT
+fi
+
+home_pool=$(echo "$home_info" | awk -F: '/^Pool/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$home_pool" != "$pool_name" ]]; then
+    echo "*** filesystem pool mismatch: $home_pool (expected $pool_name)" >> /root/RESULT
+fi
+
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+%end
+
+%post --nochroot
+
+@KSINCLUDE@ post-nochroot-lib-storage.sh
+
+# libguestfs does not support stratis, copy results and logs to /boot
+copy_results_to_boot
+
+%end

--- a/stratis-2.sh
+++ b/stratis-2.sh
@@ -1,0 +1,40 @@
+#
+# Copyright (C) 2026  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vojtech Trefny <vtrefny@redhat.com>
+
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
+TESTTYPE="storage stratis skip-on-rhel skip-on-centos"
+
+. ${KSTESTDIR}/functions.sh
+
+prepare_disks() {
+    tmpdir=$1
+
+    # make sure the first disk have some extra space for /boot
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-a.img 9G
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-b.img 8G
+
+    echo ${tmpdir}/disk-a.img
+    echo ${tmpdir}/disk-b.img
+}
+
+validate() {
+    validate_stratis $1
+    return $?
+}

--- a/stratis-3.ks.in
+++ b/stratis-3.ks.in
@@ -1,0 +1,104 @@
+# Basic test for Stratis with two disks and two separate pools.
+
+%ksappend repos/default.ks
+%ksappend common/common_no_storage_and_payload.ks
+%ksappend payload/default_packages.ks
+
+zerombr
+clearpart --all --initlabel
+
+reqpart
+part /boot --fstype=ext4 --size=500
+part stratis.01 --size=1 --grow --ondisk=vda
+part stratis.02 --size=1 --grow --ondisk=vdb
+stratispool fedora stratis.01
+stratispool secondpool stratis.02
+stratisfs / --name=root --poolname=fedora --size=5000 --grow
+stratisfs none --name=data --poolname=secondpool --size=1 --grow
+
+%post
+
+# check that root is on stratis
+root_source=$(findmnt -n -o SOURCE /)
+if [[ "$root_source" != /dev/mapper/stratis* ]]; then
+    echo "*** root device is not a Stratis filesystem: $root_source" >> /root/RESULT
+    exit 1
+fi
+
+# check that the stratis pool 'fedora' exists
+if [ ! -d /dev/stratis/fedora ]; then
+    echo "*** Stratis pool fedora not found in /dev/stratis/" >> /root/RESULT
+    exit 1
+fi
+
+# check 'fedora' pool properties
+pool_info=$(stratis pool list --name "fedora")
+
+pool_encryption=$(echo "$pool_info" | awk -F: '/Encryption Enabled/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$pool_encryption" != "No" ]]; then
+    echo "*** unexpected pool encryption: $pool_encryption (expected No)" >> /root/RESULT
+fi
+
+pool_overprov=$(echo "$pool_info" | awk -F: '/Allows Overprovisioning/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$pool_overprov" != "No" ]]; then
+    echo "*** unexpected pool overprovisioning: $pool_overprov (expected No)" >> /root/RESULT
+fi
+
+# check root filesystem properties
+root_info=$(stratis filesystem list "fedora" --name root)
+
+root_name=$(echo "$root_info" | awk -F: '/^Name/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$root_name" != "root" ]]; then
+    echo "*** unexpected filesystem name: $root_name (expected root)" >> /root/RESULT
+fi
+
+root_pool=$(echo "$root_info" | awk -F: '/^Pool/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$root_pool" != "fedora" ]]; then
+    echo "*** filesystem pool mismatch: $root_pool (expected fedora)" >> /root/RESULT
+fi
+
+# check that the stratis pool 'secondpool' exists
+if [ ! -d /dev/stratis/secondpool ]; then
+    echo "*** Stratis pool secondpool not found in /dev/stratis/" >> /root/RESULT
+    exit 1
+fi
+
+# check 'secondpool' pool properties
+pool_info=$(stratis pool list --name "secondpool")
+
+pool_encryption=$(echo "$pool_info" | awk -F: '/Encryption Enabled/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$pool_encryption" != "No" ]]; then
+    echo "*** unexpected pool encryption: $pool_encryption (expected No)" >> /root/RESULT
+fi
+
+pool_overprov=$(echo "$pool_info" | awk -F: '/Allows Overprovisioning/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$pool_overprov" != "No" ]]; then
+    echo "*** unexpected pool overprovisioning: $pool_overprov (expected No)" >> /root/RESULT
+fi
+
+# check data filesystem properties
+data_info=$(stratis filesystem list secondpool --name data)
+
+data_name=$(echo "$data_info" | awk -F: '/^Name/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$data_name" != "data" ]]; then
+    echo "*** unexpected filesystem name: $data_name (expected data)" >> /root/RESULT
+fi
+
+data_pool=$(echo "$data_info" | awk -F: '/^Pool/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$data_pool" != "secondpool" ]]; then
+    echo "*** filesystem pool mismatch: $data_pool (expected secondpool)" >> /root/RESULT
+fi
+
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+%end
+
+%post --nochroot
+
+@KSINCLUDE@ post-nochroot-lib-storage.sh
+
+# libguestfs does not support stratis, copy results and logs to /boot
+copy_results_to_boot
+
+%end

--- a/stratis-3.sh
+++ b/stratis-3.sh
@@ -1,0 +1,40 @@
+#
+# Copyright (C) 2026  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vojtech Trefny <vtrefny@redhat.com>
+
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
+TESTTYPE="storage stratis skip-on-rhel skip-on-centos"
+
+. ${KSTESTDIR}/functions.sh
+
+prepare_disks() {
+    tmpdir=$1
+
+    # make sure the first disk have some extra space for /boot
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-a.img 9G
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-b.img 8G
+
+    echo ${tmpdir}/disk-a.img
+    echo ${tmpdir}/disk-b.img
+}
+
+validate() {
+    validate_stratis $1
+    return $?
+}

--- a/stratis-encrypted-1.ks.in
+++ b/stratis-encrypted-1.ks.in
@@ -1,0 +1,76 @@
+# Basic test for encrypted Stratis with one disk and one filesystem for /.
+
+%ksappend repos/default.ks
+%ksappend common/common_no_storage_and_payload.ks
+%ksappend payload/default_packages.ks
+
+zerombr
+clearpart --all --initlabel
+
+reqpart
+part /boot --fstype=ext4 --size=500
+part stratis.01 --size=7500 --ondisk=vda
+stratispool fedora stratis.01 --encrypted --passphrase="passphrase"
+stratisfs / --name=root --poolname=fedora --size=5000 --grow
+
+%post
+pool_name="fedora"
+
+# check that root is on stratis
+root_source=$(findmnt -n -o SOURCE /)
+if [[ "$root_source" != /dev/mapper/stratis* ]]; then
+    echo "*** root device is not a Stratis filesystem: $root_source" >> /root/RESULT
+    exit 1
+fi
+
+# check that the stratis pool 'fedora' exists
+if [ ! -d /dev/stratis/$pool_name ]; then
+    echo "*** Stratis pool $pool_name not found in /dev/stratis/" >> /root/RESULT
+    exit 1
+fi
+
+# check pool properties
+pool_info=$(stratis pool list --name "$pool_name")
+
+pool_encryption=$(echo "$pool_info" | awk -F: '/Encryption Enabled/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$pool_encryption" != "Yes" ]]; then
+    echo "*** unexpected pool encryption: $pool_encryption (expected Yes)" >> /root/RESULT
+fi
+
+pool_overprov=$(echo "$pool_info" | awk -F: '/Allows Overprovisioning/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$pool_overprov" != "No" ]]; then
+    echo "*** unexpected pool overprovisioning: $pool_overprov (expected No)" >> /root/RESULT
+fi
+
+# pool size: size of the entire underlying partition (7500 MiB, 7.32 GiB)
+pool_size=$(echo "$pool_info" | awk -F: '/Size/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$pool_size" != "7.32GiB" ]]; then
+    echo "*** unexpected pool size: $pool_size (expected 7.32GiB)" >> /root/RESULT
+fi
+
+# check root filesystem properties
+root_info=$(stratis filesystem list "$pool_name" --name root)
+
+root_name=$(echo "$root_info" | awk -F: '/^Name/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$root_name" != "root" ]]; then
+    echo "*** unexpected filesystem name: $root_name (expected root)" >> /root/RESULT
+fi
+
+root_pool=$(echo "$root_info" | awk -F: '/^Pool/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$root_pool" != "$pool_name" ]]; then
+    echo "*** filesystem pool mismatch: $root_pool (expected $pool_name)" >> /root/RESULT
+fi
+
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+%end
+
+%post --nochroot
+
+@KSINCLUDE@ post-nochroot-lib-storage.sh
+
+# libguestfs does not support stratis, copy results and logs to /boot
+copy_results_to_boot
+
+%end

--- a/stratis-encrypted-1.sh
+++ b/stratis-encrypted-1.sh
@@ -1,0 +1,29 @@
+#
+# Copyright (C) 2026  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vojtech Trefny <vtrefny@redhat.com>
+
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
+TESTTYPE="storage stratis skip-on-rhel skip-on-centos"
+
+. ${KSTESTDIR}/functions.sh
+
+validate() {
+    validate_stratis $1
+    return $?
+}

--- a/stratis-overprovision-1.ks.in
+++ b/stratis-overprovision-1.ks.in
@@ -1,0 +1,90 @@
+# Basic test for Stratis with overprovisioning enabled and two 1 TiB filesystems.
+
+%ksappend repos/default.ks
+%ksappend common/common_no_storage_and_payload.ks
+%ksappend payload/default_packages.ks
+
+zerombr
+clearpart --all --initlabel
+
+reqpart
+part /boot --fstype=ext4 --size=500
+part stratis.01 --size=7500 --ondisk=vda
+stratispool --overprovisioning fedora stratis.01
+stratisfs / --name=root --poolname=fedora --size=1048576
+stratisfs /home --name=home --poolname=fedora --size=1048576
+
+%post
+pool_name="fedora"
+
+# check that root is on stratis
+root_source=$(findmnt -n -o SOURCE /)
+if [[ "$root_source" != /dev/mapper/stratis* ]]; then
+    echo "*** root device is not a Stratis filesystem: $root_source" >> /root/RESULT
+    exit 1
+fi
+
+# check that the stratis pool 'fedora' exists
+if [ ! -d /dev/stratis/$pool_name ]; then
+    echo "*** Stratis pool $pool_name not found in /dev/stratis/" >> /root/RESULT
+    exit 1
+fi
+
+# check pool properties
+pool_info=$(stratis pool list --name "$pool_name")
+
+pool_encryption=$(echo "$pool_info" | awk -F: '/Encryption Enabled/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$pool_encryption" != "No" ]]; then
+    echo "*** unexpected pool encryption: $pool_encryption (expected No)" >> /root/RESULT
+fi
+
+pool_overprov=$(echo "$pool_info" | awk -F: '/Allows Overprovisioning/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$pool_overprov" != "Yes" ]]; then
+    echo "*** unexpected pool overprovisioning: $pool_overprov (expected Yes)" >> /root/RESULT
+fi
+
+# pool size: size of the entire underlying partition (7500 MiB, 7.32 GiB)
+pool_size=$(echo "$pool_info" | awk -F: '/Size/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$pool_size" != "7.32GiB" ]]; then
+    echo "*** unexpected pool size: $pool_size (expected 7.32GiB)" >> /root/RESULT
+fi
+
+# check root filesystem properties
+root_info=$(stratis filesystem list "$pool_name" --name root)
+
+root_name=$(echo "$root_info" | awk -F: '/^Name/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$root_name" != "root" ]]; then
+    echo "*** unexpected filesystem name: $root_name (expected root)" >> /root/RESULT
+fi
+
+root_pool=$(echo "$root_info" | awk -F: '/^Pool/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$root_pool" != "$pool_name" ]]; then
+    echo "*** filesystem pool mismatch: $root_pool (expected $pool_name)" >> /root/RESULT
+fi
+
+# check home filesystem properties
+home_info=$(stratis filesystem list "$pool_name" --name home)
+
+home_name=$(echo "$home_info" | awk -F: '/^Name/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$home_name" != "home" ]]; then
+    echo "*** unexpected filesystem name: $home_name (expected home)" >> /root/RESULT
+fi
+
+home_pool=$(echo "$home_info" | awk -F: '/^Pool/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$home_pool" != "$pool_name" ]]; then
+    echo "*** filesystem pool mismatch: $home_pool (expected $pool_name)" >> /root/RESULT
+fi
+
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+%end
+
+%post --nochroot
+
+@KSINCLUDE@ post-nochroot-lib-storage.sh
+
+# libguestfs does not support stratis, copy results and logs to /boot
+copy_results_to_boot
+
+%end

--- a/stratis-overprovision-1.sh
+++ b/stratis-overprovision-1.sh
@@ -1,0 +1,29 @@
+#
+# Copyright (C) 2026  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vojtech Trefny <vtrefny@redhat.com>
+
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
+TESTTYPE="storage stratis skip-on-rhel skip-on-centos"
+
+. ${KSTESTDIR}/functions.sh
+
+validate() {
+    validate_stratis $1
+    return $?
+}

--- a/stratis-pre-1.ks.in
+++ b/stratis-pre-1.ks.in
@@ -1,0 +1,117 @@
+# Test for Stratis --useexisting: reuse a pool and filesystems created in %pre.
+
+%ksappend repos/default.ks
+%ksappend common/common_no_storage_and_payload.ks
+%ksappend payload/default_packages.ks
+
+zerombr
+clearpart --none
+
+reqpart
+part /boot --fstype=ext4 --size=500
+stratispool fedora --useexisting
+stratisfs / --name=root --poolname=fedora --useexisting
+stratisfs /home --name=home --poolname=fedora --useexisting
+
+%pre
+# partition for the stratis pool
+parted -s /dev/vda mklabel gpt
+parted -s /dev/vda mkpart primary 1MiB 7500MiB
+
+# wait for the partition device to appear
+udevadm settle
+
+# stratis pool and filesystems
+stratis pool create fedora /dev/vda1
+stratis filesystem create fedora root
+stratis filesystem create fedora home
+
+# create file in the home filesystem to verify it survives the installation
+mkdir -p /mnt/test-home
+mount /dev/stratis/fedora/home /mnt/test-home
+echo "HOME_TEST_DATA" > /mnt/test-home/marker.txt
+umount /mnt/test-home
+%end
+
+%post
+pool_name="fedora"
+
+# check that root is on stratis
+root_source=$(findmnt -n -o SOURCE /)
+if [[ "$root_source" != /dev/mapper/stratis* ]]; then
+    echo "*** root device is not a Stratis filesystem: $root_source" >> /root/RESULT
+    exit 1
+fi
+
+# check that home is on stratis
+home_source=$(findmnt -n -o SOURCE /home)
+if [[ "$home_source" != /dev/mapper/stratis* ]]; then
+    echo "*** home device is not a Stratis filesystem: $home_source" >> /root/RESULT
+    exit 1
+fi
+
+# check that the stratis pool 'fedora' exists
+if [ ! -d /dev/stratis/$pool_name ]; then
+    echo "*** Stratis pool $pool_name not found in /dev/stratis/" >> /root/RESULT
+    exit 1
+fi
+
+# check pool properties
+pool_info=$(stratis pool list --name "$pool_name")
+
+pool_encryption=$(echo "$pool_info" | awk -F: '/Encryption Enabled/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$pool_encryption" != "No" ]]; then
+    echo "*** unexpected pool encryption: $pool_encryption (expected No)" >> /root/RESULT
+fi
+
+pool_overprov=$(echo "$pool_info" | awk -F: '/Allows Overprovisioning/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$pool_overprov" != "Yes" ]]; then
+    echo "*** unexpected pool overprovisioning: $pool_overprov (expected No)" >> /root/RESULT
+fi
+
+# check root filesystem properties
+root_info=$(stratis filesystem list "$pool_name" --name root)
+
+root_name=$(echo "$root_info" | awk -F: '/^Name/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$root_name" != "root" ]]; then
+    echo "*** unexpected filesystem name: $root_name (expected root)" >> /root/RESULT
+fi
+
+root_pool=$(echo "$root_info" | awk -F: '/^Pool/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$root_pool" != "$pool_name" ]]; then
+    echo "*** filesystem pool mismatch: $root_pool (expected $pool_name)" >> /root/RESULT
+fi
+
+# check home filesystem properties
+home_info=$(stratis filesystem list "$pool_name" --name home)
+
+home_name=$(echo "$home_info" | awk -F: '/^Name/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$home_name" != "home" ]]; then
+    echo "*** unexpected filesystem name: $home_name (expected home)" >> /root/RESULT
+fi
+
+home_pool=$(echo "$home_info" | awk -F: '/^Pool/ { gsub(/ /,"",$2); print $2 }')
+if [[ "$home_pool" != "$pool_name" ]]; then
+    echo "*** filesystem pool mismatch: $home_pool (expected $pool_name)" >> /root/RESULT
+fi
+
+# check the file in /home
+if [ ! -f /home/marker.txt ]; then
+    echo "*** marker file /home/marker.txt not found -- home filesystem was destroyed" >> /root/RESULT
+elif [ "$(cat /home/marker.txt)" != "HOME_TEST_DATA" ]; then
+    echo "*** marker file has unexpected content: $(cat /home/marker.txt)" >> /root/RESULT
+fi
+
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+%end
+
+%post --nochroot
+
+@KSINCLUDE@ post-nochroot-lib-storage.sh
+
+# libguestfs does not support stratis, copy results and logs to /boot
+copy_results_to_boot
+
+%end

--- a/stratis-pre-1.sh
+++ b/stratis-pre-1.sh
@@ -1,0 +1,29 @@
+#
+# Copyright (C) 2026  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vojtech Trefny <vtrefny@redhat.com>
+
+# Ignore unused variable parsed out by tooling scripts as test tags metadata
+# shellcheck disable=SC2034
+TESTTYPE="storage stratis skip-on-rhel skip-on-centos"
+
+. ${KSTESTDIR}/functions.sh
+
+validate() {
+    validate_stratis $1
+    return $?
+}


### PR DESCRIPTION
This should cover everything we can do with stratis, including encryption, overprovisioning and reusing existing pools and filesystems.

----

https://github.com/pykickstart/pykickstart/pull/585 and (not yet posted) changes for Anaconda and blivet will be needed for this so marking as blocked and draft for now.