### PR TITLE
Disable more storage luks tests for gh1715

### DIFF
--- a/escrow-cert.sh
+++ b/escrow-cert.sh
@@ -20,7 +20,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage"
+TESTTYPE="storage gh1715"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-luks-1.sh
+++ b/raid-luks-1.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage raid luks"
+TESTTYPE="storage raid luks gh1715"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-luks-2.sh
+++ b/raid-luks-2.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage raid luks"
+TESTTYPE="storage raid luks gh1715"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-luks-3.sh
+++ b/raid-luks-3.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage raid luks"
+TESTTYPE="storage raid luks gh1715"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Based on daily results we should disable also raid-luks-{1,2,3} and escrow-cert.
https://github.com/rhinstaller/kickstart-tests/actions/runs/30592718124/job/91038290138