### PR TITLE
Reenable raid-1-reqpart which is passing on default UEFI

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -15,7 +15,6 @@ fedora_skip_array=(
 fedora_disabled_array=(
   gh576       # clearpart-4 test is flaky on all scenarios
   gh595       # proxy-cmdline failing on all scenarios
-  gh777       # raid-1-reqpart failing
   rhbz1853668 # multipath device not constructed back after installation
   gh1023      # rpm-ostree failing
   gh1530      # dns-global-exclusive-tls-* stage2-from-compose failing
@@ -94,7 +93,6 @@ rhel9_disabled_array=(
 rhel10_centos10_disabled_array=(
   gh576       # clearpart-4 test is flaky on all scenarios
   gh804       # tests requiring dvd iso failing
-  gh1090      # raid-1-reqpart failing
   gh1207      # packages-multilib failing
   gh1213      # harddrive-iso-single failing
   gh1633      # rpm-ostree-container-uefi failing with Fedora 44 runner container
@@ -126,7 +124,6 @@ fedora_eln_skip_array=(
 
 fedora_eln_disabled_array=(
   gh1213      # harddrive-iso-single failing
-  gh1090      # raid-1-reqpart failing
   gh1207      # packages-multilib failing
   gh1530      # dns-global-exclusive-tls-* stage2-from-compose failing
   gh804       # tests requiring dvd iso failing

--- a/raid-1-reqpart.sh
+++ b/raid-1-reqpart.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE=${TESTTYPE:-"raid storage gh777 gh1090"}
+TESTTYPE=${TESTTYPE:-"raid storage"}
 
 . ${KSTESTDIR}/raid-1.sh


### PR DESCRIPTION
The default for kstest was changed to UEFI so reenable the test

(test passing discoverd by https://github.com/rhinstaller/kickstart-tests/actions/workflows/disabled-tests.yml)

Related: INSTALLER-4015