### PR TITLE
Remove obsolete biosboot testtype tag from raid-1

### DIFF
--- a/raid-1.sh
+++ b/raid-1.sh
@@ -19,7 +19,7 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"raid storage coverage smoke biosboot"}
+TESTTYPE=${TESTTYPE:-"raid storage coverage smoke"}
 
 . ${KSTESTDIR}/functions.sh
 


### PR DESCRIPTION
Fixup of commit bd92dbd136aa7394dd3d9b3c018afe961502bd4b