### PR TITLE
Re-enable luks/encrypted tests on daily-iso-webui (gh1715)

### DIFF
--- a/autopart-encrypted-1.sh
+++ b/autopart-encrypted-1.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage coverage smoke gh1715"
+TESTTYPE="autopart storage coverage smoke"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/autopart-encrypted-2.sh
+++ b/autopart-encrypted-2.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage gh1715"
+TESTTYPE="autopart storage"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/autopart-encrypted-3.sh
+++ b/autopart-encrypted-3.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage gh1715"
+TESTTYPE="autopart storage"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/autopart-luks-1.sh
+++ b/autopart-luks-1.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage luks gh1715"
+TESTTYPE="autopart storage luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/autopart-luks-2.sh
+++ b/autopart-luks-2.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage luks gh1715"
+TESTTYPE="autopart storage luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/autopart-luks-3.sh
+++ b/autopart-luks-3.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage luks gh1715"
+TESTTYPE="autopart storage luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/autopart-luks-4.sh
+++ b/autopart-luks-4.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage luks gh1715"
+TESTTYPE="autopart storage luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/autopart-luks-5.sh
+++ b/autopart-luks-5.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="autopart storage luks gh1715"
+TESTTYPE="autopart storage luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/bootc-luks.sh
+++ b/bootc-luks.sh
@@ -18,7 +18,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="skip-on-rhel-9 payload bootc luks gh1574 gh1715"
+TESTTYPE="skip-on-rhel-9 payload bootc luks gh1574"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -56,7 +56,6 @@ daily_iso_webui_only_skip_array=(
 )
 
 daily_iso_webui_disabled_array=(
-  gh1715      # tests failing on UknownDeviceError
 )
 
 rawhide_disabled_array=(

--- a/encrypt-device.sh
+++ b/encrypt-device.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage gh1715"
+TESTTYPE="storage"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/encrypt-swap.sh
+++ b/encrypt-swap.sh
@@ -17,7 +17,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage gh1715"
+TESTTYPE="storage"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/escrow-cert.sh
+++ b/escrow-cert.sh
@@ -20,7 +20,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage gh1715"
+TESTTYPE="storage"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/lvm-luks-1.sh
+++ b/lvm-luks-1.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage lvm luks gh1715"
+TESTTYPE="storage lvm luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/lvm-luks-2.sh
+++ b/lvm-luks-2.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage lvm luks gh1715"
+TESTTYPE="storage lvm luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/lvm-luks-3.sh
+++ b/lvm-luks-3.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage lvm luks gh1715"
+TESTTYPE="storage lvm luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/lvm-luks-4.sh
+++ b/lvm-luks-4.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage lvm luks gh1715"
+TESTTYPE="storage lvm luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/part-luks-1.sh
+++ b/part-luks-1.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage partition luks gh1715"
+TESTTYPE="storage partition luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/part-luks-2.sh
+++ b/part-luks-2.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage partition luks gh1715"
+TESTTYPE="storage partition luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/part-luks-3.sh
+++ b/part-luks-3.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage partition luks gh1715"
+TESTTYPE="storage partition luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/part-luks-4.sh
+++ b/part-luks-4.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage partition luks gh1715"
+TESTTYPE="storage partition luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-luks-1.sh
+++ b/raid-luks-1.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage raid luks gh1715"
+TESTTYPE="storage raid luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-luks-2.sh
+++ b/raid-luks-2.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage raid luks gh1715"
+TESTTYPE="storage raid luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-luks-3.sh
+++ b/raid-luks-3.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage raid luks gh1715"
+TESTTYPE="storage raid luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/raid-luks-4.sh
+++ b/raid-luks-4.sh
@@ -20,7 +20,7 @@
 # Check the results on the running VM.
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="storage raid luks gh1715"
+TESTTYPE="storage raid luks"
 
 . ${KSTESTDIR}/functions.sh
 

--- a/rpm-ostree-container-luks.sh
+++ b/rpm-ostree-container-luks.sh
@@ -18,7 +18,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="payload ostree bootc luks reboot skip-on-rhel-8 gh1533 gh1715"
+TESTTYPE="payload ostree bootc luks reboot skip-on-rhel-8 gh1533"
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
The fix for gh1715 was merged in anaconda-webui#1431: GetDiskFreeSpace and GetDiskTotalSpace are now only called for disk devices, guarded by devData["is-disk"].v.

Remove the gh1715 testtype from the affected tests and from the daily_iso_webui_disabled_array.