### PR TITLE
Disable snapshot-pre on webui for gh1750

### DIFF
--- a/containers/runner/skip-testtypes
+++ b/containers/runner/skip-testtypes
@@ -56,6 +56,7 @@ daily_iso_webui_only_skip_array=(
 
 daily_iso_webui_disabled_array=(
   gh1715      # tests failing on UknownDeviceError
+  gh1750      # tests failing on UknownDeviceError
 )
 
 rawhide_disabled_array=(

--- a/snapshot-pre.sh
+++ b/snapshot-pre.sh
@@ -19,6 +19,6 @@
 
 # Ignore unused variable parsed out by tooling scripts as test tags metadata
 # shellcheck disable=SC2034
-TESTTYPE="snapshot lvm storage"
+TESTTYPE="snapshot lvm storage gh1750"
 
 . ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Although it might be related, I am keeping the issue for snapshot-pre separate from https://github.com/rhinstaller/kickstart-tests/issues/1715 as the latter has already a fix in progress so let's not disturb it and check if snapshot-pre would be resolved as well after https://github.com/rhinstaller/kickstart-tests/issues/1715 is handled.