### PR TITLE
infra: Add TOCTOU push detection to test-os-variants workflow

### DIFF
--- a/.github/workflows/test-os-variants.yml
+++ b/.github/workflows/test-os-variants.yml
@@ -42,6 +42,12 @@
 # ... run all the tests of type network only on rhel10
 #
 #
+# By default the workflow verifies that the PR head commit was not pushed
+# after the trigger comment (TOCTOU protection). To skip this check:
+#
+#  /test-os-variants --skip-timestamps-check
+#
+#
 # Lastly there is a dry-run mode, that just indicates which tests would be run
 # (useful to check test grouping and overall infra health):
 #
@@ -126,12 +132,63 @@ jobs:
           echo "os variants: $OS_VARIANTS"
           echo "os_variants=${OS_VARIANTS}" >> $GITHUB_OUTPUT
 
+          # parse --skip-timestamps-check flag
+          SKIP_TIMESTAMPS_CHECK=false
+          if echo "$ARGS" | grep -qw -- '--skip-timestamps-check'; then
+            SKIP_TIMESTAMPS_CHECK=true
+            ARGS=$(echo "$ARGS" | sed 's/--skip-timestamps-check\b//' | sed 's/^ *//;s/ *$//' | sed 's/  */ /g')
+          fi
+          echo "skip_timestamps_check=${SKIP_TIMESTAMPS_CHECK}" >> $GITHUB_OUTPUT
+
           echo "comment_args=${ARGS}" >> $GITHUB_OUTPUT
           # check for dry run mode
           DRY_RUN=False
           echo "$BODY" | grep -q "/test-os-variants-dry" && DRY_RUN=True
           echo "Dry run: ${DRY_RUN}"
           echo "dry_run=${DRY_RUN}" >> $GITHUB_OUTPUT
+
+      # Guard against TOCTOU attack: an attacker could force-push or push
+      # new malicious commits to the PR branch between when the maintainer
+      # posted the trigger comment and when the workflow fetched the head SHA.
+      # Use the Check Suites API to get a server-side timestamp for when the
+      # head commit first appeared. GitHub creates check suites on the base
+      # repo when a PR is updated, with a created_at that cannot be forged.
+      - name: Verify head commit was not pushed after the trigger comment
+        if: steps.parse_comment_args.outputs.skip_timestamps_check != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_TIME: ${{ github.event.comment.created_at }}
+          EXPECTED_SHA: ${{ fromJson(steps.pr_api.outputs.data).head.sha }}
+        run: |
+          echo "Comment created at: $COMMENT_TIME"
+          echo "Head SHA: $EXPECTED_SHA"
+
+          # Get the earliest check suite created_at for this commit.
+          # GitHub creates check suites on the base repo when a PR is
+          # updated, with a server-side timestamp that cannot be forged.
+          EARLIEST_CHECK_SUITE=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${EXPECTED_SHA}/check-suites" \
+            --jq '.check_suites | sort_by(.created_at) | .[0].created_at')
+
+          echo "Earliest check suite created at: $EARLIEST_CHECK_SUITE"
+
+          if [ "$EARLIEST_CHECK_SUITE" = "null" ] || [ -z "$EARLIEST_CHECK_SUITE" ]; then
+            echo "::error::No check suites found for commit $EXPECTED_SHA."
+            exit 1
+          fi
+
+          # ISO 8601 timestamps - lexicographic comparison works correctly.
+          # Require check suite to be strictly before the comment: the commit
+          # must have been pushed before the maintainer typed the comment,
+          # so its check suite timestamp must be earlier.
+          if [[ ! "$EARLIEST_CHECK_SUITE" < "$COMMENT_TIME" ]]; then
+            echo "::error::The head commit was pushed AFTER the /test-os-variants comment!"
+            echo "::error::Check suite time: $EARLIEST_CHECK_SUITE"
+            echo "::error::Comment time:     $COMMENT_TIME"
+            echo "::error::Re-review the PR and post a new /test-os-variants comment."
+            exit 1
+          fi
+
+          echo "Verification passed: head commit existed before the trigger comment."
 
     outputs:
       allowed_user: ${{ steps.check_user_perm.outputs.allowed_user }}


### PR DESCRIPTION
Use the Check Suites API to verify the PR head commit was pushed before the /test-os-variants trigger comment. Enabled by default, can be skipped with --skip-timestamps-check.

The same patch has been already applied to anaconda repository workflow https://github.com/rhinstaller/anaconda/blob/main/.github/workflows/kickstart-tests.yml