### PR TITLE
testingfarm: update compose to Fedora-44

### DIFF
--- a/.github/workflows/testingfarm.yml
+++ b/.github/workflows/testingfarm.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Run the tests
       uses: sclorg/testing-farm-as-github-action@main
       with:
-        compose: Fedora-42
+        compose: Fedora-44
         api_key: ${{ secrets.TF_API_KEY }}
         git_url: "https://github.com/${{ github.repository }}"
         git_ref: "refs/pull/${{ github.event.issue.number }}/head"


### PR DESCRIPTION
Fedora-42 reached EOL. Use Fedora-44 which is the current stable release.

Assisted-by: claude-sonnet-4-6