### PR TITLE
Enable tests affected by gh1727 on Webui-boot.iso

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -58,7 +58,6 @@ daily_iso_webui_only_skip_array=(
 
 daily_iso_webui_disabled_array=(
   gh1715      # tests failing on UknownDeviceError
-  gh1727      # tests timeouting because of incomplete accounts screen
 )
 
 rawhide_disabled_array=(

--- a/fedora-live-image-build.sh
+++ b/fedora-live-image-build.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="packaging skip-on-rhel skip-on-centos skip-on-fedora-eln payload gh1727"
+TESTTYPE="packaging skip-on-rhel skip-on-centos skip-on-fedora-eln payload"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/rootpw-lock-no-password.sh
+++ b/rootpw-lock-no-password.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="users gh1727"
+TESTTYPE="users"
 
 . ${KSTESTDIR}/functions.sh

--- a/rootpw-lock.sh
+++ b/rootpw-lock.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="users coverage gh1727"
+TESTTYPE="users coverage"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
The gh1727 skip tag is no longer needed.